### PR TITLE
feat(news): add 5 ASX news sources (ABC, SMH, Age, AFR, BNA)

### DIFF
--- a/services/news-aggregator/sources.go
+++ b/services/news-aggregator/sources.go
@@ -44,5 +44,35 @@ func GetDefaultSources() []NewsSource {
 			SourceID:  "googlenews",
 			IsTrusted: true,
 		},
+		{
+			Name:      "ABC News Business",
+			URL:       "https://www.abc.net.au/news/feed/2942460/rss.xml",
+			SourceID:  "abc",
+			IsTrusted: true,
+		},
+		{
+			Name:      "SMH Business",
+			URL:       "https://www.smh.com.au/rss/business.xml",
+			SourceID:  "smh",
+			IsTrusted: true,
+		},
+		{
+			Name:      "The Age Business",
+			URL:       "https://www.theage.com.au/rss/business.xml",
+			SourceID:  "theage",
+			IsTrusted: true,
+		},
+		{
+			Name:      "AFR Markets",
+			URL:       "https://www.afr.com/rss/markets.xml",
+			SourceID:  "afr",
+			IsTrusted: true,
+		},
+		{
+			Name:      "Business News Australia",
+			URL:       "https://www.businessnewsaustralia.com/rss.xml",
+			SourceID:  "businessnews",
+			IsTrusted: false,
+		},
 	}
 }

--- a/web/src/@/components/ui/news-source-badge.tsx
+++ b/web/src/@/components/ui/news-source-badge.tsx
@@ -57,6 +57,36 @@ const NEWS_SOURCES: Record<string, NewsSourceConfig> = {
     logo: "",
     bgClass: "bg-teal-50 dark:bg-teal-900/20 text-teal-700 dark:text-teal-300 border-teal-200 dark:border-teal-700",
   },
+  abc: {
+    name: "ABC News",
+    url: "https://www.abc.net.au/news",
+    logo: "",
+    bgClass: "bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border-red-200 dark:border-red-700",
+  },
+  smh: {
+    name: "SMH",
+    url: "https://www.smh.com.au/business",
+    logo: "",
+    bgClass: "bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 border-indigo-200 dark:border-indigo-700",
+  },
+  theage: {
+    name: "The Age",
+    url: "https://www.theage.com.au/business",
+    logo: "",
+    bgClass: "bg-cyan-50 dark:bg-cyan-900/20 text-cyan-700 dark:text-cyan-300 border-cyan-200 dark:border-cyan-700",
+  },
+  afr: {
+    name: "AFR",
+    url: "https://www.afr.com/markets",
+    logo: "",
+    bgClass: "bg-rose-50 dark:bg-rose-900/20 text-rose-700 dark:text-rose-300 border-rose-200 dark:border-rose-700",
+  },
+  businessnews: {
+    name: "Business News AU",
+    url: "https://www.businessnewsaustralia.com",
+    logo: "",
+    bgClass: "bg-lime-50 dark:bg-lime-900/20 text-lime-700 dark:text-lime-300 border-lime-200 dark:border-lime-700",
+  },
 };
 
 const DEFAULT_SOURCE: NewsSourceConfig = {


### PR DESCRIPTION
SEO_ROADMAP.md item #16.

| Source | Trust | RSS feed |
|---|---|---|
| ABC News Business | trusted | abc.net.au/news/feed/2942460/rss.xml |
| SMH Business | trusted | smh.com.au/rss/business.xml |
| The Age Business | trusted | theage.com.au/rss/business.xml |
| AFR Markets | trusted | afr.com/rss/markets.xml |
| Business News Australia | not trusted | businessnewsaustralia.com/rss.xml |

All 5 verified returning valid RSS XML (200 + `<rss>`). Each ships with a matching NewsSourceBadge colour theme.

Existing `extractRSSImage()` will pick up images from any feeds that emit `media:content` / `media:thumbnail` (verified ABC + SMH include them).

**Re-applied** — dropped by an accidental git reset in an earlier batch.