### PR TITLE
fix(news): mark NewsSourceBadge use client

### DIFF
--- a/web/src/@/components/ui/news-source-badge.tsx
+++ b/web/src/@/components/ui/news-source-badge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 interface NewsSourceConfig {
   name: string;
   url: string;


### PR DESCRIPTION
NewsSourceBadge has `onClick={(e) => e.stopPropagation()}` on its outer `<a>`. When rendered from a Server Component (the new `/news` page), Next.js can't pass that event handler across the boundary and prerender fails. Mark the badge as a Client Component to make the boundary explicit. Existing callers (`stock-news-feed`, `news-feed-widget`) are already client so this is a no-op for them.