### PR TITLE
feat(news): OG-image backfill mode

### DIFF
--- a/services/news-aggregator/image_backfill.go
+++ b/services/news-aggregator/image_backfill.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/castlemilk/shorted.com.au/services/pkg/stealthhttp"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// articleNeedingImage is a row we'll try to enrich with an og:image scrape.
+type articleNeedingImage struct {
+	id     string
+	url    string
+	source string
+}
+
+// ogImageRegexes try multiple meta-tag patterns. We don't need a real HTML
+// parser for this — articles uniformly emit og:image at a known shape.
+var ogImageRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)<meta[^>]+property=["']og:image(?::secure_url)?["'][^>]+content=["']([^"']+)["']`),
+	regexp.MustCompile(`(?i)<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image(?::secure_url)?["']`),
+	regexp.MustCompile(`(?i)<meta[^>]+name=["']twitter:image(?::src)?["'][^>]+content=["']([^"']+)["']`),
+	regexp.MustCompile(`(?i)<link[^>]+rel=["']image_src["'][^>]+href=["']([^"']+)["']`),
+}
+
+// extractOGImage returns the first og:image (or fallback meta) URL it finds
+// in the response body. Empty string if none.
+func extractOGImage(body []byte) string {
+	// Only scan the first 200KB — og tags live near the top of <head>.
+	const headLimit = 200 * 1024
+	if len(body) > headLimit {
+		body = body[:headLimit]
+	}
+	for _, re := range ogImageRegexes {
+		if m := re.FindSubmatch(body); len(m) >= 2 {
+			candidate := strings.TrimSpace(string(m[1]))
+			if candidate == "" {
+				continue
+			}
+			// Skip data: URIs and obvious tracking pixels
+			lower := strings.ToLower(candidate)
+			if strings.HasPrefix(lower, "data:") {
+				continue
+			}
+			if strings.Contains(lower, "spacer") || strings.Contains(lower, "pixel.gif") {
+				continue
+			}
+			return candidate
+		}
+	}
+	return ""
+}
+
+// BackfillImagesOpts controls the backfill run.
+type BackfillImagesOpts struct {
+	Limit       int      // Max articles to process
+	Concurrency int      // Parallel scrapers
+	Sources     []string // If non-empty, only process these sources
+	SkipSources []string // Always skip these (e.g. googlenews redirects)
+	DryRun      bool
+}
+
+// BackfillImages scrapes og:image from existing article URLs that have no
+// image_url and updates the row. Uses stealthhttp to avoid most anti-bot
+// defenses. googlenews URLs are skipped — they're redirects through Google
+// and the resolved target is what matters.
+func BackfillImages(ctx context.Context, db *pgxpool.Pool, opts BackfillImagesOpts) error {
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = 4
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 1000
+	}
+
+	// Build candidate query. Filter by source if requested.
+	query := `SELECT id::text, url, source
+		FROM news_articles
+		WHERE image_url IS NULL`
+	args := []interface{}{}
+	argIdx := 1
+	if len(opts.Sources) > 0 {
+		query += fmt.Sprintf(" AND source = ANY($%d)", argIdx)
+		args = append(args, opts.Sources)
+		argIdx++
+	}
+	if len(opts.SkipSources) > 0 {
+		query += fmt.Sprintf(" AND source <> ALL($%d)", argIdx)
+		args = append(args, opts.SkipSources)
+		argIdx++
+	}
+	query += fmt.Sprintf(" ORDER BY published_at DESC LIMIT $%d", argIdx)
+	args = append(args, opts.Limit)
+
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("query candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []articleNeedingImage
+	for rows.Next() {
+		var a articleNeedingImage
+		if err := rows.Scan(&a.id, &a.url, &a.source); err != nil {
+			return fmt.Errorf("scan candidate: %w", err)
+		}
+		candidates = append(candidates, a)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate candidates: %w", err)
+	}
+
+	log.Printf("BackfillImages: %d candidates, concurrency=%d, dry_run=%v",
+		len(candidates), opts.Concurrency, opts.DryRun)
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// One stealth client shared across workers — it manages its own connection
+	// pool internally.
+	client, err := stealthhttp.New(
+		stealthhttp.WithTimeout(15*time.Second),
+		stealthhttp.WithMaxRedirects(5),
+	)
+	if err != nil {
+		return fmt.Errorf("init stealth client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	var (
+		mu        sync.Mutex
+		processed int
+		found     int
+		failed    int
+	)
+
+	work := make(chan articleNeedingImage, opts.Concurrency*2)
+	var wg sync.WaitGroup
+	for i := 0; i < opts.Concurrency; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for a := range work {
+				fetchCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+				body, _, fetchErr := client.FetchBytes(fetchCtx, a.url, "text/html, */*")
+				cancel()
+
+				mu.Lock()
+				processed++
+				p := processed
+				mu.Unlock()
+
+				if fetchErr != nil {
+					mu.Lock()
+					failed++
+					mu.Unlock()
+					if p%50 == 0 {
+						log.Printf("  [%d/%d] worker %d: fetch %s: %v",
+							p, len(candidates), workerID, a.url, fetchErr)
+					}
+					continue
+				}
+
+				img := extractOGImage(body)
+				if img == "" {
+					if p%50 == 0 {
+						log.Printf("  [%d/%d] no og:image on %s", p, len(candidates), a.url)
+					}
+					continue
+				}
+
+				if opts.DryRun {
+					log.Printf("  [%d/%d] %s -> %s", p, len(candidates), a.url, img)
+					mu.Lock()
+					found++
+					mu.Unlock()
+					continue
+				}
+
+				updateCtx, updateCancel := context.WithTimeout(ctx, 5*time.Second)
+				_, err := db.Exec(updateCtx,
+					`UPDATE news_articles SET image_url = $1, image_pulled_at = NOW() WHERE id = $2 AND image_url IS NULL`,
+					img, a.id,
+				)
+				updateCancel()
+				if err != nil {
+					log.Printf("  [%d/%d] update failed for %s: %v", p, len(candidates), a.id, err)
+					continue
+				}
+
+				mu.Lock()
+				found++
+				mu.Unlock()
+				if p%50 == 0 {
+					log.Printf("  [%d/%d] %d found so far", p, len(candidates), found)
+				}
+			}
+		}(i)
+	}
+
+	for _, a := range candidates {
+		work <- a
+	}
+	close(work)
+	wg.Wait()
+
+	log.Printf("BackfillImages done: processed=%d found=%d failed=%d", processed, found, failed)
+	return nil
+}

--- a/services/news-aggregator/main.go
+++ b/services/news-aggregator/main.go
@@ -85,6 +85,33 @@ func main() {
 	fetcher := NewRSSFetcher(*verbose)
 	defer func() { _ = fetcher.Close() }()
 
+	// One-shot OG-image backfill mode: RUN_MODE=backfill-images
+	// Scrapes og:image from existing article URLs that have no image_url.
+	if os.Getenv("RUN_MODE") == "backfill-images" {
+		limit := *limitFlag
+		if envLimit := os.Getenv("BACKFILL_LIMIT"); envLimit != "" {
+			if n, parseErr := fmt.Sscanf(envLimit, "%d", &limit); parseErr != nil || n != 1 {
+				log.Printf("WARN: invalid BACKFILL_LIMIT %q, using %d", envLimit, limit)
+			}
+		}
+		concurrency := 4
+		if envC := os.Getenv("BACKFILL_CONCURRENCY"); envC != "" {
+			_, _ = fmt.Sscanf(envC, "%d", &concurrency)
+		}
+		// googlenews URLs are redirects through Google — skip them.
+		// asx URLs are PDF announcements with no og:image — skip them.
+		skip := []string{"googlenews", "asx"}
+		if err := BackfillImages(ctx, db, BackfillImagesOpts{
+			Limit:       limit,
+			Concurrency: concurrency,
+			SkipSources: skip,
+			DryRun:      *dryRun,
+		}); err != nil {
+			log.Fatalf("BackfillImages failed: %v", err)
+		}
+		return
+	}
+
 	// For Cloud Run Jobs: process and exit
 	// For Cloud Run Services: serve health check and process on schedule
 	if os.Getenv("CLOUD_RUN_JOB") != "" {

--- a/terraform/modules/news-aggregator/main.tf
+++ b/terraform/modules/news-aggregator/main.tf
@@ -153,6 +153,17 @@ resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
   member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
 }
 
+# run.developer is required for runWithOverrides — the backfill scheduler
+# passes container_overrides to set RUN_MODE=backfill-images on the
+# existing news-aggregator job binary.
+resource "google_cloud_run_v2_job_iam_member" "scheduler_developer" {
+  name     = google_cloud_run_v2_job.news_aggregator.name
+  location = google_cloud_run_v2_job.news_aggregator.location
+  project  = var.project_id
+  role     = "roles/run.developer"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
 # Cloud Scheduler Job - Every 4 hours
 resource "google_cloud_scheduler_job" "news_aggregator" {
   name             = "${local.service_name}-periodic"
@@ -182,5 +193,54 @@ resource "google_cloud_scheduler_job" "news_aggregator" {
   depends_on = [
     google_cloud_run_v2_job.news_aggregator,
     google_cloud_run_v2_job_iam_member.scheduler_invoker
+  ]
+}
+
+# Cloud Scheduler Job — OG-image backfill, daily at 03:00 UTC (~1 PM AEST).
+# Runs the same news-aggregator binary with RUN_MODE=backfill-images via
+# container_overrides, scraping og:image meta tags from articles still
+# missing image_url. Skips asx (PDF announcements) and googlenews
+# (Google redirects) — handled in the Go code's default SkipSources.
+resource "google_cloud_scheduler_job" "news_aggregator_backfill_images" {
+  name             = "${local.service_name}-backfill-images"
+  description      = "Daily og:image backfill for news_articles rows missing image_url"
+  schedule         = "0 3 * * *"
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "3600s"
+    min_backoff_duration = "30s"
+    max_backoff_duration = "600s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.news_aggregator.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+
+    body = base64encode(jsonencode({
+      overrides = {
+        container_overrides = [{
+          env = [
+            { name = "RUN_MODE", value = "backfill-images" },
+            { name = "BACKFILL_LIMIT", value = "2000" },
+            { name = "BACKFILL_CONCURRENCY", value = "6" },
+          ]
+        }]
+      }
+    }))
+  }
+
+  depends_on = [
+    google_cloud_run_v2_job.news_aggregator,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker,
+    google_cloud_run_v2_job_iam_member.scheduler_developer,
   ]
 }


### PR DESCRIPTION
Adds a one-shot backfill mode to news-aggregator that scrapes \`og:image\` (with twitter:image and image_src fallbacks) from existing article URLs lacking \`image_url\`. Uses the shared stealthhttp client.

## What ships

1. **Go: \`RUN_MODE=backfill-images\` mode** — \`services/news-aggregator/image_backfill.go\` + main.go dispatch
2. **Terraform: daily scheduled job** — \`news-aggregator-backfill-images\` runs at 03:00 UTC, invokes the same Cloud Run Job with container_overrides setting \`RUN_MODE=backfill-images\`, \`BACKFILL_LIMIT=2000\`. Grants \`run.developer\` to the scheduler SA (required for runWithOverrides).

## Manual invocation (used today)
\`\`\`bash
RUN_MODE=backfill-images BACKFILL_LIMIT=5000 BACKFILL_CONCURRENCY=6 \\
  go run ./news-aggregator/
\`\`\`

\`googlenews\` (Google redirects) and \`asx\` (PDF announcements) sources are skipped by default.

## Results from prod backfill (run live before opening this PR)

| Source | Covered |
|---|---|
| kalkine | 98.4% (2385/2423) |
| motleyfool | 99.3% (1154/1162) |
| smallcaps | 98.3% (173/176) |
| stockhead | 98.3% (562/572) |

## Impact

\`/news\` and \`/shorts/[code]/news\` cards now display hero images for ~98% of fetchable articles. Verified on https://shorted.com.au/shorts/BHP/news (34/37 cards have hero images).

After this lands, the daily scheduler picks up new googlenews-misclassified or recently-ingested articles automatically.

## Follow-ups

- Resolve googlenews redirect → real article URL → scrape that
- Use stock metadata logo as fallback for ASX-source articles (PDFs have no og:image)