### PR TITLE
feat(seo): price + short-interest dual-axis overlay chart on stock pages

### DIFF
--- a/web/src/@/components/company/short-price-overlay.tsx
+++ b/web/src/@/components/company/short-price-overlay.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { CandlestickChart, TrendingDown } from "lucide-react";
+import {
+  ShortPriceOverlayChart,
+  type OverlayPoint,
+} from "~/@/components/ui/short-price-overlay-chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/@/components/ui/card";
+import { Skeleton } from "~/@/components/ui/skeleton";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "~/@/components/ui/toggle-group";
+import { fetchStockDataClient } from "~/@/lib/client-api";
+import {
+  getHistoricalData,
+  type HistoricalDataPoint,
+} from "~/@/lib/stock-data-service";
+import { type TimeSeriesPoint } from "~/gen/stocks/v1alpha1/stocks_pb";
+
+interface ShortPriceOverlayProps {
+  stockCode: string;
+  initialPeriod?: string;
+}
+
+const PERIODS = ["3m", "6m", "1y", "2y", "5y"] as const;
+type Period = (typeof PERIODS)[number];
+
+interface MergedSeries {
+  points: OverlayPoint[];
+  correlation: number | null;
+}
+
+const dayKey = (d: Date): string =>
+  `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+
+function mergeSeries(
+  shorts: TimeSeriesPoint[],
+  prices: HistoricalDataPoint[],
+): MergedSeries {
+  // Index both series by ISO date string for a tight inner-join then a
+  // left-outer-join on the union of dates. Most stocks have daily price
+  // points; short positions are also daily (ASIC T+4) so the union is
+  // tight.
+  const byDate = new Map<string, OverlayPoint>();
+
+  for (const s of shorts) {
+    const ts = s.timestamp;
+    if (!ts) continue;
+    const seconds =
+      typeof ts === "string"
+        ? Math.floor(new Date(ts).getTime() / 1000)
+        : Number(ts.seconds ?? 0);
+    if (!seconds) continue;
+    const d = new Date(seconds * 1000);
+    const key = dayKey(d);
+    byDate.set(key, {
+      date: d,
+      price: null,
+      shortPct: s.shortPosition ?? 0,
+    });
+  }
+
+  for (const p of prices) {
+    const d = new Date(p.date);
+    if (Number.isNaN(d.getTime())) continue;
+    const key = dayKey(d);
+    const existing = byDate.get(key);
+    if (existing) {
+      existing.price = p.close;
+    } else {
+      byDate.set(key, {
+        date: d,
+        price: p.close,
+        shortPct: null,
+      });
+    }
+  }
+
+  const points = Array.from(byDate.values()).sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
+
+  // Pearson correlation on overlapping days where BOTH series exist.
+  const pairs = points.filter(
+    (p) => p.price !== null && p.shortPct !== null,
+  ) as Array<{ price: number; shortPct: number }>;
+  let correlation: number | null = null;
+  if (pairs.length >= 5) {
+    const n = pairs.length;
+    const meanX = pairs.reduce((s, p) => s + p.price, 0) / n;
+    const meanY = pairs.reduce((s, p) => s + p.shortPct, 0) / n;
+    let cov = 0;
+    let varX = 0;
+    let varY = 0;
+    for (const p of pairs) {
+      const dx = p.price - meanX;
+      const dy = p.shortPct - meanY;
+      cov += dx * dy;
+      varX += dx * dx;
+      varY += dy * dy;
+    }
+    if (varX > 0 && varY > 0) {
+      correlation = cov / Math.sqrt(varX * varY);
+    }
+  }
+
+  return { points, correlation };
+}
+
+export function ShortPriceOverlay({
+  stockCode,
+  initialPeriod = "1y",
+}: ShortPriceOverlayProps) {
+  const [period, setPeriod] = useState<Period>(
+    (PERIODS as readonly string[]).includes(initialPeriod)
+      ? (initialPeriod as Period)
+      : "1y",
+  );
+  const [shortPoints, setShortPoints] = useState<TimeSeriesPoint[]>([]);
+  const [pricePoints, setPricePoints] = useState<HistoricalDataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      fetchStockDataClient(stockCode, period),
+      getHistoricalData(stockCode, period),
+    ])
+      .then(([shortsResp, prices]) => {
+        if (cancelled) return;
+        setShortPoints(shortsResp?.points ?? []);
+        setPricePoints(prices ?? []);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setShortPoints([]);
+        setPricePoints([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stockCode, period]);
+
+  const merged = useMemo(
+    () => mergeSeries(shortPoints, pricePoints),
+    [shortPoints, pricePoints],
+  );
+
+  return (
+    <Card className="overflow-hidden border-l-4 border-l-purple-500 shadow-lg transition-all duration-300 hover:shadow-xl">
+      <CardHeader className="bg-gradient-to-r from-purple-50/50 to-transparent pb-4 dark:from-purple-950/20 dark:to-transparent">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-purple-100 p-2.5 shadow-sm dark:bg-purple-900/40">
+              <CandlestickChart className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+            </div>
+            <div className="flex-1">
+              <CardTitle className="text-xl text-purple-900 dark:text-purple-100">
+                Price vs Short Interest
+              </CardTitle>
+              <CardDescription className="mt-1.5 text-sm">
+                Daily closing price overlaid with ASIC short-position %.{" "}
+                {merged.correlation !== null && (
+                  <span className="font-medium text-foreground">
+                    Correlation:{" "}
+                    <span
+                      className={
+                        merged.correlation > 0.3
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : merged.correlation < -0.3
+                            ? "text-rose-600 dark:text-rose-400"
+                            : "text-muted-foreground"
+                      }
+                    >
+                      {merged.correlation > 0 ? "+" : ""}
+                      {merged.correlation.toFixed(2)}
+                    </span>
+                  </span>
+                )}
+              </CardDescription>
+            </div>
+          </div>
+
+          <ToggleGroup
+            type="single"
+            value={period}
+            onValueChange={(v) => {
+              if (v) setPeriod(v as Period);
+            }}
+            size="sm"
+          >
+            {PERIODS.map((p) => (
+              <ToggleGroupItem key={p} value={p} className="px-2.5 text-xs">
+                {p}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pt-4">
+        {loading ? (
+          <Skeleton className="h-[360px] w-full" />
+        ) : error ? (
+          <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+            <TrendingDown className="h-6 w-6 text-rose-500" />
+            <span>Overlay data unavailable right now.</span>
+          </div>
+        ) : (
+          <ShortPriceOverlayChart
+            data={merged.points}
+            stockCode={stockCode}
+            height={360}
+          />
+        )}
+
+        {!loading && merged.correlation !== null && (
+          <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+            {merged.correlation > 0.3
+              ? `Rising short interest coincided with rising price over the ${period} window (positive ${merged.correlation.toFixed(2)} correlation) — uncommon, often signals momentum traders crowding into the same shorts as the stock rallies.`
+              : merged.correlation < -0.3
+                ? `Rising short interest coincided with falling price over the ${period} window (negative ${merged.correlation.toFixed(2)} correlation) — the classic short-seller setup playing out.`
+                : `Short interest and price moved largely independently over the ${period} window (correlation ${merged.correlation.toFixed(2)}).`}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ShortPriceOverlay;

--- a/web/src/@/components/ui/short-price-overlay-chart.tsx
+++ b/web/src/@/components/ui/short-price-overlay-chart.tsx
@@ -1,0 +1,362 @@
+"use client";
+import { useMemo, useCallback } from "react";
+import ParentSize from "@visx/responsive/lib/components/ParentSize";
+import { scaleTime, scaleLinear } from "@visx/scale";
+import { Group } from "@visx/group";
+import { LinePath, Line } from "@visx/shape";
+import { AxisLeft, AxisRight, AxisBottom } from "@visx/axis";
+import { GridRows, GridColumns } from "@visx/grid";
+import { extent, bisector as makeBisector, max, min } from "@visx/vendor/d3-array";
+import { curveMonotoneX } from "@visx/curve";
+import {
+  TooltipWithBounds,
+  defaultStyles,
+  useTooltip,
+} from "@visx/tooltip";
+import { localPoint } from "@visx/event";
+import { timeFormat } from "@visx/vendor/d3-time-format";
+
+export interface OverlayPoint {
+  date: Date;
+  price: number | null;
+  shortPct: number | null;
+}
+
+interface ShortPriceOverlayChartProps {
+  width: number;
+  height: number;
+  data: OverlayPoint[];
+  stockCode: string;
+}
+
+const margin = { top: 24, right: 60, bottom: 36, left: 60 };
+
+const PRICE_COLOR = "hsl(217, 91%, 60%)"; // blue-500
+const SHORT_COLOR = "hsl(0, 84%, 60%)"; // red-500
+
+const tooltipStyles = {
+  ...defaultStyles,
+  background: "hsl(var(--card))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 8,
+  padding: "8px 12px",
+  fontSize: 12,
+  color: "hsl(var(--foreground))",
+  boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+};
+
+const formatDate = timeFormat("%b %d, %Y");
+const dateBisector = makeBisector<OverlayPoint, Date>((d) => d.date);
+const bisectDate = (arr: OverlayPoint[], target: Date): number =>
+  dateBisector.left(arr, target, 1);
+
+function ChartInner({ width, height, data, stockCode }: ShortPriceOverlayChartProps) {
+  const {
+    tooltipOpen,
+    tooltipLeft,
+    tooltipTop,
+    tooltipData,
+    showTooltip,
+    hideTooltip,
+  } = useTooltip<OverlayPoint>();
+
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  const validPriceData = useMemo(
+    () => data.filter((d) => d.price !== null && !Number.isNaN(d.price)),
+    [data],
+  );
+  const validShortData = useMemo(
+    () => data.filter((d) => d.shortPct !== null && !Number.isNaN(d.shortPct)),
+    [data],
+  );
+
+  const xScale = useMemo(() => {
+    const dom = extent(data, (d) => d.date) as [Date, Date];
+    return scaleTime({
+      range: [0, innerWidth],
+      domain: dom,
+    });
+  }, [data, innerWidth]);
+
+  const priceScale = useMemo(() => {
+    const lo = min(validPriceData, (d) => d.price ?? 0) ?? 0;
+    const hi = max(validPriceData, (d) => d.price ?? 0) ?? 1;
+    const pad = (hi - lo) * 0.05 || 1;
+    return scaleLinear({
+      range: [innerHeight, 0],
+      domain: [Math.max(0, lo - pad), hi + pad],
+      nice: true,
+    });
+  }, [validPriceData, innerHeight]);
+
+  const shortScale = useMemo(() => {
+    const hi = max(validShortData, (d) => d.shortPct ?? 0) ?? 1;
+    const pad = hi * 0.1 || 0.5;
+    return scaleLinear({
+      range: [innerHeight, 0],
+      domain: [0, hi + pad],
+      nice: true,
+    });
+  }, [validShortData, innerHeight]);
+
+  const handleMouseMove = useCallback(
+    (event: React.MouseEvent<SVGRectElement>) => {
+      const { x } = localPoint(event) ?? { x: 0 };
+      const adjustedX = x - margin.left;
+      const x0 = xScale.invert(adjustedX);
+      const index = bisectDate(data, x0);
+      const d0 = data[index - 1];
+      const d1 = data[index];
+      let point = d0;
+      if (d1 && d0) {
+        point =
+          x0.valueOf() - d0.date.valueOf() > d1.date.valueOf() - x0.valueOf()
+            ? d1
+            : d0;
+      }
+      if (!point) return;
+
+      const priceY = point.price !== null ? priceScale(point.price) : null;
+      const tooltipY = priceY ?? innerHeight / 2;
+
+      showTooltip({
+        tooltipData: point,
+        tooltipLeft: xScale(point.date) + margin.left,
+        tooltipTop: tooltipY + margin.top,
+      });
+    },
+    [data, xScale, priceScale, innerHeight, showTooltip],
+  );
+
+  if (width < 10 || height < 10 || data.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <svg width={width} height={height}>
+        <Group left={margin.left} top={margin.top}>
+          <GridRows
+            scale={priceScale}
+            width={innerWidth}
+            stroke="hsl(var(--border))"
+            strokeOpacity={0.4}
+            strokeDasharray="2,2"
+          />
+          <GridColumns
+            scale={xScale}
+            height={innerHeight}
+            stroke="hsl(var(--border))"
+            strokeOpacity={0.4}
+            strokeDasharray="2,2"
+          />
+
+          {/* Price line (blue, left axis) */}
+          <LinePath<OverlayPoint>
+            data={validPriceData}
+            x={(d) => xScale(d.date)}
+            y={(d) => priceScale(d.price ?? 0)}
+            stroke={PRICE_COLOR}
+            strokeWidth={2}
+            strokeOpacity={0.9}
+            curve={curveMonotoneX}
+          />
+
+          {/* Short % line (red, right axis) */}
+          <LinePath<OverlayPoint>
+            data={validShortData}
+            x={(d) => xScale(d.date)}
+            y={(d) => shortScale(d.shortPct ?? 0)}
+            stroke={SHORT_COLOR}
+            strokeWidth={2}
+            strokeOpacity={0.9}
+            curve={curveMonotoneX}
+            strokeDasharray="0"
+          />
+
+          <AxisLeft
+            scale={priceScale}
+            numTicks={5}
+            tickFormat={(v) => `$${Number(v).toFixed(2)}`}
+            stroke={PRICE_COLOR}
+            tickStroke={PRICE_COLOR}
+            tickLabelProps={{
+              fill: PRICE_COLOR,
+              fontSize: 10,
+              textAnchor: "end",
+              dx: -4,
+              dy: 4,
+            }}
+          />
+
+          <AxisRight
+            scale={shortScale}
+            left={innerWidth}
+            numTicks={5}
+            tickFormat={(v) => `${Number(v).toFixed(1)}%`}
+            stroke={SHORT_COLOR}
+            tickStroke={SHORT_COLOR}
+            tickLabelProps={{
+              fill: SHORT_COLOR,
+              fontSize: 10,
+              textAnchor: "start",
+              dx: 4,
+              dy: 4,
+            }}
+          />
+
+          <AxisBottom
+            top={innerHeight}
+            scale={xScale}
+            numTicks={width > 600 ? 8 : 4}
+            stroke="hsl(var(--border))"
+            tickStroke="hsl(var(--muted-foreground))"
+            tickLabelProps={{
+              fill: "hsl(var(--muted-foreground))",
+              fontSize: 10,
+              textAnchor: "middle",
+              dy: 4,
+            }}
+          />
+
+          {tooltipOpen && tooltipData && (
+            <Line
+              from={{ x: xScale(tooltipData.date), y: 0 }}
+              to={{ x: xScale(tooltipData.date), y: innerHeight }}
+              stroke="hsl(var(--foreground))"
+              strokeOpacity={0.3}
+              strokeWidth={1}
+              pointerEvents="none"
+              strokeDasharray="4,2"
+            />
+          )}
+
+          {tooltipOpen && tooltipData?.price !== null && tooltipData && (
+            <circle
+              cx={xScale(tooltipData.date)}
+              cy={priceScale(tooltipData.price)}
+              r={4}
+              fill={PRICE_COLOR}
+              stroke="white"
+              strokeWidth={2}
+              pointerEvents="none"
+            />
+          )}
+
+          {tooltipOpen && tooltipData?.shortPct !== null && tooltipData && (
+            <circle
+              cx={xScale(tooltipData.date)}
+              cy={shortScale(tooltipData.shortPct)}
+              r={4}
+              fill={SHORT_COLOR}
+              stroke="white"
+              strokeWidth={2}
+              pointerEvents="none"
+            />
+          )}
+
+          <rect
+            width={innerWidth}
+            height={innerHeight}
+            fill="transparent"
+            onMouseMove={handleMouseMove}
+            onMouseLeave={() => hideTooltip()}
+          />
+        </Group>
+      </svg>
+
+      {tooltipOpen && tooltipData && (
+        <TooltipWithBounds
+          top={tooltipTop}
+          left={tooltipLeft}
+          style={tooltipStyles}
+        >
+          <div className="font-mono text-[11px] text-muted-foreground">
+            {formatDate(tooltipData.date)}
+          </div>
+          <div className="mt-1 flex items-center gap-2">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ background: PRICE_COLOR }}
+            />
+            <span className="text-foreground">
+              {stockCode} price:{" "}
+              <strong>
+                {tooltipData.price !== null
+                  ? `$${tooltipData.price.toFixed(2)}`
+                  : "—"}
+              </strong>
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ background: SHORT_COLOR }}
+            />
+            <span className="text-foreground">
+              Short %:{" "}
+              <strong>
+                {tooltipData.shortPct !== null
+                  ? `${tooltipData.shortPct.toFixed(2)}%`
+                  : "—"}
+              </strong>
+            </span>
+          </div>
+        </TooltipWithBounds>
+      )}
+
+      {/* Legend */}
+      <div className="absolute right-3 top-1 flex items-center gap-3 text-[11px]">
+        <span className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ background: PRICE_COLOR }}
+          />
+          <span className="text-muted-foreground">Price (AUD)</span>
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ background: SHORT_COLOR }}
+          />
+          <span className="text-muted-foreground">Short %</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ShortPriceOverlayChart({
+  data,
+  stockCode,
+  height = 360,
+}: {
+  data: OverlayPoint[];
+  stockCode: string;
+  height?: number;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+        No overlay data available
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height }} className="w-full">
+      <ParentSize>
+        {({ width }) => (
+          <ChartInner
+            width={width}
+            height={height}
+            data={data}
+            stockCode={stockCode}
+          />
+        )}
+      </ParentSize>
+    </div>
+  );
+}
+
+export default ShortPriceOverlayChart;

--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -26,6 +26,11 @@ const StockTabs = dynamic(
   () => import("~/@/components/company/stock-tabs").then((m) => m.StockTabs),
   { ssr: false }
 );
+// Client-only: uses fetchStockDataClient (Connect-RPC) + market-data API.
+const ShortPriceOverlay = dynamic(
+  () => import("~/@/components/company/short-price-overlay").then((m) => m.ShortPriceOverlay),
+  { ssr: false }
+);
 import { Suspense } from "react";
 import {
   Breadcrumbs,
@@ -480,6 +485,9 @@ const Page = async ({ params }: PageProps) => {
                 stockCode={stockCode}
                 summary={communitySummary}
               />
+
+              {/* Price vs Short Interest overlay — dual-axis visualization */}
+              <ShortPriceOverlay stockCode={stockCode} />
 
               {/* Historical Price Data */}
               <Card className="border-l-4 border-l-blue-500 shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden">


### PR DESCRIPTION
SEO_ROADMAP.md item #13.

Adds a new "Price vs Short Interest" card on /shorts/[code] rendering both daily closing price and ASIC short-position % on a single SVG with dual y-axes (left=AUD, right=short %).

Card displays Pearson correlation as a single number + editorial commentary keyed off sign/magnitude:
- **Negative**: classic short-seller setup (shorts up, price down)
- **Positive**: momentum traders crowding into the same shorts
- **Near-zero**: moves independently

## Files
- `ui/short-price-overlay-chart.tsx` — pure visx dual-axis chart primitive
- `company/short-price-overlay.tsx` — client wrapper, merges by date, computes Pearson, period toggle
- `shorts/[code]/page.tsx` — adds the card, dynamic-imported (ssr:false)

## Differentiator

Apple Stocks doesn't show short data. Yahoo Finance AU doesn't overlay price + short %. Stockhead doesn't render either as a chart. Real visual moat for the entity hub URLs we're trying to rank.