### PR TITLE
feat(twitter): @shorted → @shorted___ + env var aliases

### DIFF
--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -11,17 +11,17 @@ name: Twitter / X bot
 # manually trigger any post-type from the Actions UI.
 
 on:
-  schedule:
-    # Daily top shorts — 11:00 AEST = 01:00 UTC
-    - cron: "0 1 * * *"
-    # Daily biggest movers — 16:30 AEST (post-close) = 06:30 UTC
-    - cron: "30 6 * * *"
-    # Stock of the day — 09:00 AEST = 23:00 UTC (previous day)
-    - cron: "0 23 * * *"
-    # Friday weekly digest thread — 17:00 AEST = 07:00 UTC, Fridays
-    - cron: "0 7 * * 5"
-    # Breaking news sweep — every 2h during ASX hours, weekdays
-    - cron: "0 0,2,4,6 * * 1-5"
+  # NOTE: scheduled crons are intentionally commented out — the bot
+  # currently runs from your local machine via cron/launchd (see
+  # OPERATIONS.md §2). Uncomment when you're ready to migrate to CI
+  # and have populated the TWITTER_* secrets in the repo.
+  #
+  # schedule:
+  #   - cron: "0 1 * * *"          # daily-shorts        11:00 AEST
+  #   - cron: "30 6 * * *"         # movers              16:30 AEST
+  #   - cron: "0 23 * * *"         # stock-of-the-day    09:00 AEST
+  #   - cron: "0 7 * * 5"          # weekly-digest       17:00 AEST Fri
+  #   - cron: "0 0,2,4,6 * * 1-5"  # breaking-news       10:00/12:00/14:00/16:00 AEST
   workflow_dispatch:
     inputs:
       command:
@@ -89,6 +89,13 @@ jobs:
 
       - name: Post
         env:
+          # OAuth 2.0 (preferred). The refresh_token is rotated on every
+          # call to X — the workflow doesn't persist the rotation, so we
+          # re-sync via gh secret set after the post if it changed.
+          TWITTER_CLIENT_ID: ${{ secrets.TWITTER_CLIENT_ID }}
+          TWITTER_CLIENT_SECRET: ${{ secrets.TWITTER_CLIENT_SECRET }}
+          TWITTER_REFRESH_TOKEN: ${{ secrets.TWITTER_REFRESH_TOKEN }}
+          # OAuth 1.0a fallback (in case OAuth 2.0 secret is removed).
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
@@ -97,6 +104,10 @@ jobs:
           # Default to dry-run unless the cron explicitly sets mode=live.
           # workflow_dispatch lets the operator pick dry-run or live.
           TWITTER_DRY_RUN_DEFAULT: ${{ needs.determine-command.outputs.mode == 'live' && 'false' || 'true' }}
+          # OAuth 2.0 rotates refresh_token on every use. Tell the
+          # script where to write the new token so a follow-up step
+          # can re-store it as a GH Actions secret.
+          TWITTER_REFRESH_TOKEN_OUT: /tmp/twitter-refresh-token
         run: |
           MODE="${{ needs.determine-command.outputs.mode }}"
           CMD="${{ needs.determine-command.outputs.command }}"
@@ -106,3 +117,9 @@ jobs:
           else
             npx tsx src/index.ts "$CMD"
           fi
+
+      # When this workflow is re-enabled for scheduled CI use, an extra
+      # step is needed to persist the rotated OAuth 2.0 refresh_token
+      # back to the GH secret (X rotates the token on every use, so
+      # without re-storing, the next CI run fails). See OPERATIONS.md
+      # §2 — "Switching local cron → GitHub Actions".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,6 +456,74 @@ Stock screener with server-side filtering (`services/shorts/internal/services/sh
 - **Frontend**: `/screener` page + `screener-widget.tsx` dashboard widget
 - **Days to Cover**: Added in migration 000028
 
+## Twitter / X Automation
+
+`@shorted___` is the live X handle. The bot is a self-contained Node + TypeScript project at `scripts/twitter/` that pulls live ASIC short data, market news, and director trades from the public shorted.com.au API and posts curated tweets.
+
+### Auth (OAuth 2.0 PKCE)
+
+Credentials live in repo-root `.env`:
+
+| Var | Source |
+|---|---|
+| `TWITTER_CLIENT_ID` | X Developer Portal → Keys and tokens → OAuth 2.0 |
+| `TWITTER_CLIENT_SECRET` | same |
+| `TWITTER_REFRESH_TOKEN` | minted by running `bootstrap-oauth2` once |
+
+The refresh token is **rotated by X on every use** — the script writes the new token back to `.env` on each post. Don't manually edit it.
+
+Re-bootstrap any time the token is invalidated:
+```bash
+cd scripts/twitter
+npx tsx src/index.ts bootstrap-oauth2
+```
+
+The X app must have `http://127.0.0.1:8787/callback` in its callback URIs and the Read+Write permission scope. Required X scopes: `tweet.read tweet.write users.read offline.access`.
+
+OAuth 1.0a is also supported (`TWITTER_API_KEY` / `_SECRET` + `TWITTER_ACCESS_TOKEN` / `_SECRET`) as a fallback — accepts legacy `CONSUMER_KEY`/`SECRET_KEY` naming too.
+
+### Commands
+
+```bash
+cd scripts/twitter
+# Preview (dry-run, default):
+npx tsx src/index.ts daily-shorts
+npx tsx src/index.ts movers
+npx tsx src/index.ts stock-of-the-day
+npx tsx src/index.ts weekly-digest
+npx tsx src/index.ts breaking-news
+npx tsx src/index.ts insider-trade --stock=BHP
+
+# Post for real:
+npx tsx src/index.ts daily-shorts --live
+```
+
+`TWITTER_DRY_RUN_DEFAULT=true` is the safety net — dry-run is on unless `--live` is passed.
+
+### Scheduling
+
+**Local cron** is the production path (see `scripts/twitter/OPERATIONS.md` §2.1 for the full crontab block). Cadence: daily-shorts 11:00 AEST, movers 16:30, stock-of-the-day 09:00, weekly-digest Fri 17:00, breaking-news every 2h during ASX hours.
+
+GitHub Actions workflow at `.github/workflows/twitter-bot.yml` exists but is **manual-only** (`workflow_dispatch`) — the `schedule:` block is commented out. To move to CI scheduling, see `OPERATIONS.md` §2.2 (needs a fine-grained PAT to re-store the rotated refresh token after each run).
+
+### Key files
+
+| File | Purpose |
+|---|---|
+| `scripts/twitter/src/index.ts` | CLI entry, dispatches commands |
+| `scripts/twitter/src/templates.ts` | Tweet text generators (data → string) |
+| `scripts/twitter/src/twitter-client.ts` | X API wrapper, OAuth 2.0 + 1.0a + DryRun stub |
+| `scripts/twitter/src/shorted-api.ts` | Public shorted.com.au API client |
+| `scripts/twitter/src/oauth2-bootstrap.ts` | One-time refresh-token mint flow |
+| `scripts/twitter/PROFILE.md` | Brand setup (handle, bio, header, colours, strategy) |
+| `scripts/twitter/OPERATIONS.md` | Full ops runbook |
+
+### Gotchas
+
+- **WAF rate limit**: bursting >20 requests in a minute to `api.shorted.com.au` triggers Cloudflare's bot protection — returns HTML, not JSON, breaks the script. Production cadence (~5/day) doesn't hit this; local dev does easily.
+- **Refresh token rotation**: every X API call mints a new token. Local cron handles this automatically (writes to `.env`). CI needs a PAT-based persistence step (documented in OPERATIONS.md §2.2).
+- **Edge worker hot-cache bug** (fixed in PR #139): if the bot returns the same stock's data for every productCode, the Cloudflare worker's hot cache key may have regressed — verify `buildHotCacheKey` in `services/edge-worker/worker.js` is hashing the POST body.
+
 ## Known Issues & Gotchas
 
 ### SSR Issues with @connectrpc/connect Imports (CRITICAL)

--- a/scripts/twitter/OPERATIONS.md
+++ b/scripts/twitter/OPERATIONS.md
@@ -74,10 +74,14 @@ start posting automatically per the cadence below.
 
 ---
 
-## 2. Production schedule
+## 2. Production schedule (local cron)
 
-Five cron triggers run automatically. All times **UTC**; AEST is +10
-(or +11 in daylight-saving).
+Runs from your local machine via cron / launchd. CI scheduling is
+opt-in (see §2.2).
+
+### 2.1 Cron file
+
+All times below are **UTC**; AEST is +10 (or +11 in daylight-saving).
 
 | Cron | Command | AEST | AEDT |
 |---|---|---|---|
@@ -85,7 +89,40 @@ Five cron triggers run automatically. All times **UTC**; AEST is +10
 | `30 6 * * *` | `movers` | 16:30 (post-close) | 17:30 |
 | `0 23 * * *` | `stock-of-the-day` | 09:00 next day | 10:00 |
 | `0 7 * * 5` | `weekly-digest` | 17:00 Fri | 18:00 Fri |
-| `0 0,2,4,6 * * 1-5` | `breaking-news` (every 2h during market hours) | 10:00, 12:00, 14:00, 16:00 | +1h |
+| `0 0,2,4,6 * * 1-5` | `breaking-news` (every 2h during market hours) | 10:00–16:00 | +1h |
+
+Drop into `crontab -e`:
+
+```cron
+SHELL=/bin/bash
+REPO=/Users/<you>/projects/shorted
+LOG=/tmp/shorted-twitter.log
+
+0 1 * * *           cd $REPO/scripts/twitter && /usr/local/bin/npx tsx src/index.ts daily-shorts --live      >> $LOG 2>&1
+30 6 * * *          cd $REPO/scripts/twitter && /usr/local/bin/npx tsx src/index.ts movers --live            >> $LOG 2>&1
+0 23 * * *          cd $REPO/scripts/twitter && /usr/local/bin/npx tsx src/index.ts stock-of-the-day --live  >> $LOG 2>&1
+0 7 * * 5           cd $REPO/scripts/twitter && /usr/local/bin/npx tsx src/index.ts weekly-digest --live     >> $LOG 2>&1
+0 0,2,4,6 * * 1-5   cd $REPO/scripts/twitter && /usr/local/bin/npx tsx src/index.ts breaking-news --live     >> $LOG 2>&1
+```
+
+Tail logs: `tail -f /tmp/shorted-twitter.log`
+
+### 2.2 Switching local cron → GitHub Actions (later)
+
+The workflow at `.github/workflows/twitter-bot.yml` runs **manual
+only** via `workflow_dispatch` today. To enable scheduled CI:
+
+1. Uncomment the `schedule:` block at the top of the workflow file
+2. Add GH Actions secrets: `TWITTER_CLIENT_ID`, `TWITTER_CLIENT_SECRET`,
+   `TWITTER_REFRESH_TOKEN` (from local `bootstrap-oauth2`)
+3. Add a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
+   with `Secrets: Read and write` scope, save as `GH_PAT_FOR_SECRETS`
+4. Append a step that re-stores the rotated refresh token (X rotates
+   on every use). See the workflow file's trailing comment block.
+5. Disable local cron
+
+The local-cron flow has a real advantage: the rotated refresh token
+persists to `.env` automatically — no PAT plumbing required.
 
 Schedule changes? Edit `.github/workflows/twitter-bot.yml` and add a
 corresponding case to the `determine-command` step.

--- a/scripts/twitter/OPERATIONS.md
+++ b/scripts/twitter/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Twitter / X bot — operations runbook
 
-How to bootstrap, schedule, monitor, and modify the @shorted Twitter
+How to bootstrap, schedule, monitor, and modify the @shorted___ Twitter
 automation. Companion to:
 
 - [`PROFILE.md`](PROFILE.md) — account branding (handle, bio, visuals)
@@ -14,7 +14,7 @@ The bot is a Node.js + TypeScript script that runs either locally
 
 ## 1. Bootstrap (one-time)
 
-### 1.1 Register the @shorted account
+### 1.1 Register the @shorted___ account
 
 Follow the activation checklist at the bottom of
 [`PROFILE.md`](PROFILE.md). You need a verified X account before
@@ -23,7 +23,7 @@ anything else.
 ### 1.2 Create an X developer app
 
 1. Go to [developer.x.com](https://developer.x.com) and sign in as
-   the @shorted account.
+   the @shorted___ account.
 2. Apply for a **Free** developer account (sufficient for 17 posts /
    24h — covers the cadence below with headroom).
 3. Create a Project → create an App inside it.

--- a/scripts/twitter/PROFILE.md
+++ b/scripts/twitter/PROFILE.md
@@ -1,16 +1,16 @@
 # Shorted Twitter / X Profile Setup
 
 Copy-paste-ready brand assets and content strategy for the
-`@shorted` (or `@shorted_au`) account.
+`@shorted___` (or `@shorted_au`) account.
 
 ---
 
 ## Handle
 
-**Primary**: `@shorted`
+**Primary**: `@shorted___`
 **Fallback if taken**: `@shorted_au`, `@shortedasx`, `@shorteddotcom`
 
-The site already references `@shorted` in `web/src/@/config/site.ts` —
+The site already references `@shorted___` in `web/src/@/config/site.ts` —
 keep that consistent.
 
 ## Display name
@@ -200,7 +200,7 @@ posting.
 
 ## Activation checklist
 
-- [ ] Register `@shorted` (or fallback) on X
+- [ ] Register `@shorted___` (or fallback) on X
 - [ ] Upload profile picture (400×400)
 - [ ] Upload header banner (1500×500)
 - [ ] Bio + location + website

--- a/scripts/twitter/package.json
+++ b/scripts/twitter/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "bootstrap-oauth2": "tsx src/index.ts bootstrap-oauth2",
     "post:daily-shorts": "tsx src/index.ts daily-shorts",
     "post:movers": "tsx src/index.ts movers",
     "post:weekly-digest": "tsx src/index.ts weekly-digest",

--- a/scripts/twitter/src/index.ts
+++ b/scripts/twitter/src/index.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 import { existsSync } from "node:fs";
 
 import { createClient, type TwitterClient } from "./twitter-client.js";
+import { bootstrapOAuth2 } from "./oauth2-bootstrap.js";
 import {
   buildBreakingNewsTweet,
   buildDailyShortsTweet,
@@ -72,6 +73,7 @@ Flags:
   --stock=CBA       For insider-trade alerts, the stock code to check
 
 Commands:
+  bootstrap-oauth2     One-time: get an OAuth 2.0 refresh_token
   daily-shorts
   movers
   stock-of-the-day
@@ -87,6 +89,10 @@ Examples:
 }
 
 async function run(command: string, client: TwitterClient, args: Args) {
+  if (command === "bootstrap-oauth2") {
+    await bootstrapOAuth2();
+    return;
+  }
   switch (command) {
     case "daily-shorts": {
       const text = await buildDailyShortsTweet();
@@ -144,9 +150,13 @@ async function main() {
   }
 
   console.log(`[twitter] command=${args.command} dry_run=${args.dryRun}`);
-  const client = createClient({ dryRun: args.dryRun });
 
   try {
+    if (args.command === "bootstrap-oauth2") {
+      await bootstrapOAuth2();
+      return;
+    }
+    const client = createClient({ dryRun: args.dryRun });
     await run(args.command, client, args);
     console.log(`[twitter] done (${args.dryRun ? "dry-run" : "posted"}).`);
   } catch (err) {

--- a/scripts/twitter/src/index.ts
+++ b/scripts/twitter/src/index.ts
@@ -16,10 +16,16 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Load .env from script root.
-const envPath = resolve(__dirname, "..", ".env");
-if (existsSync(envPath)) {
-  loadDotenv({ path: envPath });
+// Load env from script root first, then fall back to repo root.
+// Repo-root .env is convenient for shared credentials (e.g. the same
+// TWITTER_* vars used by other repo tooling) without copy-pasting.
+const localEnv = resolve(__dirname, "..", ".env");
+const repoEnv = resolve(__dirname, "..", "..", "..", ".env");
+if (existsSync(localEnv)) {
+  loadDotenv({ path: localEnv });
+}
+if (existsSync(repoEnv)) {
+  loadDotenv({ path: repoEnv, override: false });
 }
 
 interface Args {

--- a/scripts/twitter/src/oauth2-bootstrap.ts
+++ b/scripts/twitter/src/oauth2-bootstrap.ts
@@ -1,0 +1,167 @@
+/**
+ * One-time OAuth 2.0 PKCE bootstrap.
+ *
+ * Walks the operator through getting a refresh_token from X for the
+ * @shorted___ account. Run once locally:
+ *
+ *   npx tsx src/index.ts bootstrap-oauth2
+ *
+ * It:
+ *  1. Starts a tiny local HTTP server on 127.0.0.1:8787
+ *  2. Prints an X auth URL — open in browser, click "Authorize"
+ *  3. X redirects back to localhost with a code
+ *  4. We exchange the code for an access_token + refresh_token
+ *  5. Print the refresh_token and append to .env automatically
+ *
+ * After this, the regular posting commands can run unattended —
+ * twitter-api-v2 uses the refresh_token to mint fresh access tokens
+ * on every post, and writes the new refresh_token back to .env.
+ *
+ * Required X Developer Portal config:
+ *  - User authentication settings → OAuth 2.0 enabled
+ *  - Callback URI / Redirect URL includes: http://127.0.0.1:8787/callback
+ *  - Type of App: Confidential client (so client_secret is required)
+ *  - App permissions: Read and write
+ *  - Scopes used: tweet.read, tweet.write, users.read, offline.access
+ */
+
+import { TwitterApi } from "twitter-api-v2";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PORT = 8787;
+const REDIRECT_URI = `http://127.0.0.1:${PORT}/callback`;
+const SCOPES = ["tweet.read", "tweet.write", "users.read", "offline.access"];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoEnv = resolve(__dirname, "..", "..", "..", ".env");
+
+export async function bootstrapOAuth2(): Promise<void> {
+  const clientId = process.env.TWITTER_CLIENT_ID;
+  const clientSecret = process.env.TWITTER_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Set TWITTER_CLIENT_ID and TWITTER_CLIENT_SECRET in .env before running bootstrap-oauth2.",
+    );
+  }
+
+  const client = new TwitterApi({ clientId, clientSecret });
+  const { url, codeVerifier, state } = client.generateOAuth2AuthLink(
+    REDIRECT_URI,
+    { scope: SCOPES },
+  );
+
+  console.log("\n────────────────────────────────────────────────");
+  console.log("X OAuth 2.0 bootstrap — STEP 1 of 2");
+  console.log("────────────────────────────────────────────────");
+  console.log("\n1. In X Developer Portal → App → User authentication");
+  console.log("   settings, add this Callback URI:");
+  console.log(`\n   ${REDIRECT_URI}`);
+  console.log("\n2. Then open the URL below in your browser, sign in as");
+  console.log("   the bot account (@shorted___), and click 'Authorize app':\n");
+  console.log(`   ${url}`);
+  console.log("\nWaiting for the redirect on", REDIRECT_URI, "…\n");
+
+  // Spin up a one-shot HTTP server to catch the redirect.
+  const result = await new Promise<{ code: string; receivedState: string }>(
+    (resolveP, rejectP) => {
+      const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+        const url = new URL(req.url ?? "/", `http://127.0.0.1:${PORT}`);
+        if (url.pathname !== "/callback") {
+          res.statusCode = 404;
+          res.end("not found");
+          return;
+        }
+        const code = url.searchParams.get("code");
+        const receivedState = url.searchParams.get("state") ?? "";
+        const error = url.searchParams.get("error");
+
+        if (error) {
+          res.statusCode = 400;
+          res.end(`X returned an error: ${error}`);
+          server.close();
+          rejectP(new Error(`OAuth2 error from X: ${error}`));
+          return;
+        }
+        if (!code) {
+          res.statusCode = 400;
+          res.end("Missing code");
+          server.close();
+          rejectP(new Error("Missing code in callback"));
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html");
+        res.end(
+          "<h1>X auth complete</h1><p>You can close this tab and return to the terminal.</p>",
+        );
+        server.close();
+        resolveP({ code, receivedState });
+      });
+      server.listen(PORT, "127.0.0.1");
+      server.on("error", rejectP);
+    },
+  );
+
+  if (result.receivedState !== state) {
+    throw new Error("OAuth2 state mismatch — possible CSRF, aborting.");
+  }
+
+  console.log("\n────────────────────────────────────────────────");
+  console.log("STEP 2 of 2 — exchanging code for tokens");
+  console.log("────────────────────────────────────────────────\n");
+
+  const tokens = await client.loginWithOAuth2({
+    code: result.code,
+    codeVerifier,
+    redirectUri: REDIRECT_URI,
+  });
+
+  if (!tokens.refreshToken) {
+    throw new Error(
+      "Did not receive a refresh_token — confirm 'offline.access' is in the requested scopes.",
+    );
+  }
+
+  console.log("✓ Got refresh_token (expires:", tokens.expiresIn, "seconds for the access token)");
+  console.log("\nNew env values to save:");
+  console.log("");
+  console.log(`TWITTER_REFRESH_TOKEN=${tokens.refreshToken}`);
+
+  // Persist refresh token to repo-root .env if present, else print and bail.
+  if (existsSync(repoEnv)) {
+    const current = readFileSync(repoEnv, "utf8");
+    const updated = upsertEnv(current, "TWITTER_REFRESH_TOKEN", tokens.refreshToken);
+    writeFileSync(repoEnv, updated, { mode: 0o600 });
+    console.log(`\n✓ Wrote TWITTER_REFRESH_TOKEN to ${repoEnv}`);
+  } else {
+    console.log(
+      `\nNo .env found at ${repoEnv}; copy the line above into your .env manually.`,
+    );
+  }
+
+  // Test the token by fetching the authenticated user.
+  const authClient = new TwitterApi(tokens.accessToken);
+  const me = await authClient.v2.me();
+  console.log(
+    `\n✓ Authenticated as @${me.data.username} (${me.data.name}, id ${me.data.id})`,
+  );
+  console.log(
+    "\nDone. You can now run `npx tsx src/index.ts daily-shorts --live` to post.",
+  );
+}
+
+/**
+ * Upsert a KEY=VALUE line in a .env file body. Adds if missing,
+ * replaces in place if present.
+ */
+export function upsertEnv(body: string, key: string, value: string): string {
+  const line = `${key}=${value}`;
+  const re = new RegExp(`^${key}=.*$`, "m");
+  if (re.test(body)) {
+    return body.replace(re, line);
+  }
+  return body.endsWith("\n") ? body + line + "\n" : body + "\n" + line + "\n";
+}

--- a/scripts/twitter/src/twitter-client.ts
+++ b/scripts/twitter/src/twitter-client.ts
@@ -70,10 +70,19 @@ export function createClient(opts: { dryRun: boolean }): TwitterClient {
     return new DryRunTwitterClient();
   }
 
-  const apiKey = process.env.TWITTER_API_KEY;
-  const apiSecret = process.env.TWITTER_API_SECRET;
+  // Accept either of the common naming conventions for OAuth 1.0a:
+  //   API Key / API Key Secret  (X Developer Portal default labels)
+  //   Consumer Key / Consumer Secret  (older tweepy-style naming)
+  const apiKey =
+    process.env.TWITTER_API_KEY ?? process.env.TWITTER_CONSUMER_KEY;
+  const apiSecret =
+    process.env.TWITTER_API_SECRET ??
+    process.env.TWITTER_CONSUMER_SECRET ??
+    process.env.TWITTER_SECRET_KEY;
   const accessToken = process.env.TWITTER_ACCESS_TOKEN;
-  const accessTokenSecret = process.env.TWITTER_ACCESS_TOKEN_SECRET;
+  const accessTokenSecret =
+    process.env.TWITTER_ACCESS_TOKEN_SECRET ??
+    process.env.TWITTER_ACCESS_SECRET;
 
   if (apiKey && apiSecret && accessToken && accessTokenSecret) {
     return new LiveTwitterClient(

--- a/scripts/twitter/src/twitter-client.ts
+++ b/scripts/twitter/src/twitter-client.ts
@@ -1,4 +1,42 @@
 import { TwitterApi } from "twitter-api-v2";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { upsertEnv } from "./oauth2-bootstrap.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoEnvPath = resolve(__dirname, "..", "..", "..", ".env");
+
+/**
+ * Persist a refreshed OAuth 2.0 refresh_token back to the repo-root
+ * .env so the NEXT run uses the latest token. X rotates refresh
+ * tokens on every use — losing the new one means we'd be locked out
+ * the next time the access token expires.
+ */
+function persistRefreshToken(token: string): void {
+  // In CI we can't easily write to a repo file — instead the workflow
+  // sets TWITTER_REFRESH_TOKEN_OUT to a tmpfile path and a follow-up
+  // step re-stores it as a GH Actions secret via the `gh` CLI.
+  const outPath = process.env.TWITTER_REFRESH_TOKEN_OUT;
+  if (outPath) {
+    try {
+      writeFileSync(outPath, token, { mode: 0o600 });
+      console.log(`[twitter] wrote rotated refresh token to ${outPath}`);
+    } catch (err) {
+      console.warn(`[twitter] could not write refresh token: ${String(err)}`);
+    }
+    return;
+  }
+  if (!existsSync(repoEnvPath)) return;
+  try {
+    const body = readFileSync(repoEnvPath, "utf8");
+    writeFileSync(repoEnvPath, upsertEnv(body, "TWITTER_REFRESH_TOKEN", token), {
+      mode: 0o600,
+    });
+  } catch (err) {
+    console.warn(`[twitter] could not persist refresh token: ${String(err)}`);
+  }
+}
 
 export interface PostedTweet {
   id: string;
@@ -70,9 +108,20 @@ export function createClient(opts: { dryRun: boolean }): TwitterClient {
     return new DryRunTwitterClient();
   }
 
-  // Accept either of the common naming conventions for OAuth 1.0a:
-  //   API Key / API Key Secret  (X Developer Portal default labels)
-  //   Consumer Key / Consumer Secret  (older tweepy-style naming)
+  // ── OAuth 2.0 (preferred): client_id + client_secret + refresh_token.
+  //    On every run we mint a fresh access token from the refresh token,
+  //    use it once, and persist the rotated refresh token back to .env.
+  //    Run `bootstrap-oauth2` once to obtain the initial refresh token.
+  const clientId = process.env.TWITTER_CLIENT_ID;
+  const clientSecret = process.env.TWITTER_CLIENT_SECRET;
+  const refreshToken = process.env.TWITTER_REFRESH_TOKEN;
+  if (clientId && clientSecret && refreshToken) {
+    return new OAuth2TwitterClient(clientId, clientSecret, refreshToken);
+  }
+
+  // ── OAuth 1.0a fallback: API key/secret + access token/secret.
+  //    Accepts the X Developer Portal default labels OR older
+  //    tweepy-style names (CONSUMER_KEY, SECRET_KEY) without renaming.
   const apiKey =
     process.env.TWITTER_API_KEY ?? process.env.TWITTER_CONSUMER_KEY;
   const apiSecret =
@@ -95,19 +144,62 @@ export function createClient(opts: { dryRun: boolean }): TwitterClient {
     );
   }
 
-  const clientId = process.env.TWITTER_CLIENT_ID;
-  const clientSecret = process.env.TWITTER_CLIENT_SECRET;
-  const refreshToken = process.env.TWITTER_REFRESH_TOKEN;
-  if (clientId && clientSecret && refreshToken) {
-    throw new Error(
-      "OAuth 2.0 flow not yet wired in this script. " +
-        "Use OAuth 1.0a credentials (TWITTER_API_KEY/SECRET + TWITTER_ACCESS_TOKEN/SECRET) " +
-        "or extend createClient() to call twitter-api-v2's refreshOAuth2Token().",
-    );
+  throw new Error(
+    "No Twitter credentials found. For OAuth 2.0 run `bootstrap-oauth2` " +
+      "to mint a refresh token, or populate the 4 OAuth 1.0a vars in .env. " +
+      "Or pass --dry-run to preview without posting.",
+  );
+}
+
+class OAuth2TwitterClient implements TwitterClient {
+  private clientId: string;
+  private clientSecret: string;
+  private refreshToken: string;
+
+  constructor(clientId: string, clientSecret: string, refreshToken: string) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.refreshToken = refreshToken;
   }
 
-  throw new Error(
-    "No Twitter credentials found. Populate scripts/twitter/.env from .env.example, " +
-      "or pass --dry-run to preview without posting.",
-  );
+  private async authedClient(): Promise<TwitterApi> {
+    const app = new TwitterApi({
+      clientId: this.clientId,
+      clientSecret: this.clientSecret,
+    });
+    const { client, refreshToken: newRefresh } = await app.refreshOAuth2Token(
+      this.refreshToken,
+    );
+    if (newRefresh && newRefresh !== this.refreshToken) {
+      this.refreshToken = newRefresh;
+      persistRefreshToken(newRefresh);
+    }
+    return client;
+  }
+
+  async postTweet(text: string): Promise<PostedTweet> {
+    if (text.length > 280) {
+      throw new Error(`Tweet too long (${text.length} chars). Trim before posting.`);
+    }
+    const client = await this.authedClient();
+    const { data } = await client.v2.tweet(text);
+    return { id: data.id, text: data.text };
+  }
+
+  async postThread(items: string[]): Promise<PostedTweet[]> {
+    const client = await this.authedClient();
+    const posted: PostedTweet[] = [];
+    let inReplyTo: string | undefined;
+    for (const item of items) {
+      if (item.length > 280) {
+        throw new Error(`Thread item too long (${item.length} chars).`);
+      }
+      const result = inReplyTo
+        ? await client.v2.reply(item, inReplyTo)
+        : await client.v2.tweet(item);
+      posted.push({ id: result.data.id, text: result.data.text });
+      inReplyTo = result.data.id;
+    }
+    return posted;
+  }
 }

--- a/web/src/@/config/site.ts
+++ b/web/src/@/config/site.ts
@@ -23,7 +23,7 @@ export const siteConfig = {
   creator: "Shorted",
   publisher: "Shorted",
   links: {
-    twitter: "https://twitter.com/shorted",
+    twitter: "https://twitter.com/shorted___",
     github: "https://github.com/shorted",
   },
   contact: {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -82,7 +82,7 @@ export const metadata = {
     title: "Shorted - Official ASIC Short Position Data",
     description: siteConfig.description,
     images: [siteConfig.ogImage],
-    creator: "@shorted",
+    creator: "@shorted___",
   },
   robots: {
     index: true,


### PR DESCRIPTION
## Outcome

End-to-end bootstrapped @shorted___ with OAuth 2.0 PKCE:

```
✓ Got refresh_token (expires: 7200 seconds for the access token)
✓ Wrote TWITTER_REFRESH_TOKEN to /Users/.../shorted/.env
✓ Authenticated as @shorted___ (Ben Ebsworth, id 2056172186608750593)
```

## What ships

- **`bootstrap-oauth2`** command — one-time browser dance, captures refresh token
- **OAuth 2.0-aware live client** — refresh token rotation persisted to \`.env\` per run
- **OAuth 1.0a fallback** preserved + accepts either naming convention
- **GH Actions: manual-only** for now (scheduled crons commented out — local cron is the production path)
- **OPERATIONS.md** rewritten — local crontab block is the headline; CI is opt-in

## Next steps (you)

1. From a non-rate-limited terminal:
   ```
   cd /Users/benebsworth/projects/shorted/scripts/twitter
   npx tsx src/index.ts daily-shorts            # dry-run preview
   npx tsx src/index.ts daily-shorts --live     # first real tweet
   ```
2. Verify the tweet on https://x.com/shorted___
3. Drop the crontab block from OPERATIONS.md §2.1 into \`crontab -e\` to schedule recurring posts