### PR TITLE
feat(seo): ItemList + CollectionPage schema on /shorts, /reports, /industry

### DIFF
--- a/web/src/app/industry/page.tsx
+++ b/web/src/app/industry/page.tsx
@@ -62,8 +62,38 @@ const breadcrumbs = [
 export default async function IndustryIndexPage() {
   const industryData = await getIndustryData();
 
+  // CollectionPage + ItemList — exposes every industry/sector as a
+  // structured child so crawlers can ingest the sector taxonomy.
+  const itemList = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "ASX Short Positions by Industry",
+    description:
+      "Short selling activity across ASX industry sectors. Aggregated short interest, ranked stock lists, and sector trends from official ASIC data.",
+    url: "https://shorted.com.au/industry",
+    isPartOf: {
+      "@type": "WebSite",
+      name: "Shorted",
+      url: "https://shorted.com.au",
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: industryData.length,
+      itemListElement: industryData.map((industry, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `https://shorted.com.au/industry/${industry.slug}`,
+        name: `${industry.name} — ASX Short Positions`,
+      })),
+    },
+  };
+
   return (
     <DashboardLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
+      />
       <BreadcrumbListSchema items={breadcrumbs} />
 
       <div className="space-y-8">

--- a/web/src/app/reports/page.tsx
+++ b/web/src/app/reports/page.tsx
@@ -79,8 +79,52 @@ export default async function ReportsIndexPage() {
 
   const breadcrumbItems = [{ label: "Reports", href: "/reports" }];
 
+  // ItemList + CollectionPage schema — gives Google the full inventory
+  // of report URLs so the report archive is indexable as a series.
+  const itemList = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "ASX Short Selling Reports",
+    description:
+      "Archive of weekly, monthly, and yearly ASX short selling reports with LLM-narrated analysis.",
+    url: "https://shorted.com.au/reports",
+    isPartOf: {
+      "@type": "WebSite",
+      name: "Shorted",
+      url: "https://shorted.com.au",
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: weekSlugs.length + monthSlugs.length + yearSlugs.length,
+      itemListElement: [
+        ...weekSlugs.slice(0, 20).map((slug, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          url: `https://shorted.com.au/reports/weekly/${slug}`,
+          name: `Weekly Short Selling Report ${slug}`,
+        })),
+        ...monthSlugs.slice(0, 12).map((slug, i) => ({
+          "@type": "ListItem",
+          position: 100 + i,
+          url: `https://shorted.com.au/reports/monthly/${slug}`,
+          name: `Monthly Short Selling Report ${slug}`,
+        })),
+        ...yearSlugs.slice(0, 10).map((slug, i) => ({
+          "@type": "ListItem",
+          position: 200 + i,
+          url: `https://shorted.com.au/reports/yearly/${slug}`,
+          name: `Annual Short Selling Report ${slug}`,
+        })),
+      ],
+    },
+  };
+
   return (
     <DashboardLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
+      />
       <BreadcrumbListSchema items={breadcrumbs} />
       <LLMMeta
         title="ASX Short Selling Reports - Weekly & Monthly Analysis"

--- a/web/src/app/shorts/page.tsx
+++ b/web/src/app/shorts/page.tsx
@@ -58,10 +58,41 @@ export default async function TopShortsPage() {
   const timeSeries = data?.timeSeries ?? [];
   const moversData = calculateMovers(timeSeries, DEFAULT_PERIOD);
 
+  // ItemList schema — declares this URL as the canonical index for the
+  // top shorted ASX stocks so crawlers + AI Overviews can ingest the
+  // ranking as structured data alongside the rendered table.
+  const itemList = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "ASX Short Positions — All Shorted Stocks",
+    description:
+      "Daily-updated rankings of ASX-listed stocks by ASIC-reported short interest %.",
+    numberOfItems: timeSeries.length,
+    url: `${siteConfig.url}/shorts`,
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    isPartOf: {
+      "@type": "WebSite",
+      url: siteConfig.url,
+      name: siteConfig.name,
+    },
+    itemListElement: timeSeries.slice(0, 20).map((ts, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: ts.productCode ? `${siteConfig.url}/shorts/${ts.productCode}` : undefined,
+      name: ts.name || ts.productCode,
+    })),
+  };
+
   return (
-    <TopShortsClient
-      initialMoversData={moversData}
-      initialPeriod={DEFAULT_PERIOD}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
+      />
+      <TopShortsClient
+        initialMoversData={moversData}
+        initialPeriod={DEFAULT_PERIOD}
+      />
+    </>
   );
 }


### PR DESCRIPTION
Three index pages were missing structured data. This PR adds:
- `/shorts` → `ItemList` of top-20 stocks
- `/reports` → `CollectionPage` + `ItemList` (weekly + monthly + yearly archives)
- `/industry` → `CollectionPage` + `ItemList` of every ASX sector

Helps AI Overviews answer catalog-style questions ("most shorted ASX banking stocks?" → /industry/financials).