### PR TITLE
fix(infra): cost-guardian TOTAL_DELETED count was always zero

### DIFF
--- a/.github/workflows/cost-guardian.yml
+++ b/.github/workflows/cost-guardian.yml
@@ -237,7 +237,9 @@ jobs:
             echo "  Found $COUNT versions to delete (keeping newest $KEEP_COUNT)"
 
             if [ "$COUNT" -gt 0 ] && [ "$DRY_RUN" = "false" ]; then
-              echo "$DIGESTS" | while read -r digest; do
+              # Use process substitution (not `... | while`) so TOTAL_DELETED
+              # increments persist to the parent shell.
+              while read -r digest; do
                 [ -z "$digest" ] && continue
                 # Skip if this digest OR any of its tags is referenced by a
                 # live Cloud Run service/job. Match by both `pkg@digest` and
@@ -261,17 +263,19 @@ jobs:
                 done
                 [ "$TAG_PROTECTED" = "true" ] && continue
 
-                gcloud artifacts docker images delete "${pkg}@${digest}" \
-                  --quiet --delete-tags 2>/dev/null && \
-                  TOTAL_DELETED=$((TOTAL_DELETED + 1)) || \
+                if gcloud artifacts docker images delete "${pkg}@${digest}" \
+                    --quiet --delete-tags 2>/dev/null; then
+                  TOTAL_DELETED=$((TOTAL_DELETED + 1))
+                else
                   echo "  Failed to delete ${digest}"
-              done
+                fi
+              done < <(echo "$DIGESTS")
             fi
           done
           rm -f "$IN_USE_FILE"
 
           echo ""
-          echo "=== Cleanup complete ==="
+          echo "=== Cleanup complete: deleted $TOTAL_DELETED image versions ==="
 
   cleanup-secret-versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Pre-existing bug flagged in PR #107's description. `echo "\$DIGESTS" | while read ...` runs the while loop in a subshell, so the `TOTAL_DELETED=\$((TOTAL_DELETED + 1))` updates a copy that's discarded when the pipe ends.

The variable was never printed before #107, so the bug was invisible. #107 added a "Cleanup complete: deleted N versions" echo which would always have read zero.

## Fix
- Replace pipe-into-while with process substitution: `done < <(echo "\$DIGESTS")` — the while now runs in the parent shell so increments persist.
- Wrap the delete call in if/else for unambiguous exit-status semantics (previously `cmd && X || Y` could fire Y on `X` failure too).
- Final summary now reads the correct count.

## Test plan
- [ ] After merge, `gh workflow run cost-guardian.yml -f dry_run=true` won't exercise this path (dry_run skips deletion). But the next live run should print a non-zero count.