### PR TITLE
fix(cache): type BigInt replacer to satisfy eslint

### DIFF
--- a/web/src/@/lib/kv-cache.ts
+++ b/web/src/@/lib/kv-cache.ts
@@ -142,11 +142,9 @@ export async function setCached<T>(
       // BigInt replacer: protobuf Timestamp/int64 fields come back as BigInt
       // and default JSON.stringify throws on them. Stringify to a plain
       // number-as-string — read paths already coerce to Number or string.
-      await ioRedis.setex(
-        key,
-        Number(ttl),
-        JSON.stringify(data, (_, v) => (typeof v === "bigint" ? v.toString() : v)),
-      );
+      const bigintReplacer = (_key: string, value: unknown): unknown =>
+        typeof value === "bigint" ? value.toString() : value;
+      await ioRedis.setex(key, Number(ttl), JSON.stringify(data, bigintReplacer));
       return true;
     } catch (error) {
       console.error(`Cache set error for key ${key}:`, error);


### PR DESCRIPTION
Lint flagged the inline arrow as unsafe-any. Wrap as a typed function. No runtime change. Unblocks deploy of #113.