### PR TITLE
fix(news): drop onClick from NewsCard chip — prerender failure

### DIFF
--- a/web/src/@/components/news/news-card.tsx
+++ b/web/src/@/components/news/news-card.tsx
@@ -95,7 +95,6 @@ export function NewsCard({ article, variant = "default", showStockChip = true, c
             <Link
               href={`/shorts/${article.stockCode}`}
               className="inline-flex items-center rounded-full border border-border bg-muted/50 px-2 py-0.5 font-mono text-[10px] font-semibold tracking-wide text-foreground transition-colors hover:bg-muted"
-              onClick={(e) => e.stopPropagation()}
             >
               ${article.stockCode}
             </Link>


### PR DESCRIPTION
Server-rendered components can't pass event handlers to Client Components. Removed unnecessary `onClick={(e) => e.stopPropagation()}` on the stock-code chip — it was a no-op anyway (chip is sibling of article `<a>` wrap, not nested under it).

Was failing Vercel prerender of /news with:
```
Error: Event handlers cannot be passed to Client Component props.
Error occurred prerendering page "/news"
```

Test plan:
- [x] Lint passes
- [ ] After merge: Vercel prerenders /news cleanly