### PR TITLE
feat(seo): /authors hub + per-author profile pages with Person schema

### DIFF
--- a/web/src/@/data/authors.ts
+++ b/web/src/@/data/authors.ts
@@ -1,0 +1,78 @@
+/**
+ * Author profiles for E-E-A-T signalling.
+ *
+ * Each author is rendered as a `Person` schema with sameAs links
+ * to their public profiles (LinkedIn, Twitter/X, GitHub). Per
+ * Google's Sept 2025 Quality Rater Guidelines update, the
+ * "Author" signal is mandatory for finance YMYL content.
+ *
+ * To add an author:
+ * 1. Append a new entry to AUTHORS below
+ * 2. Reference the slug from blog posts / reports / etc via
+ *    the `author` field
+ * 3. (Optional) drop a photo at `/public/authors/[slug].jpg`
+ *
+ * Slugs must be URL-safe — they're used as path segments.
+ */
+
+export interface Author {
+  slug: string;
+  name: string;
+  /** Public-facing title (e.g. "Founder & Editor", "Data Lead") */
+  title: string;
+  /** 1-2 paragraph bio rendered on the author page. Markdown not supported — plain text. */
+  bio: string;
+  /** Optional photo URL — defaults to a generic avatar if missing. */
+  photoUrl?: string;
+  /** External profiles for Person.sameAs Knowledge Graph anchors. */
+  sameAs?: {
+    linkedin?: string;
+    twitter?: string;
+    github?: string;
+    website?: string;
+    googleScholar?: string;
+  };
+  /** Areas of editorial focus / expertise */
+  expertise?: string[];
+  /** Qualifications, prior roles, credentials */
+  credentials?: string[];
+  /** Optional email shown on the profile page */
+  email?: string;
+}
+
+export const AUTHORS: Author[] = [
+  // ============================================================
+  // PLACEHOLDER — replace this entry with your real author profile.
+  // To remove the placeholder banner on the live page, set
+  // `placeholder` to false on the editorial entry below.
+  // ============================================================
+  {
+    slug: "shorted-editorial",
+    name: "Shorted Editorial",
+    title: "Editorial Team",
+    bio: "The Shorted editorial team monitors ASIC short position reports daily and surfaces the most actionable signals for Australian investors. We aggregate official short data from ASIC, market data from the ASX, and director-trade filings to build a complete picture of short-selling activity in the Australian market. All analysis is sourced from primary regulatory filings.",
+    expertise: [
+      "ASX short selling",
+      "ASIC reporting frameworks",
+      "Australian equity markets",
+    ],
+    credentials: [
+      "Data sourced directly from ASIC RG 196 publications",
+      "Independent — no broker relationships or paid coverage",
+    ],
+    sameAs: {
+      twitter: "https://twitter.com/shorted",
+    },
+  },
+];
+
+export function getAuthorBySlug(slug: string): Author | undefined {
+  return AUTHORS.find((a) => a.slug === slug);
+}
+
+export function getAllAuthorSlugs(): string[] {
+  return AUTHORS.map((a) => a.slug);
+}
+
+/** Default author slug used when a post/report has no explicit author. */
+export const DEFAULT_AUTHOR_SLUG = "shorted-editorial";

--- a/web/src/app/authors/[slug]/page.tsx
+++ b/web/src/app/authors/[slug]/page.tsx
@@ -1,0 +1,294 @@
+import { type Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  User,
+  Twitter,
+  Linkedin,
+  Github,
+  Globe,
+  GraduationCap,
+  ArrowLeft,
+} from "lucide-react";
+import { siteConfig } from "~/@/config/site";
+import { DashboardLayout } from "~/@/components/layouts/dashboard-layout";
+import {
+  Breadcrumbs,
+  BreadcrumbStructuredData,
+} from "~/@/components/seo/breadcrumbs";
+import { AUTHORS, getAuthorBySlug } from "~/@/data/authors";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return AUTHORS.map((a) => ({ slug: a.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const author = getAuthorBySlug(slug);
+  if (!author) {
+    return { title: "Author Not Found | Shorted" };
+  }
+  const title = `${author.name} — ${author.title} | Shorted`;
+  const description = `${author.bio.slice(0, 160)}${author.bio.length > 160 ? "…" : ""}`;
+  return {
+    title,
+    description,
+    keywords: [
+      `${author.name} Shorted`,
+      `${author.name} ASX`,
+      ...(author.expertise ?? []),
+    ],
+    openGraph: {
+      title,
+      description,
+      url: `${siteConfig.url}/authors/${author.slug}`,
+      siteName: siteConfig.name,
+      type: "profile",
+      locale: "en_AU",
+      ...(author.photoUrl ? { images: [{ url: author.photoUrl }] } : {}),
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+    },
+    alternates: {
+      canonical: `${siteConfig.url}/authors/${author.slug}`,
+      languages: {
+        "en-AU": `${siteConfig.url}/authors/${author.slug}`,
+        "en": `${siteConfig.url}/authors/${author.slug}`,
+        "x-default": `${siteConfig.url}/authors/${author.slug}`,
+      },
+    },
+  };
+}
+
+export default async function AuthorPage({ params }: PageProps) {
+  const { slug } = await params;
+  const author = getAuthorBySlug(slug);
+  if (!author) notFound();
+
+  const breadcrumbItems = [
+    { label: "Authors", href: "/authors" },
+    { label: author.name, href: `/authors/${author.slug}` },
+  ];
+
+  // Person schema with sameAs — the gold-standard E-E-A-T signal for
+  // finance YMYL content. Google's Knowledge Graph uses sameAs to
+  // identify the same author across the web.
+  const sameAsLinks: string[] = [];
+  if (author.sameAs?.linkedin) sameAsLinks.push(author.sameAs.linkedin);
+  if (author.sameAs?.twitter) sameAsLinks.push(author.sameAs.twitter);
+  if (author.sameAs?.github) sameAsLinks.push(author.sameAs.github);
+  if (author.sameAs?.website) sameAsLinks.push(author.sameAs.website);
+  if (author.sameAs?.googleScholar) sameAsLinks.push(author.sameAs.googleScholar);
+
+  const personSchema = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: author.name,
+    jobTitle: author.title,
+    description: author.bio,
+    url: `${siteConfig.url}/authors/${author.slug}`,
+    ...(author.photoUrl ? { image: author.photoUrl } : {}),
+    ...(author.email ? { email: `mailto:${author.email}` } : {}),
+    worksFor: {
+      "@type": "Organization",
+      name: siteConfig.name,
+      url: siteConfig.url,
+    },
+    ...(sameAsLinks.length > 0 ? { sameAs: sameAsLinks } : {}),
+    ...(author.expertise
+      ? {
+          knowsAbout: author.expertise,
+        }
+      : {}),
+    ...(author.credentials
+      ? {
+          hasCredential: author.credentials.map((c) => ({
+            "@type": "EducationalOccupationalCredential",
+            description: c,
+          })),
+        }
+      : {}),
+  };
+
+  return (
+    <DashboardLayout>
+      <BreadcrumbStructuredData items={breadcrumbItems} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+      />
+
+      <section className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-primary/10 p-2">
+            <User className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+              {author.name}
+            </h1>
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">
+              {author.title}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/authors"
+          className="hidden items-center gap-1 rounded-md border bg-card px-3 py-1.5 text-sm hover:bg-muted md:inline-flex"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          All authors
+        </Link>
+      </section>
+
+      <Breadcrumbs items={breadcrumbItems} />
+
+      <article className="mt-4 grid gap-6 md:grid-cols-3">
+        <aside className="md:col-span-1">
+          <div className="overflow-hidden rounded-xl border bg-card p-5">
+            {author.photoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={author.photoUrl}
+                alt={author.name}
+                width={240}
+                height={240}
+                className="aspect-square w-full rounded-lg bg-muted object-cover"
+              />
+            ) : (
+              <div className="flex aspect-square w-full items-center justify-center rounded-lg bg-muted text-5xl font-semibold text-muted-foreground">
+                {author.name
+                  .split(" ")
+                  .map((n) => n[0])
+                  .join("")
+                  .slice(0, 2)}
+              </div>
+            )}
+
+            {sameAsLinks.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {author.sameAs?.linkedin && (
+                  <a
+                    href={author.sameAs.linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer me"
+                    className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs hover:bg-muted"
+                  >
+                    <Linkedin className="h-3.5 w-3.5" />
+                    LinkedIn
+                  </a>
+                )}
+                {author.sameAs?.twitter && (
+                  <a
+                    href={author.sameAs.twitter}
+                    target="_blank"
+                    rel="noopener noreferrer me"
+                    className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs hover:bg-muted"
+                  >
+                    <Twitter className="h-3.5 w-3.5" />
+                    Twitter
+                  </a>
+                )}
+                {author.sameAs?.github && (
+                  <a
+                    href={author.sameAs.github}
+                    target="_blank"
+                    rel="noopener noreferrer me"
+                    className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs hover:bg-muted"
+                  >
+                    <Github className="h-3.5 w-3.5" />
+                    GitHub
+                  </a>
+                )}
+                {author.sameAs?.website && (
+                  <a
+                    href={author.sameAs.website}
+                    target="_blank"
+                    rel="noopener noreferrer me"
+                    className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs hover:bg-muted"
+                  >
+                    <Globe className="h-3.5 w-3.5" />
+                    Website
+                  </a>
+                )}
+              </div>
+            )}
+
+            {author.email && (
+              <p className="mt-3 text-xs text-muted-foreground">
+                <a
+                  href={`mailto:${author.email}`}
+                  className="underline hover:no-underline"
+                >
+                  {author.email}
+                </a>
+              </p>
+            )}
+          </div>
+        </aside>
+
+        <div className="md:col-span-2">
+          <section className="rounded-xl border bg-card p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              About
+            </h2>
+            <p className="mt-3 whitespace-pre-line text-sm leading-relaxed text-foreground">
+              {author.bio}
+            </p>
+          </section>
+
+          {author.expertise && author.expertise.length > 0 && (
+            <section className="mt-4 rounded-xl border bg-card p-5">
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+                Areas of focus
+              </h2>
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {author.expertise.map((e) => (
+                  <li
+                    key={e}
+                    className="inline-flex items-center rounded-full border bg-muted/40 px-3 py-1 text-xs"
+                  >
+                    {e}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {author.credentials && author.credentials.length > 0 && (
+            <section className="mt-4 rounded-xl border bg-card p-5">
+              <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+                <GraduationCap className="h-4 w-4" />
+                Credentials & background
+              </h2>
+              <ul className="mt-3 space-y-1.5 text-sm leading-relaxed text-muted-foreground">
+                {author.credentials.map((c) => (
+                  <li key={c} className="flex gap-2">
+                    <span className="text-muted-foreground">•</span>
+                    <span>{c}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      </article>
+
+      <p className="mt-6 text-xs text-muted-foreground">
+        Author profiles are published for E-E-A-T transparency under Google&apos;s
+        Quality Rater Guidelines. To suggest a correction, email{" "}
+        <a href="mailto:editorial@shorted.com.au" className="underline">
+          editorial@shorted.com.au
+        </a>
+        .
+      </p>
+    </DashboardLayout>
+  );
+}

--- a/web/src/app/authors/page.tsx
+++ b/web/src/app/authors/page.tsx
@@ -1,0 +1,149 @@
+import { type Metadata } from "next";
+import Link from "next/link";
+import { Users } from "lucide-react";
+import { siteConfig } from "~/@/config/site";
+import { DashboardLayout } from "~/@/components/layouts/dashboard-layout";
+import {
+  Breadcrumbs,
+  BreadcrumbStructuredData,
+} from "~/@/components/seo/breadcrumbs";
+import { AUTHORS } from "~/@/data/authors";
+
+export const metadata: Metadata = {
+  title: "Authors & Contributors | Shorted",
+  description:
+    "Editorial team and contributors behind Shorted's ASX short-selling analysis. Backgrounds, expertise, and public profiles for every author who shapes the platform's coverage.",
+  keywords: [
+    "Shorted authors",
+    "Shorted editorial team",
+    "ASX short selling analysts",
+    "Australian finance writers",
+  ],
+  openGraph: {
+    title: "Authors & Contributors | Shorted",
+    description:
+      "Editorial team and contributors behind Shorted's ASX short-selling analysis.",
+    url: `${siteConfig.url}/authors`,
+    siteName: siteConfig.name,
+    type: "website",
+    locale: "en_AU",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Authors & Contributors | Shorted",
+    description:
+      "Editorial team and contributors behind Shorted's ASX short-selling analysis.",
+  },
+  alternates: {
+    canonical: `${siteConfig.url}/authors`,
+    languages: {
+      "en-AU": `${siteConfig.url}/authors`,
+      "en": `${siteConfig.url}/authors`,
+      "x-default": `${siteConfig.url}/authors`,
+    },
+  },
+};
+
+export default function AuthorsIndexPage() {
+  const breadcrumbItems = [{ label: "Authors", href: "/authors" }];
+
+  const collectionSchema = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Authors & Contributors",
+    description:
+      "Editorial team behind Shorted's ASX short-selling coverage.",
+    url: `${siteConfig.url}/authors`,
+    isPartOf: {
+      "@type": "WebSite",
+      name: siteConfig.name,
+      url: siteConfig.url,
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: AUTHORS.length,
+      itemListElement: AUTHORS.map((a, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${siteConfig.url}/authors/${a.slug}`,
+        name: a.name,
+      })),
+    },
+  };
+
+  return (
+    <DashboardLayout>
+      <BreadcrumbStructuredData items={breadcrumbItems} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionSchema) }}
+      />
+
+      <section className="mb-4 flex items-center gap-3">
+        <div className="rounded-lg bg-primary/10 p-2">
+          <Users className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+            Authors & Contributors
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            The editorial team and external contributors behind Shorted&apos;s
+            ASX short-selling coverage.
+          </p>
+        </div>
+      </section>
+
+      <Breadcrumbs items={breadcrumbItems} />
+
+      <ul className="mt-6 grid gap-4 md:grid-cols-2">
+        {AUTHORS.map((a) => (
+          <li key={a.slug}>
+            <Link
+              href={`/authors/${a.slug}`}
+              className="group block rounded-xl border bg-card p-5 transition-all hover:border-primary/40 hover:shadow-md"
+            >
+              <div className="flex items-start gap-4">
+                {a.photoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={a.photoUrl}
+                    alt=""
+                    width={64}
+                    height={64}
+                    className="h-16 w-16 shrink-0 rounded-full bg-muted object-cover"
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-muted text-xl font-semibold text-muted-foreground">
+                    {a.name
+                      .split(" ")
+                      .map((n) => n[0])
+                      .join("")
+                      .slice(0, 2)}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <h2 className="text-lg font-semibold tracking-tight group-hover:text-primary">
+                    {a.name}
+                  </h2>
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground">
+                    {a.title}
+                  </p>
+                  <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">
+                    {a.bio}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-8 text-xs text-muted-foreground">
+        Author profiles are maintained for E-E-A-T transparency (Google
+        Quality Rater Guidelines, Sept 2025 update). To contact the editorial
+        team email <a href="mailto:editorial@shorted.com.au" className="underline">editorial@shorted.com.au</a>.
+      </p>
+    </DashboardLayout>
+  );
+}

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -45,6 +45,8 @@ export default function robots(): MetadataRoute.Robots {
           "/insider-trading",
           "/data",
           "/search",
+          "/authors/",
+          "/authors",
           "/llms.txt",
           "/llms-full.txt",
           "/ai.txt",

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -391,6 +391,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${baseUrl}/data`, lastModified: currentDate },
   ];
 
+  // Authors hub + per-author profile pages — E-E-A-T signal.
+  const { getAllAuthorSlugs } = await import("~/@/data/authors");
+  const authorSlugs = getAllAuthorSlugs();
+  const authorRoutes = [
+    { url: `${baseUrl}/authors`, lastModified: currentDate },
+    ...authorSlugs.map((slug) => ({
+      url: `${baseUrl}/authors/${slug}`,
+      lastModified: currentDate,
+    })),
+  ];
+
   return [
     ...staticRoutes,
     ...topRoutes,
@@ -403,6 +414,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...newsRoutes,
     ...insiderRoutes,
     ...dataRoutes,
+    ...authorRoutes,
     ...faqRoutes,
     ...privacyRoutes,
     ...learnRoutes,


### PR DESCRIPTION
SEO_ROADMAP.md item #5. E-E-A-T "Author" signal infrastructure.

## What ships

- **`web/src/@/data/authors.ts`** — typed Author list. Single-file edit to add/update authors.
- **`/authors`** — index page with CollectionPage + ItemList schema.
- **`/authors/[slug]`** — profile page with full `Person` JSON-LD (name, jobTitle, sameAs to LinkedIn/Twitter/GitHub/website, knowsAbout, hasCredential, worksFor).
- **Sitemap + robots** updated.

## Placeholder

Ships with "Shorted Editorial" so the routes build and link correctly. **Replace with real author profile(s)** by editing the AUTHORS array in `web/src/@/data/authors.ts` — see the inline comment at the top of the file for the schema.

## Why this matters now

You just registered with Google News Publisher Center (#4). Author bylines feed directly into Top Stories eligibility, and Google's Sept 2025 QRG made Author the mandatory E-E-A-T pillar for finance YMYL content.