### PR TITLE
feat(seo): Corporation schema with sameAs anchors on stock pages

### DIFF
--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -309,12 +309,45 @@ const Page = async ({ params }: PageProps) => {
             tickerSymbol: stockCode,
           },
         };
+        // Corporation schema with sameAs anchors so Google's Knowledge
+        // Graph treats this page as the canonical hub for [stockCode]'s
+        // short-selling entity. ASX + Bloomberg URLs are deterministic.
+        // Wikipedia/Wikidata require per-stock lookup — handled in a
+        // follow-up enrichment pass.
+        const corporationSchema = {
+          "@context": "https://schema.org",
+          "@type": "Corporation",
+          name: companyName,
+          legalName: companyName,
+          tickerSymbol: stockCode,
+          identifier: `ASX:${stockCode}`,
+          ...(stock.logoUrl ? { logo: stock.logoUrl, image: stock.logoUrl } : {}),
+          ...(industry ? { naics: industry } : {}),
+          sameAs: [
+            `https://www.asx.com.au/markets/company/${stockCode}`,
+            `https://www.bloomberg.com/profile/company/${stockCode}:AU`,
+            `https://au.finance.yahoo.com/quote/${stockCode}.AX`,
+            `https://www.google.com/finance/quote/${stockCode}:ASX`,
+            `https://simplywall.st/stocks/au/none/asx-${stockCode.toLowerCase()}`,
+          ],
+          subjectOf: {
+            "@type": "WebPage",
+            url: `${siteConfig.url}/shorts/${stockCode}`,
+            name: `${companyName} (${stockCode}) Short Position`,
+          },
+        };
         return (
           <>
             <script
               type="application/ld+json"
               dangerouslySetInnerHTML={{
                 __html: JSON.stringify(datasetSchema),
+              }}
+            />
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{
+                __html: JSON.stringify(corporationSchema),
               }}
             />
             <section


### PR DESCRIPTION
Adds a Corporation JSON-LD block on \`/shorts/[code]\` with \`sameAs\` anchors to:

- \`https://www.asx.com.au/markets/company/[CODE]\`
- \`https://www.bloomberg.com/profile/company/[CODE]:AU\`
- \`https://au.finance.yahoo.com/quote/[CODE].AX\`
- \`https://www.google.com/finance/quote/[CODE]:ASX\`
- \`https://simplywall.st/stocks/au/none/asx-[code]\`

## Why

Google's Knowledge Graph uses \`sameAs\` to disambiguate entities. By pointing at the same external profiles that Google already recognises as canonical for ASX-listed companies, we tell the KG that \`/shorts/[code]\` is the authoritative short-selling hub for the same entity. This is the strongest available signal for:
- AI Overviews citations
- Rich Results carousel inclusion
- Entity-based search disambiguation

## Refs

SEO_ROADMAP.md item #3. Follow-up PR will add Wikipedia + Wikidata \`sameAs\` after running a one-off enrichment pass (needs per-stock lookup, can be cached in \`company-metadata\` table).

## Test plan

- [x] tsc + lint pass
- [ ] After deploy: paste \`https://shorted.com.au/shorts/BHP\` into [Rich Results Test](https://search.google.com/test/rich-results) — should detect both Dataset and Corporation schema
- [ ] Verify \`sameAs\` URLs resolve (some may 404 for less-popular stocks — that's OK, Google handles invalid sameAs gracefully)