### PR TITLE
fix(ci): bump Vercel CLI 41.1.4 → 47.2.2

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -725,7 +725,7 @@ jobs:
           vercel-org-id: team_xE5DMN3hIo8aPqyHNkBybg8r
           vercel-project-id: shorted-com-au
           scope: team_xE5DMN3hIo8aPqyHNkBybg8r
-          vercel-version: 41.1.4
+          vercel-version: 47.2.2
           alias-domains: preview.shorted.com.au
           vercel-args: >-
             --build-env NEXT_PUBLIC_SHORTS_SERVICE_ENDPOINT=${{ steps.deploy.outputs.shorts_url }}
@@ -1203,7 +1203,7 @@ jobs:
           vercel-org-id: team_xE5DMN3hIo8aPqyHNkBybg8r
           vercel-project-id: shorted-com-au
           scope: team_xE5DMN3hIo8aPqyHNkBybg8r
-          vercel-version: 41.1.4
+          vercel-version: 47.2.2
           vercel-args: >-
             --prod
             --build-env NEXT_PUBLIC_SHORTS_SERVICE_ENDPOINT=${{ steps.resolve-urls.outputs.shorts_url }}


### PR DESCRIPTION
## Summary
Vercel deploy step failed in CI run 25628207580 (the run that fixed image pruning) with:

> Error: Your Vercel CLI version is outdated. This endpoint requires version 47.2.2 or later.

The pin at `41.1.4` is now below Vercel's minimum supported. Bumping to the minimum required (47.2.2) to unblock prod deploys with the smallest possible behavior change.

Applies to both PR-preview deploy (line 728) and prod deploy (line 1206) — both used v41.1.4.

## Test plan
- [ ] After merge, terraform-deploy on main re-runs prod Vercel deploy successfully
- [ ] Site loads + version bump reflected in footer