### PR TITLE
fix(ci): Vercel CLI 47.2.2 → 54.1.0

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -725,7 +725,7 @@ jobs:
           vercel-org-id: team_xE5DMN3hIo8aPqyHNkBybg8r
           vercel-project-id: shorted-com-au
           scope: team_xE5DMN3hIo8aPqyHNkBybg8r
-          vercel-version: 47.2.2
+          vercel-version: 54.1.0
           alias-domains: preview.shorted.com.au
           vercel-args: >-
             --build-env NEXT_PUBLIC_SHORTS_SERVICE_ENDPOINT=${{ steps.deploy.outputs.shorts_url }}
@@ -1203,7 +1203,7 @@ jobs:
           vercel-org-id: team_xE5DMN3hIo8aPqyHNkBybg8r
           vercel-project-id: shorted-com-au
           scope: team_xE5DMN3hIo8aPqyHNkBybg8r
-          vercel-version: 47.2.2
+          vercel-version: 54.1.0
           vercel-args: >-
             --prod
             --build-env NEXT_PUBLIC_SHORTS_SERVICE_ENDPOINT=${{ steps.resolve-urls.outputs.shorts_url }}


### PR DESCRIPTION
PR #108 bumped to \`47.2.2\` but that version was never published to npm. Every prod deploy since has failed with \`ETARGET No matching version found for vercel@47.2.2\`, including the post-merge deploy of PR #110 (SEO fixes) at commit \`880a972e\`.

Bumping to \`54.1.0\` (current Vercel CLI latest, verified via \`npm view vercel versions\`).

## Impact

Unblocks the Vercel prod deploy of the SEO sitemap/schema fixes from PR #110, which are stuck behind this failure.

## Test plan

- [x] Verified 54.1.0 exists on npm
- [ ] Post-merge: prod deploy succeeds, https://shorted.com.au/sitemap.xml shows pruned ~250-300 /shorts URLs