### PR TITLE
feat(news): resolve googlenews redirects + weekly scheduler

### DIFF
--- a/services/news-aggregator/googlenews_resolve.go
+++ b/services/news-aggregator/googlenews_resolve.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/castlemilk/shorted.com.au/services/pkg/stealthhttp"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// googleNewsCandidate is a news_articles row whose url is a Google News
+// redirect that we want to resolve to its source article URL.
+type googleNewsCandidate struct {
+	id  string
+	url string
+}
+
+// ResolveGoogleNewsOpts controls the resolve run.
+type ResolveGoogleNewsOpts struct {
+	Limit       int
+	Concurrency int
+	DryRun      bool
+	UpdateURL   bool // If true, replace url with resolved URL too (not just image)
+}
+
+// ResolveGoogleNews finds news_articles rows with googlenews URLs that
+// lack an image_url, follows the redirect to the publisher's article,
+// scrapes og:image, and updates the row. By default also rewrites the
+// url to the resolved publisher URL so future visits hit the source
+// directly rather than Google's redirector.
+func ResolveGoogleNews(ctx context.Context, db *pgxpool.Pool, opts ResolveGoogleNewsOpts) error {
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = 4
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 500
+	}
+
+	// Pull candidates: googlenews-source rows still missing image_url.
+	rows, err := db.Query(ctx, `
+		SELECT id::text, url
+		FROM news_articles
+		WHERE source = 'googlenews'
+		  AND image_url IS NULL
+		  AND url LIKE 'https://news.google.com/%'
+		ORDER BY published_at DESC
+		LIMIT $1
+	`, opts.Limit)
+	if err != nil {
+		return fmt.Errorf("query candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []googleNewsCandidate
+	for rows.Next() {
+		var c googleNewsCandidate
+		if err := rows.Scan(&c.id, &c.url); err != nil {
+			return fmt.Errorf("scan candidate: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate candidates: %w", err)
+	}
+
+	log.Printf("ResolveGoogleNews: %d candidates, concurrency=%d, dry_run=%v, update_url=%v",
+		len(candidates), opts.Concurrency, opts.DryRun, opts.UpdateURL)
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Stealth client with redirect-follow enabled.
+	client, err := stealthhttp.New(
+		stealthhttp.WithTimeout(20*time.Second),
+		stealthhttp.WithMaxRedirects(8),
+	)
+	if err != nil {
+		return fmt.Errorf("init stealth client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	var (
+		mu        sync.Mutex
+		processed int
+		resolved  int
+		withImage int
+		failed    int
+	)
+
+	work := make(chan googleNewsCandidate, opts.Concurrency*2)
+	var wg sync.WaitGroup
+	for i := 0; i < opts.Concurrency; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for c := range work {
+				fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				body, finalURL, fetchErr := client.FetchBytes(fetchCtx, c.url, "text/html, */*")
+				cancel()
+
+				mu.Lock()
+				processed++
+				p := processed
+				mu.Unlock()
+
+				if fetchErr != nil {
+					mu.Lock()
+					failed++
+					mu.Unlock()
+					if p%50 == 0 {
+						log.Printf("  [%d/%d] worker %d: fetch %s: %v",
+							p, len(candidates), workerID, c.url, fetchErr)
+					}
+					continue
+				}
+
+				// finalURL is the URL after redirects. If it still points
+				// at news.google.com the resolver failed (Google sometimes
+				// serves an interstitial page).
+				resolvedURL := strings.TrimSpace(finalURL)
+				if resolvedURL == "" || strings.Contains(resolvedURL, "news.google.com") {
+					// Try to parse the resolved URL from a meta refresh on
+					// the body before giving up.
+					if alt := metaRefreshURL(body); alt != "" {
+						resolvedURL = alt
+					}
+				}
+
+				if resolvedURL == "" || strings.Contains(resolvedURL, "news.google.com") {
+					mu.Lock()
+					failed++
+					mu.Unlock()
+					continue
+				}
+
+				mu.Lock()
+				resolved++
+				mu.Unlock()
+
+				img := extractOGImage(body)
+				if img == "" && resolvedURL != c.url {
+					// If the first body was an interstitial, re-fetch the
+					// resolved URL directly to find the og:image.
+					fetchCtx2, cancel2 := context.WithTimeout(ctx, 20*time.Second)
+					body2, _, err2 := client.FetchBytes(fetchCtx2, resolvedURL, "text/html, */*")
+					cancel2()
+					if err2 == nil {
+						img = extractOGImage(body2)
+					}
+				}
+
+				if img == "" {
+					continue
+				}
+
+				if opts.DryRun {
+					log.Printf("  [%d/%d] %s -> %s (img=%s)", p, len(candidates), c.url, resolvedURL, img)
+					mu.Lock()
+					withImage++
+					mu.Unlock()
+					continue
+				}
+
+				updateCtx, updateCancel := context.WithTimeout(ctx, 5*time.Second)
+				var qErr error
+				if opts.UpdateURL {
+					_, qErr = db.Exec(updateCtx,
+						`UPDATE news_articles
+						 SET image_url = $1, image_pulled_at = NOW(), url = $2
+						 WHERE id = $3 AND image_url IS NULL`,
+						img, resolvedURL, c.id,
+					)
+				} else {
+					_, qErr = db.Exec(updateCtx,
+						`UPDATE news_articles
+						 SET image_url = $1, image_pulled_at = NOW()
+						 WHERE id = $2 AND image_url IS NULL`,
+						img, c.id,
+					)
+				}
+				updateCancel()
+				if qErr != nil {
+					log.Printf("  [%d/%d] update failed for %s: %v", p, len(candidates), c.id, qErr)
+					continue
+				}
+
+				mu.Lock()
+				withImage++
+				mu.Unlock()
+				if p%50 == 0 {
+					log.Printf("  [%d/%d] resolved=%d withImage=%d", p, len(candidates), resolved, withImage)
+				}
+			}
+		}(i)
+	}
+
+	for _, c := range candidates {
+		work <- c
+	}
+	close(work)
+	wg.Wait()
+
+	log.Printf("ResolveGoogleNews done: processed=%d resolved=%d withImage=%d failed=%d",
+		processed, resolved, withImage, failed)
+	return nil
+}
+
+// metaRefreshURL extracts the destination URL from an HTML meta refresh
+// tag, used by some interstitial pages.
+func metaRefreshURL(body []byte) string {
+	const headLimit = 32 * 1024
+	if len(body) > headLimit {
+		body = body[:headLimit]
+	}
+	lower := strings.ToLower(string(body))
+	idx := strings.Index(lower, "http-equiv=\"refresh\"")
+	if idx < 0 {
+		return ""
+	}
+	rest := string(body[idx:])
+	urlIdx := strings.Index(strings.ToLower(rest), "url=")
+	if urlIdx < 0 {
+		return ""
+	}
+	tail := rest[urlIdx+4:]
+	end := strings.IndexAny(tail, "\"'>")
+	if end < 0 {
+		return ""
+	}
+	u := strings.TrimSpace(tail[:end])
+	if _, err := url.Parse(u); err != nil {
+		return ""
+	}
+	return u
+}

--- a/services/news-aggregator/main.go
+++ b/services/news-aggregator/main.go
@@ -112,6 +112,36 @@ func main() {
 		return
 	}
 
+	// One-shot Google News resolver mode: RUN_MODE=resolve-googlenews
+	// Follows the news.google.com redirect to the source publisher,
+	// scrapes og:image, and updates the article row (optionally also
+	// rewriting url to the resolved publisher URL).
+	if os.Getenv("RUN_MODE") == "resolve-googlenews" {
+		limit := 500
+		if envLimit := os.Getenv("BACKFILL_LIMIT"); envLimit != "" {
+			_, _ = fmt.Sscanf(envLimit, "%d", &limit)
+		}
+		concurrency := 4
+		if envC := os.Getenv("BACKFILL_CONCURRENCY"); envC != "" {
+			_, _ = fmt.Sscanf(envC, "%d", &concurrency)
+		}
+		// Defaults to UpdateURL=true so /shorts/[code]/news links go
+		// directly to the publisher rather than Google's redirector.
+		updateURL := true
+		if v := os.Getenv("BACKFILL_UPDATE_URL"); v == "false" || v == "0" {
+			updateURL = false
+		}
+		if err := ResolveGoogleNews(ctx, db, ResolveGoogleNewsOpts{
+			Limit:       limit,
+			Concurrency: concurrency,
+			DryRun:      *dryRun,
+			UpdateURL:   updateURL,
+		}); err != nil {
+			log.Fatalf("ResolveGoogleNews failed: %v", err)
+		}
+		return
+	}
+
 	// For Cloud Run Jobs: process and exit
 	// For Cloud Run Services: serve health check and process on schedule
 	if os.Getenv("CLOUD_RUN_JOB") != "" {

--- a/terraform/modules/news-aggregator/main.tf
+++ b/terraform/modules/news-aggregator/main.tf
@@ -244,3 +244,54 @@ resource "google_cloud_scheduler_job" "news_aggregator_backfill_images" {
     google_cloud_run_v2_job_iam_member.scheduler_developer,
   ]
 }
+
+# Cloud Scheduler Job — weekly Google News redirect resolver. Picks up
+# googlenews-source rows whose url still points at news.google.com and
+# resolves them through to the publisher article, then scrapes og:image
+# from the destination. Runs Mondays 04:00 UTC (~2 PM AEST) so it
+# follows the daily backfill and doesn't compete with it for stealth-
+# client quota.
+resource "google_cloud_scheduler_job" "news_aggregator_resolve_googlenews" {
+  name             = "${local.service_name}-resolve-googlenews"
+  description      = "Weekly resolver: follow googlenews redirects to publisher articles and scrape og:image"
+  schedule         = "0 4 * * 1"
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "3600s"
+    min_backoff_duration = "30s"
+    max_backoff_duration = "600s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.news_aggregator.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+
+    body = base64encode(jsonencode({
+      overrides = {
+        container_overrides = [{
+          env = [
+            { name = "RUN_MODE", value = "resolve-googlenews" },
+            { name = "BACKFILL_LIMIT", value = "1000" },
+            { name = "BACKFILL_CONCURRENCY", value = "4" },
+            { name = "BACKFILL_UPDATE_URL", value = "true" },
+          ]
+        }]
+      }
+    }))
+  }
+
+  depends_on = [
+    google_cloud_run_v2_job.news_aggregator,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker,
+    google_cloud_run_v2_job_iam_member.scheduler_developer,
+  ]
+}


### PR DESCRIPTION
SEO_ROADMAP.md item #17.

After PR #117's og:image backfill, googlenews-source articles (~2.6k in the last 30 days) remained image-less because their URLs point at `news.google.com` redirectors. This PR adds a resolver that follows those redirects to the publisher article, scrapes og:image from the destination, and (by default) rewrites the stored url to the resolved publisher URL.

## What ships

1. **Go**: `RUN_MODE=resolve-googlenews` mode in news-aggregator. New file `googlenews_resolve.go` + main.go dispatch. Handles meta-refresh fallback for Google interstitials.

2. **Terraform**: `news-aggregator-resolve-googlenews` scheduler — Mondays 04:00 UTC. Same Cloud Run Job binary, container_overrides set `RUN_MODE=resolve-googlenews`, `LIMIT=1000`, `CONCURRENCY=4`, `UPDATE_URL=true`.

## Why weekly cadence

Google's redirector applies stricter rate limits than ordinary publishers. Weekly stays under any quota threshold while still chipping ~1000 articles/week through the backlog.

## Manual run

```bash
RUN_MODE=resolve-googlenews BACKFILL_LIMIT=500 BACKFILL_CONCURRENCY=4 \
  go run ./news-aggregator/
```

## Test plan
- [x] go build + golangci-lint pass
- [x] terraform validate pass
- [ ] After merge: trigger scheduler manually, verify articles with `source='googlenews'` get `image_url` populated
- [ ] Verify resolved URLs don't point at news.google.com