### PR TITLE
docs(seo): SEO roadmap + /search page

### DIFF
--- a/SEO_ROADMAP.md
+++ b/SEO_ROADMAP.md
@@ -1,0 +1,173 @@
+# Shorted.com.au — SEO Roadmap
+
+Tracking the next wave of SEO improvements after the news platform ship
+(PRs #110–#117). Items ordered by impact-to-effort within each tier.
+
+Effort: **S** = ≤1 day, **M** = 2-5 days, **L** = 1-2 weeks.
+
+---
+
+## Tier 1 — Highest impact
+
+### 1. Glossary scale-up: 26 → 100+ terms — `[S, very high impact]`
+
+Every term is an indexable long-tail page. AI-draft + editorial review.
+
+Buckets to cover:
+- **Short selling mechanics** (covered call shorting, naked short, locate, recall, rebate rate)
+- **Ratios & metrics** (days-to-cover, short interest %, utilisation, borrow fee, NAV)
+- **Market structure** (T+2 settlement, ex-clearing, market on close, opening auction)
+- **Regulators & venues** (ASIC, ASX, ASX 24, Chi-X, BlockEvent, ASX Trade)
+- **Risk concepts** (margin call, gamma squeeze, beta, R/R, drawdown, volatility)
+- **Behavioural** (capitulation, panic, FOMO, herding)
+- **Macro/AU-specific** (RBA cash rate, AUD parity, banking royal commission)
+- **Reporting cycles** (T+4 short report, half-year, full-year, Q3 update)
+- **Corporate actions** (rights issue, SPP, share buyback, bonus issue)
+- **Tax & legal** (CGT discount, franking credits, wash sale, related-party)
+
+**Acceptance**: 100+ slugs in `web/src/@/data/glossary-terms.ts`, each with
+a `DefinedTerm` schema, internal links to ≥2 other terms + ≥1 stock/sector.
+
+### 2. Programmatic sector hubs — `[M, very high impact]`
+
+`/sectors/banking`, `/sectors/mining`, etc. No page exists for
+"[sector] short selling ASX" queries today. ~12 sectors × ~800 unique words.
+
+Each sector hub:
+- Title: "[Sector] Short Selling on the ASX | Live Data + Top Shorts"
+- Self-updating top-10 shorts in that sector (from `mv_treemap_data`)
+- Sector-aggregated short %, trend chart
+- 3-paragraph editorial intro (manual or AI-drafted)
+- `Dataset` schema + `Article` schema
+- Internal links: top stocks in sector, sector glossary terms, related sectors
+
+**Acceptance**: 12 sector pages live, each with unique 600+ word intro and
+indexable in sitemap.
+
+### 3. Knowledge Graph `sameAs` anchors — `[S, high impact]`
+
+On `/shorts/[code]`, add `Corporation` schema with `sameAs` array to
+Wikipedia, Wikidata, ASX, Bloomberg. Disambiguates entity for AI Overviews.
+
+Needs a wikidata/Wikipedia lookup pass. Cache result in
+`company-metadata.wikidata_qid`, `wikipedia_url`.
+
+**Acceptance**: Top 100 stocks have `sameAs` populated. Schema validates
+in Rich Results Test.
+
+### 4. Google News Publisher Center — `[S, high impact, owner action]`
+
+Register `shorted.com.au` at [publishercenter.google.com](https://publishercenter.google.com),
+submit news sitemap, verify ownership. Unlocks Top Stories carousel
++ News tab. NewsArticle schema already shipped — this is activation.
+
+---
+
+## Tier 2 — Strong moves
+
+### 5. Author byline + `/authors` page — `[M, high impact]`
+
+E-E-A-T Author signal is mandatory for finance YMYL content. Without it
+Google discounts every page.
+
+Build:
+- `/authors/[slug]` route with `Person` schema (sameAs LinkedIn/Twitter,
+  photo, bio, qualifications, articles list)
+- Author field on blog posts + weekly reports + news cards
+- ≥2 authors (editorial + data/ML) with real bylines
+
+### 6. WebSite schema + Sitelinks search box — `[S, medium impact]`
+
+In root `layout.tsx`:
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "url": "https://shorted.com.au",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://shorted.com.au/search?q={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+```
+
+Needs `/search` page accepting `?q=`. Currently only `nav-search-input.tsx`
+exists client-side.
+
+### 7. Director/insider trades hub — `[M, medium impact]`
+
+You have `director_trades` data + `GetDirectorTrades` RPC. Build:
+- `/insider-trading` — recent insider activity across ASX
+- `/insider-trading/[code]` — per-stock insider history
+- Schema: `Article` + `ItemList`
+- Link from `/shorts/[code]` → `/insider-trading/[code]`
+
+Zero competition in AU market.
+
+### 8. Weekly report dynamic OG images — `[M, medium impact]`
+
+`@vercel/og` per-report chart cards. Replace generic report OG image
+with this week's biggest movers. Social CTR lift.
+
+---
+
+## Tier 3 — Quick wins
+
+### 9. `preconnect` for image CDNs — `[S, S impact]`
+LCP improvement on `/news`. Domains: `kalkinemedia.com`, `stockhead.com.au`,
+`fool.com.au`, `smallcaps.com.au`.
+
+### 10. llms.txt expansion — `[S, S impact]`
+Add LLM grounding for `/news`, `/glossary`, `/sectors`. Helps AI Overviews
+disambiguate shorted.com.au as the ASX-short-selling source.
+
+### 11. Audit news image CLS — `[S, S impact]`
+Lazy-load is already on but verify aspect-ratio is locked to prevent CLS.
+
+### 12. Cross-link weekly reports → stocks — `[S, M impact]`
+Audit weekly reports for 100% coverage of stock mentions → `/shorts/[code]`.
+
+---
+
+## Tier 4 — Longer plays (queue)
+
+### 13. Real-time price + short overlay chart — `[L]`
+Visual moat. Annotate price chart with ASIC short reports as overlays.
+
+### 14. Dataset Hub at `/data` — `[M]`
+Public dataset listing with downloadable CSVs. Each gets `Dataset` schema
+→ Google Dataset Search inclusion.
+
+### 15. Story clustering on `/news` — `[L]`
+Apple Stocks UX parity. Group same-event coverage from 4+ sources into
+1 card with source-count badge.
+
+### 16. More news sources — `[M]`
+ABC News Business, SMH Business, Reuters AU, livewire markets. Wire
+`asx-announcement-crawler` output into news_articles.
+
+### 17. Resolve googlenews redirects — `[M]`
+2.6k articles have googlenews URLs that redirect to source publishers.
+Follow redirects via stealth client, scrape og:image from destination.
+
+---
+
+## Tracking
+
+PRs landing for each item should link back to this file. Update with
+ship date as items close out.
+
+| # | Item | PR | Shipped |
+|---|---|---|---|
+| 6 | WebSite schema + search action | — | — |
+| 3 | sameAs Knowledge Graph anchors | — | — |
+| 1 | Glossary scale-up | — | — |
+| 2 | Programmatic sector hubs | — | — |
+| 5 | Author byline | — | — |
+| 7 | Insider trades hub | — | — |
+| 8 | Weekly report OG images | — | — |
+| 9 | preconnect | — | — |
+| 10 | llms.txt | — | — |
+
+Last updated: 2026-05-17

--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -1,0 +1,167 @@
+import { type Metadata } from "next";
+import Link from "next/link";
+import { Search as SearchIcon, TrendingDown, TrendingUp } from "lucide-react";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { createClient } from "@connectrpc/connect";
+import { ShortedStocksService } from "~/gen/shorts/v1alpha1/shorts_pb";
+import { siteConfig } from "~/@/config/site";
+import { DashboardLayout } from "~/@/components/layouts/dashboard-layout";
+import {
+  Breadcrumbs,
+  BreadcrumbStructuredData,
+} from "~/@/components/seo/breadcrumbs";
+import { SHORTS_API_URL } from "~/app/actions/config";
+
+export const revalidate = 300;
+
+interface PageProps {
+  searchParams: Promise<{ q?: string }>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: PageProps): Promise<Metadata> {
+  const { q } = await searchParams;
+  const query = (q ?? "").trim();
+  const base = `${siteConfig.url}/search`;
+  if (!query) {
+    return {
+      title: "Search ASX Stocks | Shorted",
+      description:
+        "Search Australian Securities Exchange (ASX) stocks by code or company name. View live short positions, sentiment, and analysis.",
+      alternates: { canonical: base },
+      robots: { index: false, follow: true },
+    };
+  }
+  return {
+    title: `Search "${query}" | ASX Stocks | Shorted`,
+    description: `Search results for "${query}" — ASX stocks matched by code or company name.`,
+    alternates: { canonical: `${base}?q=${encodeURIComponent(query)}` },
+    // Search-results pages are noindex by convention (Google's own guidance).
+    robots: { index: false, follow: true },
+  };
+}
+
+interface SearchResultStock {
+  productCode: string;
+  name: string;
+  percentageShorted?: number;
+}
+
+async function searchStocks(query: string): Promise<SearchResultStock[]> {
+  if (!query) return [];
+  try {
+    const transport = createConnectTransport({
+      fetch,
+      baseUrl: SHORTS_API_URL,
+    });
+    const client = createClient(ShortedStocksService, transport);
+    const resp = await client.searchStocks({
+      query,
+      limit: 30,
+      includeDetails: false,
+    });
+    return resp.stocks.map((s) => ({
+      productCode: s.productCode,
+      name: s.name,
+      percentageShorted: s.percentageShorted,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export default async function SearchPage({ searchParams }: PageProps) {
+  const { q } = await searchParams;
+  const query = (q ?? "").trim();
+  const results = await searchStocks(query);
+
+  const breadcrumbItems = [
+    { label: "Search", href: query ? `/search?q=${encodeURIComponent(query)}` : "/search" },
+  ];
+
+  return (
+    <DashboardLayout>
+      <BreadcrumbStructuredData items={breadcrumbItems} />
+      <section className="mb-4 flex items-center gap-3">
+        <div className="rounded-lg bg-primary/10 p-2">
+          <SearchIcon className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+            {query ? `Search: "${query}"` : "Search ASX Stocks"}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {query
+              ? `${results.length} match${results.length === 1 ? "" : "es"} found.`
+              : "Find an ASX stock by code (e.g. BHP) or company name."}
+          </p>
+        </div>
+      </section>
+
+      <Breadcrumbs items={breadcrumbItems} />
+
+      <form action="/search" method="get" className="mt-4">
+        <label htmlFor="q" className="sr-only">
+          Search ASX stocks
+        </label>
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            id="q"
+            name="q"
+            defaultValue={query}
+            placeholder="Stock code or company name…"
+            className="w-full rounded-lg border bg-card py-3 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+      </form>
+
+      {!query ? (
+        <div className="mt-8 rounded-lg border bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          Type a stock code or company name above. Try{" "}
+          <Link href="/search?q=BHP" className="underline">BHP</Link>,{" "}
+          <Link href="/search?q=CBA" className="underline">CBA</Link>, or{" "}
+          <Link href="/search?q=mining" className="underline">mining</Link>.
+        </div>
+      ) : results.length === 0 ? (
+        <div className="mt-8 rounded-lg border bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          No stocks matched <strong>"{query}"</strong>. Try a different search
+          term or browse the{" "}
+          <Link href="/directory" className="underline">full directory</Link>.
+        </div>
+      ) : (
+        <ul className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {results.map((s) => (
+            <li key={s.productCode}>
+              <Link
+                href={`/shorts/${s.productCode}`}
+                className="group flex items-center gap-3 rounded-lg border bg-card p-4 transition-all hover:border-primary/40 hover:shadow-md"
+              >
+                <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs font-semibold tracking-wide">
+                  {s.productCode}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium group-hover:text-primary">
+                    {s.name || s.productCode}
+                  </p>
+                  {typeof s.percentageShorted === "number" && (
+                    <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                      {s.percentageShorted > 0 ? (
+                        <TrendingDown className="h-3 w-3 text-rose-500" />
+                      ) : (
+                        <TrendingUp className="h-3 w-3 text-emerald-500" />
+                      )}
+                      {s.percentageShorted.toFixed(2)}% shorted
+                    </p>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## What

- **\`SEO_ROADMAP.md\`** — 17-item prioritized roadmap across 4 tiers covering the next wave of SEO improvements after the news platform ship (PRs #110-#117).
- **\`/search\` page** — server-rendered ASX stock search by code or company name, hits the existing \`SearchStocks\` Connect RPC. Marked \`noindex\` per Google's search-results-page guidance, but lets external links (and a future \`WebSite\` SearchAction) resolve to a usable surface.

## Why

The roadmap unblocks parallel work — each item has clear acceptance criteria, effort, and impact. The \`/search\` page lays the groundwork for Item 6 (Sitelinks SearchAction).

## Next up from roadmap

In order: #3 sameAs anchors → #1 glossary scale-up → #2 sector hubs.