### PR TITLE
fix(seo): prune sitemap, noindex thin stocks, fix spatialCoverage

### DIFF
--- a/web/src/@/components/seo/enhanced-structured-data.tsx
+++ b/web/src/@/components/seo/enhanced-structured-data.tsx
@@ -99,8 +99,12 @@ export function DatasetStructuredData({
     },
     temporalCoverage: "2010-01-01/..",
     spatialCoverage: {
-      "@type": "Country",
+      "@type": "Place",
       name: "Australia",
+      address: {
+        "@type": "PostalAddress",
+        addressCountry: "AU",
+      },
     },
   };
 

--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -91,6 +91,11 @@ interface PageProps {
   params: Promise<{ stockCode: string }>;
 }
 
+// Stocks below this short % threshold are noindex'd. They produce thin
+// templated pages with no narrative value, leading to "Crawled - currently
+// not indexed" in GSC. Page remains accessible (no 404), just not indexed.
+const STOCK_PAGE_NOINDEX_THRESHOLD = 0.5;
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { stockCode } = await params;
   const code = stockCode.toUpperCase();
@@ -98,6 +103,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   // Try to fetch stock data for enriched metadata
   let title = `${code} Short Position | Official ASIC Data (T+4)`;
   let description = `${code} short selling data from official ASIC reports. Current short interest %, historical trends, charts & analysis. Updated daily with T+4 delay. Free ASX short position tracking.`;
+  let shouldNoindex = false;
 
   try {
     const stock = await getStockOrNotFound(code);
@@ -116,6 +122,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         : `${stock.name || code} short selling data from official ASIC reports.`;
       const industryInfo = stock.industry ? ` Industry: ${stock.industry}.` : "";
       description = `${shortInfo}${industryInfo} Track ${code}'s short position history, price charts, peer comparison, and ASIC data. Updated daily with T+4 delay.`;
+
+      // Noindex thin stocks (no/minimal short interest) — they remain
+      // crawlable but don't pollute the index with templated thin content.
+      if ((stock.percentageShorted ?? 0) < STOCK_PAGE_NOINDEX_THRESHOLD) {
+        shouldNoindex = true;
+      }
     }
   } catch {
     // Fall back to default title/description if fetch fails
@@ -124,6 +136,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
+    robots: shouldNoindex
+      ? { index: false, follow: true, googleBot: { index: false, follow: true } }
+      : undefined,
     keywords: [
       `${code} short position`,
       `${code} short interest`,

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -35,8 +35,17 @@ const API_URL =
 
 // API response type for top shorts
 interface TopShortsResponse {
-  timeSeries: Array<{ productCode?: string }>;
+  // In summary mode (summaryOnly=true), the API returns `latestShortPosition`
+  // populated with `current_percent` from mv_top_shorts, sorted DESC.
+  timeSeries: Array<{ productCode?: string; latestShortPosition?: number }>;
 }
+
+// Sitemap quality bar: only index stocks with meaningful short interest.
+// Stocks below this threshold get crawled but rarely indexed, polluting
+// "Crawled - currently not indexed" in GSC. Tail pages remain accessible
+// but use metadata.robots.noindex on the page itself.
+const SITEMAP_MIN_SHORT_PCT = 0.5;
+const SITEMAP_MAX_STOCKS = 300;
 
 // Popular stock codes as fallback when API is unavailable
 const FALLBACK_STOCK_CODES = [
@@ -81,12 +90,27 @@ async function getAllStockCodes(): Promise<string[]> {
 
     const data = (await response.json()) as TopShortsResponse;
 
-    // Extract unique stock codes from the response
-    const stockCodes = (data.timeSeries || [])
-      .map((ts) => ts.productCode)
-      .filter((code): code is string => typeof code === "string" && code.length > 0);
+    // Filter by quality bar to avoid sitemap bloat:
+    // - must have a current short % >= threshold
+    // - cap total entries so the sitemap stays tight
+    // Page regex on /shorts/[code] only accepts 1-4 char alphanumeric codes;
+    // longer codes (govt bonds GSB*, warrants XCLW*, preference shares like
+    // GSBW30, BENPH, MQGPD) 404 at the page level. Filter them out so we
+    // never advertise a URL the page itself rejects.
+    const VALID_CODE = /^[A-Z0-9]{1,4}$/;
+    const qualified = (data.timeSeries || [])
+      .filter((ts) => {
+        const pct = typeof ts.latestShortPosition === "number" ? ts.latestShortPosition : 0;
+        return (
+          typeof ts.productCode === "string" &&
+          VALID_CODE.test(ts.productCode) &&
+          pct >= SITEMAP_MIN_SHORT_PCT
+        );
+      })
+      .slice(0, SITEMAP_MAX_STOCKS)
+      .map((ts) => ts.productCode!);
 
-    return stockCodes.length > 0 ? [...new Set(stockCodes)] : FALLBACK_STOCK_CODES;
+    return qualified.length > 0 ? [...new Set(qualified)] : FALLBACK_STOCK_CODES;
   } catch (error) {
     console.error("Failed to fetch stock codes for sitemap:", error);
     return FALLBACK_STOCK_CODES;


### PR DESCRIPTION
## Summary

Three SEO fixes addressing GSC issues from the May 2026 review:

- **Sitemap quality filter** (`web/src/app/sitemap.ts`): only include `/shorts/[code]` URLs for stocks with >= 0.5% short interest, capped at 300. Also enforces the 1-4 char code regex that the page itself uses, eliminating ~31 guaranteed-404 URLs (govt bonds `GSB*`, warrants `XCLW*`, preference shares like `BENPH`/`MQGPD`). Cuts the stock-URL section of the sitemap from 961 → ~250-300.
- **Per-stock noindex for thin pages** (`web/src/app/shorts/[stockCode]/page.tsx`): pages with `percentageShorted < 0.5%` now set `robots: { index: false, follow: true }`. They remain accessible (no 404) but stop polluting the index with templated thin content.
- **Dataset schema fix** (`web/src/@/components/seo/enhanced-structured-data.tsx`): `spatialCoverage.@type` changed from `Country` → `Place` with nested `PostalAddress.addressCountry`, which Google's Dataset Rich Results validator was rejecting on `/` and `/top`.

## Expected impact

- "Crawled - currently not indexed" (953) → ~100 over 2-3 weeks of recrawl
- "Server error (5xx)" (48) → unaffected by this PR (already handled at page level)
- "Not found (404)" (43) → no longer re-discovered once new sitemap is live; will age out
- "Invalid object type for field 'spatialCoverage'" → resolved on next deploy

## Test plan

- [x] `tsc --noEmit` passes
- [x] `next lint` passes
- [ ] Post-deploy: fetch `https://shorted.com.au/sitemap.xml`, confirm `<loc>` count for `/shorts/*` is ~250-300 (down from 961)
- [ ] Post-deploy: GSC → Rich Results Test on `/` and `/top` → Dataset error gone
- [ ] Post-deploy: fetch a thin stock page (e.g., one with 0% short interest), confirm `<meta name="robots" content="noindex,follow">` in HTML
- [ ] Watch GSC indexing report over 2-3 weeks for "Crawled - not indexed" trend