### PR TITLE
fix(infra): cost-guardian protects images referenced by live Cloud Run

### DIFF
--- a/.github/workflows/cost-guardian.yml
+++ b/.github/workflows/cost-guardian.yml
@@ -197,6 +197,32 @@ jobs:
 
           TOTAL_DELETED=0
 
+          # Collect image references currently in use by live Cloud Run services
+          # and jobs across all regions. Any image (by repo path or digest) in
+          # this set is protected from deletion regardless of age — this prevents
+          # the 2026-05 incident where rarely-rebuilt images were pruned out
+          # from under their Cloud Run job specs.
+          echo "Collecting live image references across regions..."
+          IN_USE_FILE=$(mktemp)
+          for region in australia-southeast2 us-central1 asia-southeast1; do
+            gcloud run services list --project="$PROJECT" --region="$region" \
+              --format='value(spec.template.spec.containers[0].image)' 2>/dev/null >> "$IN_USE_FILE" || true
+            gcloud run jobs list --project="$PROJECT" --region="$region" \
+              --format='value(spec.template.spec.template.spec.containers[0].image)' 2>/dev/null >> "$IN_USE_FILE" || true
+          done
+          IN_USE_COUNT=$(sort -u "$IN_USE_FILE" | grep -c . || true)
+          echo "  Protected: $IN_USE_COUNT distinct live image references"
+
+          # Sanity floor: if the collection produced near-zero refs the API
+          # listing likely failed (transient blip, IAM, region rename). Refuse
+          # to prune rather than fall through to the original 2026-05 footgun.
+          # Prod has ~13 image refs across regions; 5 is a safe margin.
+          if [ "$IN_USE_COUNT" -lt 5 ]; then
+            echo "ABORT: only $IN_USE_COUNT live image refs collected — collection likely failed; refusing to prune"
+            rm -f "$IN_USE_FILE"
+            exit 1
+          fi
+
           for pkg in $(gcloud artifacts docker images list "$REGISTRY" --format="value(package)" 2>/dev/null | sort -u); do
             IMAGE_NAME=$(basename "$pkg")
             echo ""
@@ -213,6 +239,28 @@ jobs:
             if [ "$COUNT" -gt 0 ] && [ "$DRY_RUN" = "false" ]; then
               echo "$DIGESTS" | while read -r digest; do
                 [ -z "$digest" ] && continue
+                # Skip if this digest OR any of its tags is referenced by a
+                # live Cloud Run service/job. Match by both `pkg@digest` and
+                # `pkg:tag` since job specs typically use tags.
+                if grep -qF "${pkg}@${digest}" "$IN_USE_FILE"; then
+                  echo "  PROTECTED ${digest} — referenced by live Cloud Run resource (by digest)"
+                  continue
+                fi
+                # Check if any tag pointing at this digest is in use
+                TAGS_FOR_DIGEST=$(gcloud artifacts docker tags list "$pkg" \
+                  --filter="version=${digest}" \
+                  --format='value(name)' 2>/dev/null)
+                TAG_PROTECTED=false
+                for tag_name in $TAGS_FOR_DIGEST; do
+                  short_tag=$(basename "$tag_name")
+                  if grep -qF "${pkg}:${short_tag}" "$IN_USE_FILE"; then
+                    echo "  PROTECTED ${digest} — tag ${short_tag} referenced by live Cloud Run resource"
+                    TAG_PROTECTED=true
+                    break
+                  fi
+                done
+                [ "$TAG_PROTECTED" = "true" ] && continue
+
                 gcloud artifacts docker images delete "${pkg}@${digest}" \
                   --quiet --delete-tags 2>/dev/null && \
                   TOTAL_DELETED=$((TOTAL_DELETED + 1)) || \
@@ -220,6 +268,7 @@ jobs:
               done
             fi
           done
+          rm -f "$IN_USE_FILE"
 
           echo ""
           echo "=== Cleanup complete ==="


### PR DESCRIPTION
## Summary
Belt-and-suspenders for the 2026-05 incident where cost-guardian pruned `short-data-sync`, `asx-announcement-crawler`, `weekly-report-generator`, `market-data`, etc. out from under their Cloud Run job specs.

PR #105 fixed the symptom by bumping `KEEP_COUNT` from 5 to 20. This adds a structural guard so the bug cannot recur regardless of `KEEP_COUNT`.

## Changes
- Before pruning by age, collect image refs (digest *and* tag) currently in use by all Cloud Run services and jobs across `australia-southeast2`, `us-central1`, `asia-southeast1`.
- Skip deletion of any digest whose path matches a live ref, or whose tags include one referenced by a live spec.
- **Sanity floor**: if the live-ref collection returns fewer than 5 distinct refs, abort with non-zero exit. Prod has ~13 today; <5 means the API listing failed (blip, IAM, region rename) — exactly when the original footgun fired. Refusing to prune is safer than falling through.

## Out of scope
- Pre-existing subshell-counter bug on `TOTAL_DELETED` (count never propagates out of `... | while read`). Left unchanged here; deserves its own micro-PR.

## Test plan
- [ ] After merge, run `gh workflow run cost-guardian.yml -f dry_run=true` and verify:
  - "Protected: N distinct live image references" shows N≥10
  - "PROTECTED <digest>" lines appear for the images that were getting nuked before
- [ ] Let next scheduled live run proceed; verify no live image is pruned