### PR TITLE
fix(cache+news): BigInt-safe Redis + image backfill on re-ingest

### DIFF
--- a/services/news-aggregator/store.go
+++ b/services/news-aggregator/store.go
@@ -62,7 +62,10 @@ func (s *NewsStore) StoreArticles(ctx context.Context, articles []*NewsArticleRa
 		tag, err := s.db.Exec(ctx,
 			`INSERT INTO news_articles (stock_code, source, headline, url, published_at, sentiment, relevance_score, is_price_sensitive, summary, image_url, image_pulled_at)
 			 VALUES ($1, $2, $3, $4, $5::timestamptz, $6, $7, $8, $9, $10, $11)
-			 ON CONFLICT (url) DO NOTHING`,
+			 ON CONFLICT (url) DO UPDATE
+			 SET image_url = COALESCE(news_articles.image_url, EXCLUDED.image_url),
+			     image_pulled_at = COALESCE(news_articles.image_pulled_at, EXCLUDED.image_pulled_at)
+			 WHERE news_articles.image_url IS NULL AND EXCLUDED.image_url IS NOT NULL`,
 			stockCode,
 			a.Source,
 			a.Headline,

--- a/web/src/@/lib/kv-cache.ts
+++ b/web/src/@/lib/kv-cache.ts
@@ -138,8 +138,15 @@ export async function setCached<T>(
   // Standard Redis via ioredis
   if (ioRedis) {
     try {
-      // ioredis requires manual JSON serialization
-      await ioRedis.setex(key, Number(ttl), JSON.stringify(data));
+      // ioredis requires manual JSON serialization.
+      // BigInt replacer: protobuf Timestamp/int64 fields come back as BigInt
+      // and default JSON.stringify throws on them. Stringify to a plain
+      // number-as-string — read paths already coerce to Number or string.
+      await ioRedis.setex(
+        key,
+        Number(ttl),
+        JSON.stringify(data, (_, v) => (typeof v === "bigint" ? v.toString() : v)),
+      );
       return true;
     } catch (error) {
       console.error(`Cache set error for key ${key}:`, error);


### PR DESCRIPTION
Two fixes blocking the /news rollout from PR #112.

## What

1. **\`kv-cache.ts\` — BigInt-safe serialization for ioredis.** \`ioredis.setex\` uses \`JSON.stringify\` which throws on BigInt; protobuf \`Timestamp\` and \`int64\` fields come back as BigInt and were causing \`Cache set error for key cache:homepage:top-shorts:3m:100:0: TypeError: Do not know how to serialize a BigInt\` during Vercel prerender. Added a replacer that coerces BigInt → string. Upstash path already handles JSON internally.

2. **\`news-aggregator/store.go\` — image backfill on conflict.** Articles already present in \`news_articles\` (\`ON CONFLICT (url)\`) used to be skipped entirely, so existing Stockhead/Kalkine articles never picked up \`image_url\` even after PR #112 wired RSS image extraction. Changed to \`DO UPDATE\` that only fills \`image_url\` when the existing row has none — each aggregator run backfills images for previously-seen articles.

## Why this matters now

- PR #112 deploy went green but Vercel ISR was serving a stale "No news" version because of the BigInt cache-set error during prerender.
- Out of ~16k articles in the last 30 days, only ~250-500 (Stockhead+Kalkine) actually have images in their RSS. After this lands and the news-aggregator runs (every 4h), those existing rows will backfill their \`image_url\` in-place. Future articles continue to get images at ingest.

## Test plan

- [x] Go build passes
- [x] TS typecheck passes
- [ ] After merge: Vercel deploy succeeds (no BigInt error)
- [ ] After news-aggregator next run: verify \`image_url\` populated for Stockhead/Kalkine articles via \`SELECT source, COUNT(*) FILTER (WHERE image_url IS NOT NULL) FROM news_articles GROUP BY source;\`
- [ ] /news visually shows hero images on cards