### PR TITLE
feat(newsroom): investigative daily newsroom engine + footer attribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ coverage.html
 .env
 .env.local
 .env.*.local
+.env.prod
+.env.production
 
 # Terraform state and sensitive files (but not the terraform/ directory itself!)
 **/*.tfstate

--- a/docs/superpowers/plans/2026-05-30-investigative-newsroom.md
+++ b/docs/superpowers/plans/2026-05-30-investigative-newsroom.md
@@ -1,0 +1,2214 @@
+# Investigative Newsroom Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `scripts/take-writer/` from a single-LLM-call generator into a daily investigative newsroom: a Claude editor commissions stories (novelty-gated), Claude investigators gather evidence via live data tools into a grounded dossier, and Gemini writes tiered Takes/deep-dives that can only cite sources actually retrieved.
+
+**Architecture:** Three-stage pipeline (editor → investigator → writer) run by a daily Cloud Run Job. Claude (Sonnet for editor + Takes, Opus for deep-dives) does tool-calling investigation and emits a structured dossier + citation ledger; Gemini 2.5 writes the prose in the tuned Shorted voice citing only ledger `refId`s; a validate-before-insert step drops dangling citations. Writes into the existing `editorial_takes` table (+ a new `tier` column) and reuses the existing image-gen and draft/publish/tweet pipeline.
+
+**Tech Stack:** TypeScript + tsx (existing), `@anthropic-ai/sdk` (new), `@google/generative-ai` (existing writer), `pg` (existing), `vitest` (new, tests), Postgres migration, Terraform (Cloud Run Job + Cloud Scheduler).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-investigative-newsroom-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `scripts/take-writer/vitest.config.ts` | Test runner config | New |
+| `scripts/take-writer/package.json` | Add `@anthropic-ai/sdk`, vitest, test script | Modify |
+| `scripts/take-writer/src/ledger.ts` | Citation ledger: register retrieved sources → stable refIds; compact/validate body citations against the ledger | New |
+| `scripts/take-writer/src/drilldowns.ts` | Pure DB drill-down query functions (zoom window, follow peer, report line, align events, news detail, search news) | New |
+| `scripts/take-writer/src/tools.ts` | Anthropic tool schema + dispatch wrapping `drilldowns.ts`, accumulating sources into the ledger | New |
+| `scripts/take-writer/src/investigator.ts` | Claude agentic tool-calling loop → `Dossier` (turn/token capped) | New |
+| `scripts/take-writer/src/editor.ts` | Claude editor: signal board → novelty gate → `Assignment[]` | New |
+| `scripts/take-writer/src/journalism.ts` | Add `lastTakeDateForStock`, `buildSignalBoard` | Modify |
+| `scripts/take-writer/src/narrative.ts` | Add `synthesiseFromDossier` (tiered writer, ledger-refId-only) + `WRITER_MODEL` env | Modify |
+| `scripts/take-writer/src/newsroom.ts` | Add `runNewsroomDaily` (editor→investigator→writer, model tiering, caps, cost log, validate-before-insert) + `tier` insert | Modify |
+| `scripts/take-writer/src/index.ts` | Add `newsroom-daily` command + caps from env/flags | Modify |
+| `services/migrations/000038_editorial_takes_tier.up.sql` / `.down.sql` | `tier` column | New |
+| `terraform/modules/newsroom-job/{main,variables,outputs}.tf` | Cloud Run Job + Scheduler + IAM | New |
+| `terraform/environments/dev/main.tf` | Reference the module | Modify |
+
+**Type contracts (defined once, referenced everywhere):**
+
+```typescript
+// ledger.ts
+export type LedgerSourceType = "news" | "report" | "director";
+export interface LedgerSource {
+  type: LedgerSourceType;
+  url: string;
+  source: string;     // publisher / report type / "director trade"
+  headline: string;   // headline / report title / trade description
+  date: string;       // YYYY-MM-DD
+}
+
+// editor.ts
+export interface Assignment {
+  stockCode: string;
+  angle: string;
+  tier: "take" | "deep_dive";
+  rationale: string;
+}
+
+// investigator.ts
+export interface DossierThread { claim: string; evidenceRefIds: string[]; note?: string }
+export interface DossierTimelineItem { date: string; event: string; refIds: string[] }
+export interface DossierKeyNumber { label: string; value: string; refId?: string }
+export interface Dossier {
+  stockCode: string;
+  tier: "take" | "deep_dive";
+  angle: string;
+  summary: string;
+  threads: DossierThread[];
+  timeline?: DossierTimelineItem[];
+  keyNumbers: DossierKeyNumber[];
+}
+```
+
+The `Citation` type already exists in `narrative.ts` (`{ refId, url, source, headline, date, type }`) and is the on-disk shape in `editorial_takes.citations`. The ledger produces `Citation[]` so nothing downstream changes.
+
+---
+
+## Task 1: Test tooling + Anthropic SDK
+
+**Files:**
+- Modify: `scripts/take-writer/package.json`
+- Create: `scripts/take-writer/vitest.config.ts`
+
+- [ ] **Step 1: Add deps and test script to package.json**
+
+Edit the `dependencies` and `devDependencies` / `scripts` blocks so they read:
+
+```json
+  "scripts": {
+    "draft": "tsx src/index.ts draft",
+    "pick": "tsx src/index.ts pick",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.69.0",
+    "@google-cloud/storage": "^7.19.0",
+    "@google/generative-ai": "^0.21.0",
+    "@types/pg": "^8.20.0",
+    "dotenv": "^16.4.5",
+    "openai": "^6.38.0",
+    "pg": "^8.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.0.0"
+  }
+```
+
+- [ ] **Step 2: Create vitest config**
+
+`scripts/take-writer/vitest.config.ts`:
+
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});
+```
+
+- [ ] **Step 3: Install**
+
+Run: `cd scripts/take-writer && npm install`
+Expected: installs `@anthropic-ai/sdk` and `vitest`, exit 0.
+
+- [ ] **Step 4: Verify vitest runs (no tests yet)**
+
+Run: `cd scripts/take-writer && npm test`
+Expected: vitest reports "No test files found" — that's fine, exit code may be non-zero. Confirms the runner is wired.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/package.json scripts/take-writer/package-lock.json scripts/take-writer/vitest.config.ts
+git commit -m "chore(take-writer): add anthropic sdk + vitest test tooling"
+```
+
+---
+
+## Task 2: Schema migration — `tier` column
+
+**Files:**
+- Create: `services/migrations/000038_editorial_takes_tier.up.sql`
+- Create: `services/migrations/000038_editorial_takes_tier.down.sql`
+
+- [ ] **Step 1: Write the up migration**
+
+`services/migrations/000038_editorial_takes_tier.up.sql`:
+
+```sql
+-- Tiered editorial output: most takes are tight 4-section "take"s; a
+-- couple per day are promoted to long-form "deep_dive" investigations.
+-- The investigative newsroom (scripts/take-writer) sets this.
+ALTER TABLE editorial_takes
+  ADD COLUMN IF NOT EXISTS tier VARCHAR(20) NOT NULL DEFAULT 'take';
+
+-- Allowed values: 'take' | 'deep_dive'. Enforced in app, documented here.
+COMMENT ON COLUMN editorial_takes.tier IS 'take | deep_dive';
+```
+
+- [ ] **Step 2: Write the down migration**
+
+`services/migrations/000038_editorial_takes_tier.down.sql`:
+
+```sql
+ALTER TABLE editorial_takes DROP COLUMN IF EXISTS tier;
+```
+
+- [ ] **Step 3: Apply against the dev DB**
+
+Run: `cd services && make migrate-up`
+Expected: migration 000038 applies; `make migrate-version` shows 38.
+
+- [ ] **Step 4: Verify the column exists**
+
+Run: `psql postgresql://admin:password@localhost:5438/shorts -c "\d editorial_takes" | grep tier`
+Expected: a `tier | character varying(20) | not null | 'take'::character varying` row.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/migrations/000038_editorial_takes_tier.up.sql services/migrations/000038_editorial_takes_tier.down.sql
+git commit -m "feat(db): add tier column to editorial_takes (migration 000038)"
+```
+
+---
+
+## Task 3: Citation ledger
+
+**Files:**
+- Create: `scripts/take-writer/src/ledger.ts`
+- Test: `scripts/take-writer/src/ledger.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+`scripts/take-writer/src/ledger.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { CitationLedger, compactCitations } from "./ledger.js";
+
+const src = (over: Partial<import("./ledger.js").LedgerSource> = {}) => ({
+  type: "news" as const,
+  url: "https://ex.com/a",
+  source: "Stockhead",
+  headline: "A headline",
+  date: "2026-05-01",
+  ...over,
+});
+
+describe("CitationLedger", () => {
+  it("assigns sequential refIds in registration order", () => {
+    const l = new CitationLedger();
+    expect(l.register(src({ url: "https://ex.com/a" }))).toBe("ref-1");
+    expect(l.register(src({ url: "https://ex.com/b" }))).toBe("ref-2");
+  });
+
+  it("dedupes by type+url, returning the existing refId", () => {
+    const l = new CitationLedger();
+    const first = l.register(src({ url: "https://ex.com/a" }));
+    const again = l.register(src({ url: "https://ex.com/a", headline: "changed" }));
+    expect(again).toBe(first);
+    expect(l.size()).toBe(1);
+  });
+
+  it("knows whether a refId is in the ledger", () => {
+    const l = new CitationLedger();
+    l.register(src());
+    expect(l.has("ref-1")).toBe(true);
+    expect(l.has("ref-9")).toBe(false);
+  });
+});
+
+describe("compactCitations", () => {
+  it("drops markers not in the ledger and renumbers cited ones in first-appearance order", () => {
+    const l = new CitationLedger();
+    l.register(src({ url: "https://ex.com/a", type: "news" }));     // ref-1
+    l.register(src({ url: "https://ex.com/b", type: "report" }));   // ref-2
+    l.register(src({ url: "https://ex.com/c", type: "news" }));     // ref-3
+    // Body cites ref-3 then ref-1, and a bogus ref-8 that must be dropped.
+    const body = "First [ref-3]. Then [ref-1]. Bogus [ref-8].";
+    const { body: out, citations } = compactCitations(body, l);
+    expect(out).toBe("First [ref-1]. Then [ref-2]. Bogus .");
+    expect(citations.map((c) => c.refId)).toEqual(["ref-1", "ref-2"]);
+    expect(citations[0]!.url).toBe("https://ex.com/c");
+    expect(citations[1]!.url).toBe("https://ex.com/a");
+    expect(citations[1]!.type).toBe("news");
+  });
+
+  it("reports dangling markers it dropped", () => {
+    const l = new CitationLedger();
+    l.register(src());
+    const { dropped } = compactCitations("ok [ref-1] bad [ref-7]", l);
+    expect(dropped).toEqual(["ref-7"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/ledger.test.ts`
+Expected: FAIL — `Cannot find module './ledger.js'`.
+
+- [ ] **Step 3: Implement the ledger**
+
+`scripts/take-writer/src/ledger.ts`:
+
+```typescript
+// Citation ledger — the grounding spine of the investigative newsroom.
+//
+// Every source the investigation agent actually retrieves via a data
+// tool is registered here and handed a stable refId. The writer may
+// ONLY cite refIds that exist in the ledger; compactCitations() drops
+// any marker the writer invents and renumbers the survivors into the
+// contiguous ref-1..M sequence the frontend (LinkifiedNarrative +
+// editorial_takes.citations) already understands.
+
+import type { Citation } from "./narrative.js";
+
+export type LedgerSourceType = "news" | "report" | "director";
+
+export interface LedgerSource {
+  type: LedgerSourceType;
+  url: string;
+  source: string;
+  headline: string;
+  date: string; // YYYY-MM-DD
+}
+
+export class CitationLedger {
+  private byKey = new Map<string, string>();   // type:url -> refId
+  private byRefId = new Map<string, LedgerSource>();
+  private seq = 0;
+
+  private key(s: LedgerSource): string {
+    return `${s.type}:${s.url}`;
+  }
+
+  /** Register a retrieved source; returns its stable refId. Idempotent on type+url. */
+  register(s: LedgerSource): string {
+    const k = this.key(s);
+    const existing = this.byKey.get(k);
+    if (existing) return existing;
+    this.seq += 1;
+    const refId = `ref-${this.seq}`;
+    this.byKey.set(k, refId);
+    this.byRefId.set(refId, s);
+    return refId;
+  }
+
+  has(refId: string): boolean {
+    return this.byRefId.has(refId);
+  }
+
+  get(refId: string): LedgerSource | undefined {
+    return this.byRefId.get(refId);
+  }
+
+  size(): number {
+    return this.byRefId.size;
+  }
+}
+
+const MARKER = /\[(ref-\d+)\]/g;
+
+/**
+ * Walk the body, drop any [ref-N] not in the ledger, and renumber the
+ * cited-and-valid markers into contiguous ref-1..M in first-appearance
+ * order. Returns the rewritten body, the ordered Citation[] for the
+ * editorial_takes.citations column, and the dropped (dangling) marker ids.
+ */
+export function compactCitations(
+  body: string,
+  ledger: CitationLedger,
+): { body: string; citations: Citation[]; dropped: string[] } {
+  const remap = new Map<string, string>();
+  const ordered: LedgerSource[] = [];
+  const dropped: string[] = [];
+  let assigned = 0;
+
+  for (const m of body.matchAll(MARKER)) {
+    const id = m[1]!;
+    if (remap.has(id)) continue;
+    const srcRec = ledger.get(id);
+    if (!srcRec) {
+      if (!dropped.includes(id)) dropped.push(id);
+      continue;
+    }
+    assigned += 1;
+    const to = `ref-${assigned}`;
+    remap.set(id, to);
+    ordered.push(srcRec);
+  }
+
+  const outBody = body.replace(MARKER, (whole, id: string) => {
+    if (remap.has(id)) return `[${remap.get(id)}]`;
+    return ""; // drop dangling marker
+  });
+
+  const citations: Citation[] = ordered.map((s, i) => ({
+    refId: `ref-${i + 1}`,
+    url: s.url,
+    source: s.source,
+    headline: s.headline,
+    date: s.date,
+    type: s.type === "director" ? "trade" : s.type, // Citation.type has no 'director'; map to 'trade'
+  }));
+
+  return { body: outBody, citations, dropped };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/ledger.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/src/ledger.ts scripts/take-writer/src/ledger.test.ts
+git commit -m "feat(take-writer): citation ledger + compactCitations grounding primitive"
+```
+
+---
+
+## Task 4: Drill-down DB queries
+
+**Files:**
+- Create: `scripts/take-writer/src/drilldowns.ts`
+- Test: `scripts/take-writer/src/drilldowns.test.ts`
+
+These are thin, incremental queries (windows around a date, one peer, one report line) — NOT full re-fetches. They take a minimal pg-query interface so tests can inject a fake.
+
+- [ ] **Step 1: Write failing tests**
+
+`scripts/take-writer/src/drilldowns.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { zoomWindow, reportLine, searchNews, type Queryable } from "./drilldowns.js";
+
+function fakePg(capture: { sql: string; params: unknown[] }[], rows: unknown[]): Queryable {
+  return {
+    async query(sql: string, params?: unknown[]) {
+      capture.push({ sql, params: params ?? [] });
+      return { rows } as { rows: unknown[] };
+    },
+  };
+}
+
+describe("zoomWindow", () => {
+  it("queries shorts+prices+news in a +/- day window around a date", async () => {
+    const cap: { sql: string; params: unknown[] }[] = [];
+    const pg = fakePg(cap, []);
+    await zoomWindow(pg, "BHP", "2026-05-01", 3);
+    // 3 queries: shorts, prices, news — all parameterised with the code.
+    expect(cap.length).toBe(3);
+    expect(cap.every((c) => c.params.includes("BHP"))).toBe(true);
+    expect(cap.every((c) => c.params.some((p) => String(p).includes("2026-05-01")))).toBe(true);
+  });
+});
+
+describe("reportLine", () => {
+  it("returns the metric value + source record for a stock", async () => {
+    const cap: { sql: string; params: unknown[] }[] = [];
+    const pg = fakePg(cap, [{
+      report_url: "https://x/r.pdf", report_type: "annual_results",
+      report_title: "FY25", report_date: "2026-02-01",
+      metrics: { revenue: "A$1.2bn", ebitda: "A$300m" },
+    }]);
+    const out = await reportLine(pg, "BHP", "revenue");
+    expect(out?.value).toBe("A$1.2bn");
+    expect(out?.source.type).toBe("report");
+    expect(out?.source.url).toBe("https://x/r.pdf");
+  });
+
+  it("returns null when the metric is absent", async () => {
+    const pg = fakePg([], [{ report_url: "u", report_type: null, report_title: null, report_date: null, metrics: {} }]);
+    expect(await reportLine(pg, "BHP", "revenue")).toBeNull();
+  });
+});
+
+describe("searchNews", () => {
+  it("parameterises the query string and optional code", async () => {
+    const cap: { sql: string; params: unknown[] }[] = [];
+    const pg = fakePg(cap, []);
+    await searchNews(pg, "probe", "DRO");
+    expect(cap[0]!.params).toContain("DRO");
+    expect(cap[0]!.params.some((p) => String(p).includes("probe"))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/drilldowns.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement drill-downs**
+
+`scripts/take-writer/src/drilldowns.ts`:
+
+```typescript
+// Incremental drill-down queries used by the investigation agent's
+// tools. Each zooms into a slice of the data the agent already has a
+// summary of — a window around a date, one peer, one report line — so
+// the loop stays cheap instead of re-sending 365-day series each turn.
+
+import type { LedgerSource } from "./ledger.js";
+
+/** Minimal slice of pg.Client we need — lets tests inject a fake. */
+export interface Queryable {
+  query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }>;
+}
+
+export interface WindowResult {
+  shorts: Array<{ date: string; pct: number }>;
+  prices: Array<{ date: string; close: number; volume: number }>;
+  news: Array<{ id: string; date: string; source: string; headline: string; url: string; sentiment: string | null }>;
+}
+
+export async function zoomWindow(
+  pg: Queryable,
+  code: string,
+  date: string,
+  days: number,
+): Promise<WindowResult> {
+  const lo = `${date} -${days} days`;
+  const hi = `${date} +${days} days`;
+  const shortsQ = pg.query(
+    `SELECT to_char("DATE",'YYYY-MM-DD') AS date,
+            "PERCENT_OF_TOTAL_PRODUCT_IN_ISSUE_REPORTED_AS_SHORT_POSITIONS" AS pct
+     FROM shorts
+     WHERE "PRODUCT_CODE"=$1 AND "DATE" BETWEEN $2::timestamp AND $3::timestamp
+     ORDER BY "DATE" ASC`,
+    [code, lo, hi],
+  );
+  const pricesQ = pg.query(
+    `SELECT to_char(date,'YYYY-MM-DD') AS date, close, volume
+     FROM stock_prices
+     WHERE stock_code=$1 AND date BETWEEN $2::date AND $3::date
+     ORDER BY date ASC`,
+    [code, lo, hi],
+  );
+  const newsQ = pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url, sentiment
+     FROM news_articles
+     WHERE stock_code=$1 AND published_at BETWEEN $2::timestamp AND $3::timestamp
+     ORDER BY published_at ASC LIMIT 40`,
+    [code, lo, hi],
+  );
+  const [s, p, n] = await Promise.all([shortsQ, pricesQ, newsQ]);
+  return {
+    shorts: (s.rows as Array<{ date: string; pct: string }>).map((r) => ({ date: r.date, pct: Number(r.pct) })),
+    prices: (p.rows as Array<{ date: string; close: string; volume: string }>).map((r) => ({ date: r.date, close: Number(r.close), volume: Number(r.volume) })),
+    news: n.rows as WindowResult["news"],
+  };
+}
+
+export interface ReportLineResult {
+  value: string;
+  reportType: string | null;
+  reportDate: string | null;
+  source: LedgerSource;
+}
+
+export async function reportLine(
+  pg: Queryable,
+  code: string,
+  metric: string,
+): Promise<ReportLineResult | null> {
+  const { rows } = await pg.query(
+    `SELECT report_url, report_type, report_title,
+            to_char(report_date,'YYYY-MM-DD') AS report_date, metrics
+     FROM financial_report_extractions
+     WHERE stock_code=$1
+     ORDER BY report_date DESC NULLS LAST, extracted_at DESC
+     LIMIT 6`,
+    [code],
+  );
+  for (const r of rows as Array<{ report_url: string; report_type: string | null; report_title: string | null; report_date: string | null; metrics: Record<string, unknown> | null }>) {
+    const m = r.metrics ?? {};
+    if (metric in m && m[metric] != null) {
+      return {
+        value: String(m[metric]),
+        reportType: r.report_type,
+        reportDate: r.report_date,
+        source: {
+          type: "report",
+          url: r.report_url,
+          source: r.report_type ?? "report",
+          headline: r.report_title ?? "(financial report)",
+          date: r.report_date ?? "",
+        },
+      };
+    }
+  }
+  return null;
+}
+
+export interface FollowPeerResult {
+  shorts: Array<{ date: string; pct: number }>;
+  prices: Array<{ date: string; close: number }>;
+}
+
+export async function followPeer(
+  pg: Queryable,
+  peerCode: string,
+  days = 180,
+): Promise<FollowPeerResult> {
+  const sQ = pg.query(
+    `SELECT to_char("DATE",'YYYY-MM-DD') AS date,
+            "PERCENT_OF_TOTAL_PRODUCT_IN_ISSUE_REPORTED_AS_SHORT_POSITIONS" AS pct
+     FROM shorts WHERE "PRODUCT_CODE"=$1 AND "DATE" > NOW() - $2::interval ORDER BY "DATE" ASC`,
+    [peerCode, `${days} days`],
+  );
+  const pQ = pg.query(
+    `SELECT to_char(date,'YYYY-MM-DD') AS date, close FROM stock_prices
+     WHERE stock_code=$1 AND date > NOW() - $2::interval ORDER BY date ASC`,
+    [peerCode, `${days} days`],
+  );
+  const [s, p] = await Promise.all([sQ, pQ]);
+  return {
+    shorts: (s.rows as Array<{ date: string; pct: string }>).map((r) => ({ date: r.date, pct: Number(r.pct) })),
+    prices: (p.rows as Array<{ date: string; close: string }>).map((r) => ({ date: r.date, close: Number(r.close) })),
+  };
+}
+
+export interface AlignEventsItem {
+  date: string;
+  kind: "director_trade" | "news";
+  detail: string;
+  source: LedgerSource;
+}
+
+export async function alignEvents(
+  pg: Queryable,
+  code: string,
+  days = 180,
+): Promise<AlignEventsItem[]> {
+  const tradesQ = pg.query(
+    `SELECT to_char(trade_date,'YYYY-MM-DD') AS date, director_name, trade_type,
+            total_value, announcement_url
+     FROM director_trades WHERE stock_code=$1 AND trade_date > NOW() - $2::interval
+     ORDER BY trade_date DESC LIMIT 50`,
+    [code, `${days} days`],
+  );
+  const newsQ = pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url
+     FROM news_articles WHERE stock_code=$1 AND is_price_sensitive=true
+       AND published_at > NOW() - $2::interval ORDER BY published_at DESC LIMIT 40`,
+    [code, `${days} days`],
+  );
+  const [t, n] = await Promise.all([tradesQ, newsQ]);
+  const out: AlignEventsItem[] = [];
+  for (const r of t.rows as Array<{ date: string; director_name: string; trade_type: string; total_value: string | null; announcement_url: string | null }>) {
+    out.push({
+      date: r.date,
+      kind: "director_trade",
+      detail: `${r.director_name} ${r.trade_type}${r.total_value ? ` A$${r.total_value}` : ""}`,
+      source: { type: "director", url: r.announcement_url ?? "", source: "director trade", headline: `${r.director_name} ${r.trade_type}`, date: r.date },
+    });
+  }
+  for (const r of n.rows as Array<{ id: string; date: string; source: string; headline: string; url: string }>) {
+    out.push({ date: r.date, kind: "news", detail: r.headline, source: { type: "news", url: r.url, source: r.source, headline: r.headline, date: r.date } });
+  }
+  out.sort((a, b) => (a.date < b.date ? 1 : -1));
+  return out;
+}
+
+export interface NewsDetailResult {
+  id: string; date: string; source: string; headline: string; url: string;
+  sentiment: string | null; summary: string | null; ledgerSource: LedgerSource;
+}
+
+export async function newsDetail(pg: Queryable, articleId: string): Promise<NewsDetailResult | null> {
+  const { rows } = await pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url, sentiment, summary
+     FROM news_articles WHERE id=$1::uuid LIMIT 1`,
+    [articleId],
+  );
+  const r = (rows as Array<{ id: string; date: string; source: string; headline: string; url: string; sentiment: string | null; summary: string | null }>)[0];
+  if (!r) return null;
+  return { ...r, ledgerSource: { type: "news", url: r.url, source: r.source, headline: r.headline, date: r.date } };
+}
+
+export interface SearchNewsItem {
+  id: string; date: string; source: string; headline: string; url: string; ledgerSource: LedgerSource;
+}
+
+export async function searchNews(pg: Queryable, query: string, code?: string): Promise<SearchNewsItem[]> {
+  const params: unknown[] = [`%${query}%`];
+  let codeClause = "";
+  if (code) { params.push(code); codeClause = `AND stock_code=$${params.length}`; }
+  const { rows } = await pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url
+     FROM news_articles
+     WHERE (headline ILIKE $1 OR summary ILIKE $1) ${codeClause}
+     ORDER BY published_at DESC LIMIT 25`,
+    params,
+  );
+  return (rows as Array<{ id: string; date: string; source: string; headline: string; url: string }>).map((r) => ({
+    ...r, ledgerSource: { type: "news", url: r.url, source: r.source, headline: r.headline, date: r.date },
+  }));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/drilldowns.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/src/drilldowns.ts scripts/take-writer/src/drilldowns.test.ts
+git commit -m "feat(take-writer): incremental drill-down DB queries for investigation tools"
+```
+
+---
+
+## Task 5: Tool registry + dispatch
+
+**Files:**
+- Create: `scripts/take-writer/src/tools.ts`
+- Test: `scripts/take-writer/src/tools.test.ts`
+
+`tools.ts` exposes the Anthropic tool schema and a `dispatchTool` that runs the drill-down, registers every source it returns into the ledger, and returns a compact JSON result string for the agent. Registering on dispatch is what guarantees the writer can only cite retrieved sources.
+
+- [ ] **Step 1: Write failing tests**
+
+`scripts/take-writer/src/tools.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { TOOL_DEFS, dispatchTool } from "./tools.js";
+import { CitationLedger } from "./ledger.js";
+
+describe("TOOL_DEFS", () => {
+  it("declares the expected tools with input schemas", () => {
+    const names = TOOL_DEFS.map((t) => t.name).sort();
+    expect(names).toEqual(
+      ["align_events", "follow_peer", "news_detail", "report_line", "search_news", "zoom_window"].sort(),
+    );
+    for (const t of TOOL_DEFS) {
+      expect(t.input_schema.type).toBe("object");
+    }
+  });
+});
+
+describe("dispatchTool", () => {
+  it("runs search_news and registers each returned source in the ledger", async () => {
+    const ledger = new CitationLedger();
+    const pg = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ id: "1", date: "2026-05-01", source: "Stockhead", headline: "Probe", url: "https://x/1" }],
+      }),
+    };
+    const out = await dispatchTool(pg, ledger, "search_news", { query: "probe", code: "DRO" });
+    expect(ledger.size()).toBe(1);
+    expect(ledger.has("ref-1")).toBe(true);
+    // The agent-facing result embeds the refId so the model can cite it.
+    expect(out).toContain("ref-1");
+    expect(out).toContain("Probe");
+  });
+
+  it("returns an error string for an unknown tool instead of throwing", async () => {
+    const ledger = new CitationLedger();
+    const pg = { query: vi.fn() };
+    const out = await dispatchTool(pg, ledger, "nope", {});
+    expect(out.toLowerCase()).toContain("unknown tool");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/tools.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tool registry**
+
+`scripts/take-writer/src/tools.ts`:
+
+```typescript
+// Anthropic tool registry for the investigation agent. Each tool wraps
+// a drill-down query. dispatchTool registers every source the tool
+// surfaces into the citation ledger (handing back stable refIds) so the
+// writer can cite only what was actually retrieved.
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { CitationLedger, LedgerSource } from "./ledger.js";
+import {
+  zoomWindow, reportLine, followPeer, alignEvents, newsDetail, searchNews,
+  type Queryable,
+} from "./drilldowns.js";
+
+export const TOOL_DEFS: Anthropic.Tool[] = [
+  {
+    name: "zoom_window",
+    description: "Zoom into the short %, price, and news in a +/- day window around a specific date — use to investigate a spike or a price move you noticed in the summary.",
+    input_schema: {
+      type: "object",
+      properties: {
+        date: { type: "string", description: "Centre date YYYY-MM-DD" },
+        days: { type: "number", description: "Half-window in days (e.g. 3)" },
+      },
+      required: ["date"],
+    },
+  },
+  {
+    name: "report_line",
+    description: "Pull one reported financial metric (revenue, ebitda, eps, dividend, guidance, cash_flow, net_profit) from the company's most recent filings. Returns the value and a citable source.",
+    input_schema: {
+      type: "object",
+      properties: { metric: { type: "string", description: "Metric key, e.g. 'revenue'" } },
+      required: ["metric"],
+    },
+  },
+  {
+    name: "follow_peer",
+    description: "Pull a named sector peer's short %/price history to compare divergence against the subject stock.",
+    input_schema: {
+      type: "object",
+      properties: { peerCode: { type: "string" }, days: { type: "number" } },
+      required: ["peerCode"],
+    },
+  },
+  {
+    name: "align_events",
+    description: "Return a merged timeline of director trades and price-sensitive news for the subject, newest first — use to align director activity against price/short moves.",
+    input_schema: { type: "object", properties: { days: { type: "number" } } },
+  },
+  {
+    name: "news_detail",
+    description: "Fetch the full record (summary, sentiment, url) for one news article by its id.",
+    input_schema: {
+      type: "object",
+      properties: { articleId: { type: "string" } },
+      required: ["articleId"],
+    },
+  },
+  {
+    name: "search_news",
+    description: "Keyword-search recent news headlines/summaries (optionally scoped to a stock code) to find a specific thread.",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" }, code: { type: "string" } },
+      required: ["query"],
+    },
+  },
+];
+
+/** Register a source and return "[refId] headline (source, date)" for the agent. */
+function cite(ledger: CitationLedger, s: LedgerSource): string {
+  const refId = ledger.register(s);
+  return `[${refId}] ${s.headline} (${s.source}, ${s.date})`;
+}
+
+export async function dispatchTool(
+  pg: Queryable,
+  ledger: CitationLedger,
+  name: string,
+  input: Record<string, unknown>,
+  subjectCode?: string,
+): Promise<string> {
+  try {
+    switch (name) {
+      case "zoom_window": {
+        const code = subjectCode ?? String(input.code ?? "");
+        const w = await zoomWindow(pg, code, String(input.date), Number(input.days ?? 3));
+        const newsLines = w.news.map((n) => cite(ledger, { type: "news", url: n.url, source: n.source, headline: n.headline, date: n.date }));
+        return JSON.stringify({
+          shorts: w.shorts, prices: w.prices,
+          news: newsLines,
+        });
+      }
+      case "report_line": {
+        const code = subjectCode ?? String(input.code ?? "");
+        const r = await reportLine(pg, code, String(input.metric));
+        if (!r) return JSON.stringify({ found: false });
+        const ref = cite(ledger, r.source);
+        return JSON.stringify({ found: true, value: r.value, reportType: r.reportType, date: r.reportDate, citation: ref });
+      }
+      case "follow_peer": {
+        const r = await followPeer(pg, String(input.peerCode), Number(input.days ?? 180));
+        return JSON.stringify(r);
+      }
+      case "align_events": {
+        const code = subjectCode ?? String(input.code ?? "");
+        const items = await alignEvents(pg, code, Number(input.days ?? 180));
+        return JSON.stringify(items.map((it) => ({ date: it.date, kind: it.kind, detail: it.detail, citation: cite(ledger, it.source) })));
+      }
+      case "news_detail": {
+        const r = await newsDetail(pg, String(input.articleId));
+        if (!r) return JSON.stringify({ found: false });
+        const ref = cite(ledger, r.ledgerSource);
+        return JSON.stringify({ found: true, headline: r.headline, summary: r.summary, sentiment: r.sentiment, date: r.date, citation: ref });
+      }
+      case "search_news": {
+        const items = await searchNews(pg, String(input.query), input.code ? String(input.code) : subjectCode);
+        return JSON.stringify(items.map((it) => ({ id: it.id, citation: cite(ledger, it.ledgerSource) })));
+      }
+      default:
+        return `ERROR: unknown tool "${name}"`;
+    }
+  } catch (err) {
+    return `ERROR running ${name}: ${String((err as Error).message ?? err).slice(0, 200)}`;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/tools.test.ts`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/src/tools.ts scripts/take-writer/src/tools.test.ts
+git commit -m "feat(take-writer): anthropic tool registry + ledger-registering dispatch"
+```
+
+---
+
+## Task 6: journalism.ts — signal board + last-take lookup
+
+**Files:**
+- Modify: `scripts/take-writer/src/journalism.ts`
+- Test: `scripts/take-writer/src/signalboard.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+`scripts/take-writer/src/signalboard.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { lastTakeDateForStock } from "./journalism.js";
+
+describe("lastTakeDateForStock", () => {
+  it("returns the most recent created_at for a stock, or null", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [{ last: "2026-05-20" }] }) } as any;
+    expect(await lastTakeDateForStock(pg, "BHP")).toBe("2026-05-20");
+  });
+  it("returns null when no take exists", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) } as any;
+    expect(await lastTakeDateForStock(pg, "BHP")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/signalboard.test.ts`
+Expected: FAIL — `lastTakeDateForStock` not exported.
+
+- [ ] **Step 3: Add the functions to journalism.ts**
+
+Append to `scripts/take-writer/src/journalism.ts` (after `buildReport`):
+
+```typescript
+// --- Newsroom helpers ---
+
+/** Most recent editorial_takes.created_at for a stock (YYYY-MM-DD), or null. */
+export async function lastTakeDateForStock(
+  pg: PgClient,
+  code: string,
+): Promise<string | null> {
+  const { rows } = await pg.query<{ last: string | null }>(
+    `SELECT to_char(MAX(created_at), 'YYYY-MM-DD') AS last
+     FROM editorial_takes WHERE stock_code = $1`,
+    [code],
+  );
+  return rows[0]?.last ?? null;
+}
+
+export interface SignalBoardRow {
+  stockCode: string;
+  name: string | null;
+  industry: string | null;
+  signals: Signals;
+  lastTakeDate: string | null;
+  recentPriceSensitiveHeadlines: Array<{ date: string; headline: string }>;
+}
+
+/**
+ * Build a compact per-stock board for the editor agent: signals +
+ * when we last covered the stock + the few most recent price-sensitive
+ * headlines (so the editor can judge novelty). Pool comes from
+ * mv_top_shorts (most-shorted first).
+ */
+export async function buildSignalBoard(
+  pg: PgClient,
+  poolSize = 30,
+): Promise<SignalBoardRow[]> {
+  const { rows } = await pg.query<{ product_code: string }>(
+    `SELECT product_code FROM mv_top_shorts ORDER BY current_percent DESC LIMIT $1`,
+    [poolSize],
+  );
+  const board: SignalBoardRow[] = [];
+  for (const r of rows) {
+    const code = r.product_code;
+    const report = await buildReport(pg, code);
+    const lastTakeDate = await lastTakeDateForStock(pg, code);
+    board.push({
+      stockCode: code,
+      name: report.bundle.meta.name,
+      industry: report.bundle.meta.industry,
+      signals: report.signals,
+      lastTakeDate,
+      recentPriceSensitiveHeadlines: report.bundle.news
+        .filter((a) => a.isPriceSensitive)
+        .slice(0, 5)
+        .map((a) => ({ date: a.publishedAt.slice(0, 10), headline: a.headline })),
+    });
+  }
+  return board;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/signalboard.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/src/journalism.ts scripts/take-writer/src/signalboard.test.ts
+git commit -m "feat(take-writer): signal board + last-take lookup for the editor"
+```
+
+---
+
+## Task 7: Editor agent + novelty gate
+
+**Files:**
+- Create: `scripts/take-writer/src/editor.ts`
+- Test: `scripts/take-writer/src/editor.test.ts`
+
+The novelty gate is a pure function tested directly; the Claude call (ranking + tier assignment) is wrapped so the pure gate filters its output too.
+
+- [ ] **Step 1: Write failing tests**
+
+`scripts/take-writer/src/editor.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { hasNewDevelopment } from "./editor.js";
+import type { SignalBoardRow } from "./journalism.js";
+
+const baseRow = (over: Partial<SignalBoardRow> = {}): SignalBoardRow => ({
+  stockCode: "BHP",
+  name: "BHP",
+  industry: "Materials",
+  lastTakeDate: "2026-05-20",
+  recentPriceSensitiveHeadlines: [],
+  signals: {
+    shortSlope90d: 0, shortSlope30d: 0, shortSlope7d: 0,
+    currentShortPct: 5, shortPct90dAvg: 5, shortPctChange90d: 0,
+    shortPctMaxIn90d: 6, shortPctMinIn90d: 4,
+    currentPrice: 40, priceChange1m: 0, priceChange3m: 0, priceChange6m: 0, priceChange12m: 0,
+    priceShortsCorrelation30d: 0,
+    newsArticlesLast30d: 0, newsArticlesLast7d: 0, priceSensitiveLast30d: 0,
+    sentimentMix: { positive: 0, negative: 0, neutral: 0 }, sentimentTrendLast30d: "n/a",
+    directorTradesLast90d: 0, directorNetValueLast90d: 0, directorMostRecentDate: null,
+    peerSectorAverageShort: 5, peerRelative: "at", topRecentEvents: [],
+  },
+  ...over,
+});
+
+describe("hasNewDevelopment", () => {
+  it("is true when never covered before", () => {
+    expect(hasNewDevelopment(baseRow({ lastTakeDate: null }))).toBe(true);
+  });
+
+  it("is true when a price-sensitive headline landed after the last take", () => {
+    const row = baseRow({
+      lastTakeDate: "2026-05-20",
+      recentPriceSensitiveHeadlines: [{ date: "2026-05-25", headline: "ASIC probe" }],
+    });
+    expect(hasNewDevelopment(row)).toBe(true);
+  });
+
+  it("is true on a short-position regime change since the last take", () => {
+    const row = baseRow({ lastTakeDate: "2026-05-20", signals: { ...baseRow().signals, shortPctChange90d: 3.5 } });
+    expect(hasNewDevelopment(row)).toBe(true);
+  });
+
+  it("is true on a fresh director trade after the last take", () => {
+    const row = baseRow({ lastTakeDate: "2026-05-20", signals: { ...baseRow().signals, directorMostRecentDate: "2026-05-28" } });
+    expect(hasNewDevelopment(row)).toBe(true);
+  });
+
+  it("is false when nothing material happened since the last take", () => {
+    expect(hasNewDevelopment(baseRow())).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/editor.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the editor**
+
+`scripts/take-writer/src/editor.ts`:
+
+```typescript
+// Editor agent — the assignment desk. Reads the day's signal board,
+// applies a novelty gate (don't re-cover a stock without a new
+// development), and asks Claude to commission the day's stories with an
+// angle and a tier (take | deep_dive).
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { Client as PgClient } from "pg";
+import { buildSignalBoard, type SignalBoardRow } from "./journalism.js";
+
+export interface Assignment {
+  stockCode: string;
+  angle: string;
+  tier: "take" | "deep_dive";
+  rationale: string;
+}
+
+export interface EditorOptions {
+  poolSize?: number;
+  maxTakes?: number;
+  maxDeepDives?: number;
+  model?: string;
+}
+
+const SHORT_REGIME_CHANGE_PCT = 2.0; // |current - 90d avg| beyond this = regime change
+
+/**
+ * Pure novelty gate. A stock is worth covering if it has never been
+ * covered, OR something material happened after the last take:
+ *  - a price-sensitive headline dated after lastTakeDate
+ *  - a short-position regime change (|shortPctChange90d| >= threshold)
+ *  - a director trade dated after lastTakeDate
+ */
+export function hasNewDevelopment(row: SignalBoardRow): boolean {
+  if (!row.lastTakeDate) return true;
+  const since = row.lastTakeDate;
+  if (row.recentPriceSensitiveHeadlines.some((h) => h.date > since)) return true;
+  if (Math.abs(row.signals.shortPctChange90d ?? 0) >= SHORT_REGIME_CHANGE_PCT) return true;
+  if (row.signals.directorMostRecentDate && row.signals.directorMostRecentDate > since) return true;
+  return false;
+}
+
+const EDITOR_SYSTEM = `You are the editor of Shorted, an ASX short-position
+publication. From the signal board, commission the day's stories. Be
+selective — only stories with a genuine angle a reader would click.
+
+For each story pick:
+- angle: one sharp sentence naming what the story IS (not a headline).
+- tier: "deep_dive" only when there is a rich, multi-thread story worth
+  600-1200 words (a probe with a timeline, a director-vs-data divergence,
+  a sector unwind). Otherwise "take".
+
+Return STRICT JSON: {"assignments":[{"stockCode","angle","tier","rationale"}]}.
+No prose outside the JSON.`;
+
+export async function commissionAssignments(
+  pg: PgClient,
+  opts: EditorOptions = {},
+): Promise<Assignment[]> {
+  const maxTakes = opts.maxTakes ?? 10;
+  const maxDeepDives = opts.maxDeepDives ?? 2;
+  const model = opts.model ?? process.env.EDITOR_MODEL ?? "claude-sonnet-4-6";
+
+  const board = await buildSignalBoard(pg, opts.poolSize ?? 30);
+  const fresh = board.filter(hasNewDevelopment);
+  if (fresh.length === 0) return [];
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY not set");
+  const client = new Anthropic({ apiKey });
+
+  const boardText = fresh.map((r) => {
+    const s = r.signals;
+    return [
+      `${r.stockCode} (${r.name ?? "?"}, ${r.industry ?? "?"})`,
+      `  short ${s.currentShortPct?.toFixed(1)}% (Δ90d ${s.shortPctChange90d?.toFixed(1)}), price 3m ${s.priceChange3m?.toFixed(0)}%, corr ${s.priceShortsCorrelation30d?.toFixed(2)}`,
+      `  news30d ${s.newsArticlesLast30d} (ps ${s.priceSensitiveLast30d}), sentiment ${s.sentimentTrendLast30d}, director net A$${s.directorNetValueLast90d.toFixed(0)}`,
+      `  last covered: ${r.lastTakeDate ?? "never"}; recent price-sensitive: ${r.recentPriceSensitiveHeadlines.map((h) => `${h.date} ${h.headline}`).join(" | ") || "none"}`,
+    ].join("\n");
+  }).join("\n\n");
+
+  const resp = await client.messages.create({
+    model,
+    max_tokens: 2000,
+    system: EDITOR_SYSTEM,
+    messages: [{
+      role: "user",
+      content: `Signal board (${fresh.length} stocks with a new development):\n\n${boardText}\n\nCommission up to ${maxTakes} takes and ${maxDeepDives} deep-dives. Return the JSON now.`,
+    }],
+  });
+
+  const text = resp.content.filter((b): b is Anthropic.TextBlock => b.type === "text").map((b) => b.text).join("");
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return [];
+  let parsed: { assignments?: Assignment[] };
+  try { parsed = JSON.parse(jsonMatch[0]); } catch { return []; }
+  const all = (parsed.assignments ?? []).filter((a) => a.stockCode && (a.tier === "take" || a.tier === "deep_dive"));
+
+  // Enforce caps defensively (the model may over-commission).
+  const deepDives = all.filter((a) => a.tier === "deep_dive").slice(0, maxDeepDives);
+  const takes = all.filter((a) => a.tier === "take").slice(0, maxTakes);
+  return [...deepDives, ...takes].map((a) => ({ ...a, stockCode: a.stockCode.toUpperCase() }));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/editor.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/src/editor.ts scripts/take-writer/src/editor.test.ts
+git commit -m "feat(take-writer): editor agent with novelty gate + tiered assignments"
+```
+
+---
+
+## Task 8: Investigation agent
+
+**Files:**
+- Create: `scripts/take-writer/src/investigator.ts`
+- Test: `scripts/take-writer/src/investigator.test.ts`
+
+The agentic loop is driven by an injected "messages.create"-shaped function so the loop logic (tool dispatch, turn cap, dossier finalisation) is testable without a live API.
+
+- [ ] **Step 1: Write failing tests**
+
+`scripts/take-writer/src/investigator.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { investigate, type MessagesCreate } from "./investigator.js";
+import { CitationLedger } from "./ledger.js";
+
+const assignment = { stockCode: "DRO", angle: "Probe vs shorts", tier: "take" as const, rationale: "x" };
+
+describe("investigate", () => {
+  it("runs a tool round then finalises the dossier from emit_dossier", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [{ id: "1", date: "2026-05-01", source: "S", headline: "Probe opened", url: "https://x/1" }] }) };
+    const create: MessagesCreate = vi.fn()
+      // round 1: call a tool
+      .mockResolvedValueOnce({
+        stop_reason: "tool_use",
+        content: [{ type: "tool_use", id: "t1", name: "search_news", input: { query: "probe" } }],
+      })
+      // round 2: emit the dossier via the emit_dossier tool
+      .mockResolvedValueOnce({
+        stop_reason: "tool_use",
+        content: [{ type: "tool_use", id: "t2", name: "emit_dossier", input: {
+          summary: "ASIC opened a probe; shorts held.",
+          threads: [{ claim: "Probe opened 1 May", evidenceRefIds: ["ref-1"] }],
+          keyNumbers: [{ label: "short %", value: "14%" }],
+        } }],
+      });
+
+    const ledger = new CitationLedger();
+    const dossier = await investigate(create as MessagesCreate, pg, assignment, ledger, { maxTurns: 6, model: "claude-sonnet-4-6" });
+    expect(dossier.summary).toContain("probe");
+    expect(dossier.threads[0]!.evidenceRefIds).toEqual(["ref-1"]);
+    expect(ledger.size()).toBe(1); // search_news registered the source
+    expect((create as any).mock.calls.length).toBe(2);
+  });
+
+  it("finalises a minimal dossier if the turn cap is hit without emit_dossier", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const create: MessagesCreate = vi.fn().mockResolvedValue({
+      stop_reason: "tool_use",
+      content: [{ type: "tool_use", id: "t", name: "align_events", input: {} }],
+    });
+    const ledger = new CitationLedger();
+    const dossier = await investigate(create as MessagesCreate, pg, assignment, ledger, { maxTurns: 2, model: "claude-sonnet-4-6" });
+    expect(dossier.stockCode).toBe("DRO");
+    expect(Array.isArray(dossier.threads)).toBe(true);
+    expect((create as any).mock.calls.length).toBe(2); // stopped at the cap
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/investigator.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the investigator**
+
+`scripts/take-writer/src/investigator.ts`:
+
+```typescript
+// Investigation agent — the agentic core. Given an assignment, it runs
+// Claude in a tool-calling loop over the drill-down tools, registering
+// every retrieved source into the ledger, and finalises a structured
+// Dossier via a special emit_dossier tool. Turn-capped; if the cap is
+// hit before emit_dossier, we finalise with whatever was gathered.
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { Queryable } from "./drilldowns.js";
+import type { CitationLedger } from "./ledger.js";
+import { TOOL_DEFS, dispatchTool } from "./tools.js";
+import type { Assignment } from "./editor.js";
+
+export interface DossierThread { claim: string; evidenceRefIds: string[]; note?: string }
+export interface DossierTimelineItem { date: string; event: string; refIds: string[] }
+export interface DossierKeyNumber { label: string; value: string; refId?: string }
+export interface Dossier {
+  stockCode: string;
+  tier: "take" | "deep_dive";
+  angle: string;
+  summary: string;
+  threads: DossierThread[];
+  timeline?: DossierTimelineItem[];
+  keyNumbers: DossierKeyNumber[];
+}
+
+/** The subset of Anthropic's client.messages.create we depend on. */
+export type MessagesCreate = (body: Anthropic.MessageCreateParamsNonStreaming) => Promise<Anthropic.Message>;
+
+export interface InvestigateOptions {
+  maxTurns?: number;
+  model: string;
+  maxTokens?: number;
+}
+
+const EMIT_DOSSIER_TOOL: Anthropic.Tool = {
+  name: "emit_dossier",
+  description: "Call this ONCE when your investigation is complete to hand off your findings. Cite evidence ONLY by the refIds returned to you by other tools.",
+  input_schema: {
+    type: "object",
+    properties: {
+      summary: { type: "string", description: "2-3 sentence neutral summary of what you found." },
+      threads: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            claim: { type: "string" },
+            evidenceRefIds: { type: "array", items: { type: "string" } },
+            note: { type: "string" },
+          },
+          required: ["claim", "evidenceRefIds"],
+        },
+      },
+      timeline: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { date: { type: "string" }, event: { type: "string" }, refIds: { type: "array", items: { type: "string" } } },
+          required: ["date", "event"],
+        },
+      },
+      keyNumbers: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { label: { type: "string" }, value: { type: "string" }, refId: { type: "string" } },
+          required: ["label", "value"],
+        },
+      },
+    },
+    required: ["summary", "threads", "keyNumbers"],
+  },
+};
+
+function systemPrompt(a: Assignment): string {
+  return `You are an investigative reporter for Shorted (ASX short positions).
+Assignment: ${a.stockCode} — ${a.angle}
+Tier: ${a.tier} (${a.tier === "deep_dive" ? "rich, multi-thread; build a timeline" : "tight, single sharp thread"}).
+
+Investigate using the tools. Drill into spikes, follow peers, align
+director trades to price, pull reported numbers. Every factual claim in
+your dossier MUST be backed by a refId a tool returned to you — do not
+invent sources or numbers. When done, call emit_dossier exactly once.
+Keep it to ${a.tier === "deep_dive" ? "at most 10" : "at most 4"} investigative tool calls before emitting.`;
+}
+
+export async function investigate(
+  create: MessagesCreate,
+  pg: Queryable,
+  assignment: Assignment,
+  ledger: CitationLedger,
+  opts: InvestigateOptions,
+): Promise<Dossier> {
+  const maxTurns = opts.maxTurns ?? (assignment.tier === "deep_dive" ? 14 : 6);
+  const tools = [...TOOL_DEFS, EMIT_DOSSIER_TOOL];
+  const messages: Anthropic.MessageParam[] = [{
+    role: "user",
+    content: `Begin your investigation of ${assignment.stockCode}. Angle: ${assignment.angle}.`,
+  }];
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const resp = await create({
+      model: opts.model,
+      max_tokens: opts.maxTokens ?? 4000,
+      system: systemPrompt(assignment),
+      tools,
+      messages,
+    });
+
+    const toolUses = resp.content.filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use");
+    if (toolUses.length === 0) break; // model stopped without tools
+
+    // Did it emit the dossier? Finalise.
+    const emit = toolUses.find((t) => t.name === "emit_dossier");
+    if (emit) {
+      const input = emit.input as Partial<Dossier>;
+      return finalise(assignment, input);
+    }
+
+    // Otherwise run the requested tools and feed results back.
+    messages.push({ role: "assistant", content: resp.content });
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const t of toolUses) {
+      const result = await dispatchTool(pg, ledger, t.name, t.input as Record<string, unknown>, assignment.stockCode);
+      toolResults.push({ type: "tool_result", tool_use_id: t.id, content: result });
+    }
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  // Turn cap hit without emit_dossier — finalise minimally with what's gathered.
+  return finalise(assignment, {});
+}
+
+function finalise(assignment: Assignment, input: Partial<Dossier>): Dossier {
+  return {
+    stockCode: assignment.stockCode,
+    tier: assignment.tier,
+    angle: assignment.angle,
+    summary: input.summary ?? assignment.angle,
+    threads: input.threads ?? [],
+    timeline: input.timeline,
+    keyNumbers: input.keyNumbers ?? [],
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/investigator.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/take-writer/src/investigator.ts scripts/take-writer/src/investigator.test.ts
+git commit -m "feat(take-writer): claude agentic investigation loop -> dossier"
+```
+
+---
+
+## Task 9: Writer — dossier-aware narrative + WRITER_MODEL
+
+**Files:**
+- Modify: `scripts/take-writer/src/narrative.ts`
+- Test: `scripts/take-writer/src/dossierwriter.test.ts`
+
+Add a `synthesiseFromDossier` path. It builds the writer prompt from the dossier + ledger, calls Gemini (model from `WRITER_MODEL`), then runs `compactCitations` to drop any invented marker and produce the final `Citation[]`. The legacy `synthesiseNarrative` is untouched.
+
+- [ ] **Step 1: Write failing tests for the pure prompt-builder + body assembler**
+
+`scripts/take-writer/src/dossierwriter.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { buildDossierPrompt, assembleTakeBody, assembleDeepDiveBody } from "./narrative.js";
+import { CitationLedger } from "./ledger.js";
+import type { Dossier } from "./investigator.js";
+
+const ledger = new CitationLedger();
+const r1 = ledger.register({ type: "news", url: "https://x/1", source: "S", headline: "Probe opened", date: "2026-05-01" });
+
+const dossier: Dossier = {
+  stockCode: "DRO", tier: "take", angle: "Probe vs shorts",
+  summary: "ASIC opened a probe; shorts held.",
+  threads: [{ claim: `Probe opened on 1 May [${r1}]`, evidenceRefIds: [r1] }],
+  keyNumbers: [{ label: "short %", value: "14%", refId: r1 }],
+};
+
+describe("buildDossierPrompt", () => {
+  it("lists ledger sources by refId so the writer can cite them", () => {
+    const p = buildDossierPrompt(dossier, ledger);
+    expect(p).toContain("ref-1");
+    expect(p).toContain("Probe opened");
+    expect(p).toContain("Probe vs shorts");
+  });
+});
+
+describe("assembleTakeBody", () => {
+  it("joins the four sections with blank lines", () => {
+    const body = assembleTakeBody({ background: "a", recent_events: "b", the_data: "c", outlook: "d" });
+    expect(body).toBe("a\n\nb\n\nc\n\nd");
+  });
+});
+
+describe("assembleDeepDiveBody", () => {
+  it("renders ## headings for each titled section", () => {
+    const body = assembleDeepDiveBody([
+      { heading: "The probe timeline", prose: "para one" },
+      { heading: "What the shorts saw", prose: "para two" },
+    ]);
+    expect(body).toContain("## The probe timeline\n\npara one");
+    expect(body).toContain("## What the shorts saw\n\npara two");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/take-writer && npx vitest run src/dossierwriter.test.ts`
+Expected: FAIL — functions not exported.
+
+- [ ] **Step 3: Add the dossier writer to narrative.ts**
+
+Add these exports to `scripts/take-writer/src/narrative.ts` (keep existing code; add imports for `CitationLedger`, `compactCitations`, and the `Dossier` type at the top):
+
+```typescript
+import { CitationLedger, compactCitations } from "./ledger.js";
+import type { Dossier } from "./investigator.js";
+```
+
+Then append:
+
+```typescript
+// ---- Dossier-aware writer (investigative newsroom) ----
+
+const WRITER_MODEL = () => process.env.WRITER_MODEL ?? "gemini-2.5-flash";
+const WRITER_MODEL_DEEPDIVE = () => process.env.WRITER_MODEL_DEEPDIVE ?? WRITER_MODEL();
+
+/** Build the writer prompt from a dossier + its ledger. The writer may
+ *  only cite the refIds listed here. */
+export function buildDossierPrompt(dossier: Dossier, ledger: CitationLedger): string {
+  const sources: string[] = [];
+  for (let i = 1; ledger.has(`ref-${i}`); i++) {
+    const s = ledger.get(`ref-${i}`)!;
+    sources.push(`[ref-${i}] (${s.date}, ${s.source}, ${s.type}): ${s.headline}`);
+  }
+  const threads = dossier.threads
+    .map((t, i) => `${i + 1}. ${t.claim}${t.note ? ` — ${t.note}` : ""} (evidence: ${t.evidenceRefIds.join(", ") || "none"})`)
+    .join("\n");
+  const numbers = dossier.keyNumbers
+    .map((n) => `- ${n.label}: ${n.value}${n.refId ? ` [${n.refId}]` : ""}`)
+    .join("\n");
+  const timeline = (dossier.timeline ?? [])
+    .map((t) => `- ${t.date}: ${t.event} (${t.refIds.join(", ")})`)
+    .join("\n");
+  return [
+    `Subject: ${dossier.stockCode}`,
+    `Angle: ${dossier.angle}`,
+    `Investigation summary: ${dossier.summary}`,
+    "",
+    "=== FINDINGS (threads) ===",
+    threads || "(none)",
+    "",
+    "=== KEY NUMBERS ===",
+    numbers || "(none)",
+    timeline ? `\n=== TIMELINE ===\n${timeline}` : "",
+    "",
+    "=== CITABLE SOURCES (cite ONLY these refIds, inline as [ref-N]) ===",
+    sources.join("\n") || "(none)",
+  ].join("\n");
+}
+
+export function assembleTakeBody(s: { background: string; recent_events: string; the_data: string; outlook: string }): string {
+  return [s.background, "", s.recent_events, "", s.the_data, "", s.outlook].join("\n");
+}
+
+export function assembleDeepDiveBody(sections: Array<{ heading: string; prose: string }>): string {
+  return sections.map((s) => `## ${s.heading}\n\n${s.prose}`).join("\n\n");
+}
+
+export interface DossierTake {
+  slug: string;
+  headline: string;
+  sentiment: "positive" | "negative" | "neutral";
+  tier: "take" | "deep_dive";
+  bodyMd: string;
+  citations: Citation[];
+  droppedCitations: string[];
+}
+
+const TAKE_DOSSIER_SCHEMA = {
+  type: SchemaType.OBJECT,
+  properties: {
+    headline: { type: SchemaType.STRING },
+    sentiment: { type: SchemaType.STRING, enum: ["positive", "negative", "neutral"] },
+    background: { type: SchemaType.STRING },
+    recent_events: { type: SchemaType.STRING },
+    the_data: { type: SchemaType.STRING },
+    outlook: { type: SchemaType.STRING },
+  },
+  required: ["headline", "sentiment", "background", "recent_events", "the_data", "outlook"],
+};
+
+const DEEPDIVE_DOSSIER_SCHEMA = {
+  type: SchemaType.OBJECT,
+  properties: {
+    headline: { type: SchemaType.STRING },
+    sentiment: { type: SchemaType.STRING, enum: ["positive", "negative", "neutral"] },
+    sections: {
+      type: SchemaType.ARRAY,
+      items: {
+        type: SchemaType.OBJECT,
+        properties: { heading: { type: SchemaType.STRING }, prose: { type: SchemaType.STRING } },
+        required: ["heading", "prose"],
+      },
+    },
+  },
+  required: ["headline", "sentiment", "sections"],
+};
+
+/** Write a tiered Take from a grounded dossier. Cites only ledger refIds;
+ *  compactCitations drops anything invented. */
+export async function synthesiseFromDossier(
+  dossier: Dossier,
+  ledger: CitationLedger,
+  stockCode: string,
+): Promise<DossierTake> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error("GEMINI_API_KEY not set");
+  const ai = new GoogleGenerativeAI(apiKey);
+  const deep = dossier.tier === "deep_dive";
+  const model = ai.getGenerativeModel({
+    model: deep ? WRITER_MODEL_DEEPDIVE() : WRITER_MODEL(),
+    systemInstruction: NARRATIVE_SYSTEM_PROMPT,
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseSchema: deep ? DEEPDIVE_DOSSIER_SCHEMA : TAKE_DOSSIER_SCHEMA,
+      temperature: 0.7,
+      maxOutputTokens: deep ? 16000 : 8000,
+    },
+  });
+
+  const prompt = [
+    buildDossierPrompt(dossier, ledger),
+    "",
+    deep
+      ? "Write a long-form investigation (600-1200 words). Derive 3-5 section headings from the findings. Cite [ref-N] inline wherever a fact comes from a source. Only cite refIds in CITABLE SOURCES."
+      : "Write the four sections (background, recent_events, the_data, outlook). Cite [ref-N] inline. Only cite refIds in CITABLE SOURCES.",
+  ].join("\n");
+
+  let raw = "";
+  let parsed: Record<string, unknown> = {};
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const resp = await model.generateContent(
+      attempt === 1 ? prompt : prompt + `\n\nIMPORTANT: your previous draft used banned terms. Remove every one.`,
+    );
+    raw = resp.response.text();
+    parsed = JSON.parse(raw);
+    const proseForBan = deep
+      ? (parsed.sections as Array<{ prose: string }> ?? []).map((s) => s.prose).join("\n") + "\n" + String(parsed.headline ?? "")
+      : [parsed.background, parsed.recent_events, parsed.the_data, parsed.outlook, parsed.headline].join("\n");
+    if (findBanned(proseForBan).length === 0) break;
+  }
+
+  const rawBody = deep
+    ? assembleDeepDiveBody((parsed.sections as Array<{ heading: string; prose: string }>) ?? [])
+    : assembleTakeBody({
+        background: String(parsed.background ?? ""),
+        recent_events: String(parsed.recent_events ?? ""),
+        the_data: String(parsed.the_data ?? ""),
+        outlook: String(parsed.outlook ?? ""),
+      });
+
+  const { body, citations, dropped } = compactCitations(rawBody, ledger);
+
+  // Slug pass (reuse the existing low-temp slug model behaviour).
+  const slugModel = ai.getGenerativeModel({ model: WRITER_MODEL(), generationConfig: { temperature: 0.2, maxOutputTokens: 500 } });
+  const slugResp = await slugModel.generateContent(
+    SLUG_PROMPT.replace("{{HEADLINE}}", String(parsed.headline ?? "")).replace("{{STOCK_CODE}}", stockCode),
+  );
+  const slug = slugResp.response.text().trim().toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, "").replace(/\s+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").slice(0, 80);
+
+  return {
+    slug,
+    headline: String(parsed.headline ?? ""),
+    sentiment: (parsed.sentiment as DossierTake["sentiment"]) ?? "neutral",
+    tier: dossier.tier,
+    bodyMd: body,
+    citations,
+    droppedCitations: dropped,
+  };
+}
+```
+
+> Note: `SLUG_PROMPT` is currently a module-local const in `narrative.ts` (defined at line ~146) — it is already in scope for this appended code. `findBanned`, `NARRATIVE_SYSTEM_PROMPT`, `SchemaType`, `GoogleGenerativeAI`, and `Citation` are all already defined/imported in the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/take-writer && npx vitest run src/dossierwriter.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Typecheck the package**
+
+Run: `cd scripts/take-writer && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/take-writer/src/narrative.ts scripts/take-writer/src/dossierwriter.test.ts
+git commit -m "feat(take-writer): dossier-aware tiered writer (WRITER_MODEL), ledger-grounded citations"
+```
+
+---
+
+## Task 10: Daily newsroom pipeline + validate-before-insert
+
+**Files:**
+- Modify: `scripts/take-writer/src/newsroom.ts`
+- Test: `scripts/take-writer/src/publishguard.test.ts`
+
+`runNewsroomDaily` wires editor → investigator → writer, applies model tiering, caps, and cost logging, and gates publishing through `shouldHoldAsDraft`.
+
+- [ ] **Step 1: Write failing test for the publish guard**
+
+`scripts/take-writer/src/publishguard.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { shouldHoldAsDraft } from "./newsroom.js";
+
+describe("shouldHoldAsDraft", () => {
+  it("holds when there are dropped (dangling) citations", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: ["ref-9"], citations: [{ refId: "ref-1" } as any] })).toBe(true);
+  });
+  it("holds a deep_dive with zero citations (ungrounded long-form)", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: [], citations: [], tier: "deep_dive" } as any)).toBe(true);
+  });
+  it("allows a clean grounded take through", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: [], citations: [{ refId: "ref-1" } as any], tier: "take" } as any)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/take-writer && npx vitest run src/publishguard.test.ts`
+Expected: FAIL — `shouldHoldAsDraft` not exported.
+
+- [ ] **Step 3: Add the guard + daily pipeline to newsroom.ts**
+
+Add imports near the top of `scripts/take-writer/src/newsroom.ts`:
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import { commissionAssignments, type Assignment } from "./editor.js";
+import { investigate } from "./investigator.js";
+import { synthesiseFromDossier, type DossierTake } from "./narrative.js";
+import { CitationLedger } from "./ledger.js";
+```
+
+Add the guard (exported, pure):
+
+```typescript
+/** Hold a piece as a draft (don't auto-publish) when grounding is weak:
+ *  any dangling citation the writer invented, or a deep-dive with no
+ *  citations at all. Never auto-publish ungrounded claims about a named
+ *  company. */
+export function shouldHoldAsDraft(t: { droppedCitations: string[]; citations: unknown[]; tier?: "take" | "deep_dive" }): boolean {
+  if (t.droppedCitations.length > 0) return true;
+  if (t.tier === "deep_dive" && t.citations.length === 0) return true;
+  return false;
+}
+```
+
+Add a tier-aware insert (extends the existing `insertTake`, adds `tier`):
+
+```typescript
+async function insertDossierTake(
+  pg: PgClient,
+  take: DossierTake,
+  stockCode: string,
+  heroUrl: string | null,
+  inlineImages: InlineImageRow[],
+  publish: boolean,
+  writerModel: string,
+): Promise<void> {
+  const publishedClause = publish ? "NOW()" : "NULL";
+  await pg.query(
+    `INSERT INTO editorial_takes (
+       slug, headline, stock_code, body_md, sentiment, word_count, model, tier,
+       citations, hero_image_url, inline_images, published_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11::jsonb,${publishedClause})
+     ON CONFLICT (slug) DO UPDATE SET
+       headline=EXCLUDED.headline, body_md=EXCLUDED.body_md, tier=EXCLUDED.tier,
+       sentiment=EXCLUDED.sentiment, word_count=EXCLUDED.word_count,
+       citations=EXCLUDED.citations,
+       hero_image_url=COALESCE(EXCLUDED.hero_image_url, editorial_takes.hero_image_url),
+       inline_images=CASE WHEN jsonb_array_length(EXCLUDED.inline_images) > 0
+                          THEN EXCLUDED.inline_images ELSE editorial_takes.inline_images END,
+       updated_at=NOW()`,
+    [
+      take.slug, take.headline, stockCode, take.bodyMd, take.sentiment,
+      take.bodyMd.split(/\s+/).filter(Boolean).length, writerModel, take.tier,
+      JSON.stringify(take.citations), heroUrl, JSON.stringify(inlineImages),
+    ],
+  );
+}
+```
+
+Add the daily runner:
+
+```typescript
+export interface DailyOptions {
+  poolSize?: number;
+  maxTakes?: number;
+  maxDeepDives?: number;
+  autoPublish: boolean;
+  withImages: boolean;
+}
+
+export async function runNewsroomDaily(opts: DailyOptions): Promise<void> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error("DATABASE_URL not set");
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (!anthropicKey) throw new Error("ANTHROPIC_API_KEY not set");
+
+  const takeModel = process.env.INVESTIGATOR_MODEL_TAKE ?? "claude-sonnet-4-6";
+  const deepModel = process.env.INVESTIGATOR_MODEL_DEEPDIVE ?? "claude-opus-4-8";
+  const maxTurnsTake = Number(process.env.MAX_TURNS_TAKE ?? 6);
+  const maxTurnsDeep = Number(process.env.MAX_TURNS_DEEPDIVE ?? 14);
+
+  const pg = new PgClient({ connectionString: dbUrl });
+  await pg.connect();
+  const client = new Anthropic({ apiKey: anthropicKey });
+  const create = (body: Anthropic.MessageCreateParamsNonStreaming) => client.messages.create(body) as Promise<Anthropic.Message>;
+
+  let openai: OpenAI | null = null;
+  let storage: Storage | null = null;
+  if (opts.withImages) {
+    const key = process.env.OPENAI_API_KEY;
+    if (!key) throw new Error("OPENAI_API_KEY not set (required for --with-images)");
+    openai = new OpenAI({ apiKey: key });
+    storage = new Storage();
+  }
+
+  let totalCost = 0;
+  let published = 0, drafted = 0, held = 0, failed = 0;
+
+  try {
+    console.log(`\n[newsroom-daily] commissioning (pool ${opts.poolSize ?? 30}, ≤${opts.maxTakes ?? 10} takes, ≤${opts.maxDeepDives ?? 2} deep-dives)…`);
+    const assignments = await commissionAssignments(pg, {
+      poolSize: opts.poolSize,
+      maxTakes: opts.maxTakes,
+      maxDeepDives: opts.maxDeepDives,
+    });
+    if (assignments.length === 0) {
+      console.log("[newsroom-daily] nothing new to cover today.");
+      return;
+    }
+    console.log(`[newsroom-daily] ${assignments.length} assignments:`);
+    for (const a of assignments) console.log(`  - ${a.stockCode} [${a.tier}] ${a.angle}`);
+
+    for (const [i, a] of assignments.entries()) {
+      const tag = `[${i + 1}/${assignments.length}] ${a.stockCode}`;
+      const t0 = Date.now();
+      try {
+        const ledger = new CitationLedger();
+        const dossier = await investigate(create, pg, a, ledger, {
+          model: a.tier === "deep_dive" ? deepModel : takeModel,
+          maxTurns: a.tier === "deep_dive" ? maxTurnsDeep : maxTurnsTake,
+        });
+        const writerModel = a.tier === "deep_dive"
+          ? (process.env.WRITER_MODEL_DEEPDIVE ?? process.env.WRITER_MODEL ?? "gemini-2.5-flash")
+          : (process.env.WRITER_MODEL ?? "gemini-2.5-flash");
+        const take = await synthesiseFromDossier(dossier, ledger, a.stockCode);
+        console.log(`${tag} → "${take.headline}" (${take.citations.length} cites, ${take.droppedCitations.length} dropped)`);
+
+        const hold = shouldHoldAsDraft(take);
+        if (hold && opts.autoPublish) {
+          console.warn(`${tag}   ⚠ holding as draft (grounding weak: dropped ${take.droppedCitations.join(",") || "none"})`);
+        }
+        const publishThis = opts.autoPublish && !hold;
+
+        let heroUrl: string | null = null;
+        let inlineImages: InlineImageRow[] = [];
+        if (opts.withImages && openai && storage) {
+          // Reuse the existing image helpers — they take an AgendaCandidate
+          // shape; build the minimal shape they read (stockCode, industry).
+          const candidate = { stockCode: a.stockCode, industry: null } as unknown as AgendaCandidate;
+          const narrativeShim = { slug: take.slug, headline: take.headline } as unknown as NarrativeTake;
+          const img = await generateHero(openai, storage, candidate, narrativeShim);
+          heroUrl = img.url; totalCost += img.costUsd;
+          const inl = await generateInlineImages(openai, storage, candidate, narrativeShim, 2);
+          inlineImages = inl.images; totalCost += inl.costUsd;
+        }
+
+        await insertDossierTake(pg, take, a.stockCode, heroUrl, inlineImages, publishThis, writerModel);
+        if (publishThis) published++;
+        else if (hold) held++;
+        else drafted++;
+        console.log(`${tag}   ✓ ${publishThis ? "published" : "draft"} /news/${take.slug} (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+      } catch (err) {
+        failed++;
+        console.log(`${tag}   ✗ ${String((err as Error).message ?? err).slice(0, 160)}`);
+      }
+    }
+  } finally {
+    await pg.end();
+  }
+
+  console.log("\n=== Newsroom-daily briefing ===");
+  console.log(`  published: ${published}  drafted: ${drafted}  held(weak grounding): ${held}  failed: ${failed}`);
+  console.log(`  image cost: $${totalCost.toFixed(3)} (LLM token cost logged by providers)`);
+}
+```
+
+> The image helpers (`generateHero`, `generateInlineImages`) read only `candidate.stockCode`, `candidate.industry`, `take.slug`, and `take.headline` — the shims above satisfy that. If a future change makes them read more fields, widen the shims.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/take-writer && npx vitest run src/publishguard.test.ts`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd scripts/take-writer && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/take-writer/src/newsroom.ts scripts/take-writer/src/publishguard.test.ts
+git commit -m "feat(take-writer): daily editor->investigator->writer pipeline + publish guard"
+```
+
+---
+
+## Task 11: CLI command `newsroom-daily`
+
+**Files:**
+- Modify: `scripts/take-writer/src/index.ts`
+
+- [ ] **Step 1: Add the import**
+
+In `scripts/take-writer/src/index.ts`, change the newsroom import to also pull the daily runner:
+
+```typescript
+import { runNewsroom } from "./newsroom.js";
+import { runNewsroomDaily } from "./newsroom.js";
+```
+
+- [ ] **Step 2: Add the command to the switch**
+
+In `main()`'s `switch (args.command)`, add a case after the existing `newsroom` case:
+
+```typescript
+    case "newsroom-daily": {
+      const autoPublish = args.autoPublish ?? false;
+      const withImages = args.withImages ?? (autoPublish && !args.noImages);
+      await runNewsroomDaily({
+        poolSize: args.poolSize,
+        maxTakes: args.topN ?? Number(process.env.MAX_TAKES_PER_DAY ?? 10),
+        maxDeepDives: Number(process.env.MAX_DEEPDIVES_PER_DAY ?? 2),
+        autoPublish,
+        withImages,
+      });
+      break;
+    }
+```
+
+- [ ] **Step 3: Document it in `help()`**
+
+In the `help()` Commands block, add the line after `newsroom`:
+
+```
+  newsroom-daily  Investigative daily run: editor → agentic investigation → tiered writer
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd scripts/take-writer && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Verify help lists the command**
+
+Run: `cd scripts/take-writer && npx tsx src/index.ts --help`
+Expected: output includes `newsroom-daily`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/take-writer/src/index.ts
+git commit -m "feat(take-writer): add newsroom-daily CLI command"
+```
+
+---
+
+## Task 12: Terraform — daily Cloud Run Job + Scheduler
+
+**Files:**
+- Create: `terraform/modules/newsroom-job/main.tf`
+- Create: `terraform/modules/newsroom-job/variables.tf`
+- Create: `terraform/modules/newsroom-job/outputs.tf`
+- Modify: `terraform/environments/dev/main.tf`
+
+Follow the existing Cloud Run Job pattern (see project memory: module under `terraform/modules/`, SA + Secret Manager IAM, scheduler in `australia-southeast1`, `min_instance_count` not set on Jobs).
+
+- [ ] **Step 1: variables.tf**
+
+`terraform/modules/newsroom-job/variables.tf`:
+
+```hcl
+variable "project_id" { type = string }
+variable "region" { type = string, default = "australia-southeast2" }
+variable "scheduler_region" { type = string, default = "australia-southeast1" }
+variable "image" { type = string, description = "Container image for the take-writer newsroom job" }
+variable "schedule" { type = string, default = "0 20 * * *", description = "Cron (UTC) — default 06:00 AEST" }
+variable "database_url_secret" { type = string, description = "Secret Manager secret id holding DATABASE_URL" }
+variable "anthropic_key_secret" { type = string }
+variable "gemini_key_secret" { type = string }
+variable "openai_key_secret" { type = string }
+variable "gcs_logo_bucket" { type = string, default = "shorted-company-logos" }
+variable "max_takes_per_day" { type = string, default = "10" }
+variable "max_deepdives_per_day" { type = string, default = "2" }
+```
+
+- [ ] **Step 2: main.tf**
+
+`terraform/modules/newsroom-job/main.tf`:
+
+```hcl
+resource "google_service_account" "newsroom" {
+  account_id   = "newsroom-job"
+  display_name = "Newsroom daily job"
+  project      = var.project_id
+}
+
+locals {
+  secret_ids = [
+    var.database_url_secret,
+    var.anthropic_key_secret,
+    var.gemini_key_secret,
+    var.openai_key_secret,
+  ]
+}
+
+resource "google_secret_manager_secret_iam_member" "newsroom_secrets" {
+  for_each  = toset(local.secret_ids)
+  project   = var.project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.newsroom.email}"
+}
+
+resource "google_storage_bucket_iam_member" "newsroom_gcs" {
+  bucket = var.gcs_logo_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.newsroom.email}"
+}
+
+resource "google_cloud_run_v2_job" "newsroom" {
+  name     = "newsroom-daily"
+  location = var.region
+  project  = var.project_id
+
+  template {
+    template {
+      service_account = google_service_account.newsroom.email
+      timeout         = "1800s"
+      max_retries     = 0
+
+      containers {
+        image = var.image
+        # Entry: tsx src/index.ts newsroom-daily --auto-publish --with-images
+        args = ["newsroom-daily", "--auto-publish", "--with-images"]
+
+        resources {
+          limits = { cpu = "2", memory = "2Gi" }
+        }
+
+        env {
+          name  = "GCS_LOGO_BUCKET"
+          value = var.gcs_logo_bucket
+        }
+        env {
+          name  = "MAX_TAKES_PER_DAY"
+          value = var.max_takes_per_day
+        }
+        env {
+          name  = "MAX_DEEPDIVES_PER_DAY"
+          value = var.max_deepdives_per_day
+        }
+        dynamic "env" {
+          for_each = {
+            DATABASE_URL      = var.database_url_secret
+            ANTHROPIC_API_KEY = var.anthropic_key_secret
+            GEMINI_API_KEY    = var.gemini_key_secret
+            OPENAI_API_KEY    = var.openai_key_secret
+          }
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+# Cloud Scheduler must live in australia-southeast1 (no southeast2 scheduler).
+resource "google_service_account" "scheduler" {
+  account_id   = "newsroom-scheduler"
+  display_name = "Newsroom scheduler invoker"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke" {
+  name     = google_cloud_run_v2_job.newsroom.name
+  location = var.region
+  project  = var.project_id
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+resource "google_cloud_scheduler_job" "newsroom_daily" {
+  name     = "newsroom-daily"
+  project  = var.project_id
+  region   = var.scheduler_region
+  schedule = var.schedule
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.newsroom.name}:run"
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+}
+```
+
+- [ ] **Step 3: outputs.tf**
+
+`terraform/modules/newsroom-job/outputs.tf`:
+
+```hcl
+output "job_name" { value = google_cloud_run_v2_job.newsroom.name }
+output "service_account_email" { value = google_service_account.newsroom.email }
+```
+
+- [ ] **Step 4: Wire into the dev environment**
+
+Append to `terraform/environments/dev/main.tf` (adjust secret ids/image var to match the env's existing naming — grep the file for an existing `google_secret_manager_secret` or job module to copy the exact secret resource ids):
+
+```hcl
+module "newsroom_job" {
+  source = "../../modules/newsroom-job"
+
+  project_id           = var.project_id
+  image                = "${var.region}-docker.pkg.dev/${var.project_id}/shorted/take-writer:latest"
+  database_url_secret  = "DATABASE_URL"
+  anthropic_key_secret = "ANTHROPIC_API_KEY"
+  gemini_key_secret    = "GEMINI_API_KEY"
+  openai_key_secret    = "OPENAI_API_KEY"
+}
+```
+
+- [ ] **Step 5: Validate the module formatting**
+
+Run: `cd terraform/modules/newsroom-job && terraform fmt && terraform validate || echo "validate needs 'terraform init' + GCP creds — fmt is the local gate"`
+Expected: `terraform fmt` rewrites nothing (or formats cleanly); validate may require init/creds per project memory — fmt passing is the local gate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add terraform/modules/newsroom-job/ terraform/environments/dev/main.tf
+git commit -m "feat(infra): daily newsroom Cloud Run Job + scheduler (southeast1)"
+```
+
+> **Manual prerequisite (note for the operator, not a code step):** create the `ANTHROPIC_API_KEY` secret in Secret Manager before `terraform apply`. The `take-writer:latest` image must be built/pushed (the job's Dockerfile/CI is an existing-pattern follow-up if `scripts/take-writer` isn't yet containerised — flag to the user; out of scope for this plan if no Dockerfile exists).
+
+---
+
+## Task 13: End-to-end dry run + full test suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `cd scripts/take-writer && npm test`
+Expected: all test files pass (ledger, drilldowns, tools, signalboard, editor, investigator, dossierwriter, publishguard).
+
+- [ ] **Step 2: Typecheck the whole package**
+
+Run: `cd scripts/take-writer && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Live dry run against the dev DB (drafts, no publish, no images)**
+
+Requires `DATABASE_URL`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` in the repo-root `.env`. Run:
+
+`cd scripts/take-writer && npx tsx src/index.ts newsroom-daily --top=2 --no-images`
+Expected: editor commissions ≤2 assignments; each investigates (tool calls logged) and drafts a Take; briefing prints `drafted: N`. No rows published (published=0).
+
+- [ ] **Step 4: Inspect a drafted row + verify grounding**
+
+Run:
+```bash
+psql postgresql://admin:password@localhost:5438/shorts -c \
+  "SELECT slug, tier, jsonb_array_length(citations) AS cites, word_count FROM editorial_takes ORDER BY created_at DESC LIMIT 2;"
+```
+Expected: rows with `tier` set, `cites >= 1`, sensible `word_count`. Spot-check one body: every `[ref-N]` in `body_md` has a matching entry in `citations` (the compaction guarantee).
+
+- [ ] **Step 5: Commit any fixes found during the dry run**
+
+If the dry run surfaced issues, fix them, re-run steps 1-4, then commit:
+
+```bash
+git add -A
+git commit -m "fix(take-writer): newsroom-daily dry-run fixes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Editor agent + novelty gate → Task 7 ✓
+- Agentic investigation loop with data tools → Tasks 4, 5, 8 ✓
+- Incremental drill-downs (not re-fetches) → Task 4 ✓
+- Citation ledger + writer-cites-only-retrieved + validate-before-insert → Tasks 3, 9, 10 ✓
+- Tiered output (take vs deep_dive) → Tasks 7, 9 ✓
+- Writer stays Gemini, `WRITER_MODEL` configurable + `gemini-3.5-preview` opt-in → Task 9 ✓
+- Model tiering (Sonnet editor/take, Opus deep-dive) → Task 10 ✓
+- Cost caps (turns, stories, model tier) → Tasks 7, 8, 10, 11 ✓
+- Schema `tier` column → Task 2 ✓
+- Scheduling (Cloud Run Job + Scheduler southeast1, no min-instance) → Task 12 ✓
+- Existing image-gen + draft/publish/tweet pipeline reused → Task 10 ✓
+- Out of scope: frontend rich rendering (SP2) — correctly absent ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; tests have real assertions.
+
+**Type consistency:** `Assignment` defined in `editor.ts`, imported by `investigator.ts`/`newsroom.ts`. `Dossier` defined in `investigator.ts`, imported by `narrative.ts`. `LedgerSource`/`CitationLedger`/`compactCitations` in `ledger.ts`. `Citation` reused from `narrative.ts` (type `"news"|"trade"|"data"|"report"` — ledger maps `"director"`→`"trade"`, verified in Task 3 impl). `Queryable` in `drilldowns.ts` reused by `tools.ts`/`investigator.ts`. `DossierTake` defined in `narrative.ts`, consumed in `newsroom.ts`. Function names consistent: `commissionAssignments`, `investigate`, `synthesiseFromDossier`, `compactCitations`, `shouldHoldAsDraft`, `buildSignalBoard`, `lastTakeDateForStock`.
+
+**Known follow-ups flagged (not gaps):** containerising `scripts/take-writer` (Dockerfile/CI) for the Cloud Run Job image, and creating the `ANTHROPIC_API_KEY` secret — both noted in Task 12 as operator prerequisites.

--- a/docs/superpowers/specs/2026-05-30-investigative-newsroom-design.md
+++ b/docs/superpowers/specs/2026-05-30-investigative-newsroom-design.md
@@ -1,0 +1,170 @@
+# Investigative Newsroom Engine — Design Spec
+
+**Date:** 2026-05-30
+**Status:** Approved design, pre-implementation
+**Scope:** Sub-project 1 of 2 (engine). Sub-project 2 (rich frontend rendering) is a follow-on spec.
+
+## Goal
+
+Turn the `scripts/take-writer/` suite from a fast, shallow single-LLM-call generator into a daily **investigative newsroom**: an editor commissions stories from the day's data, agentic investigators gather evidence through live data tools, and the tuned Shorted voice writes grounded, citation-backed pieces. Tiered output — most stories are tight 4-section Takes, 1–2 per day are promoted to long-form deep-dive investigations.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Investigation mechanism | Agentic loop with live data tools (multi-turn, plans an angle then queries) |
+| Cadence | Daily editorial run (no event hotline in SP1) |
+| Output shape | Tiered: short 4-section Takes + 1–2 promoted long-form deep-dives |
+| Investigation/reasoning model | Claude Sonnet for editor + Takes; Claude Opus for deep-dives |
+| Writer model | **Gemini 2.5 stays** — keeps the tuned voice + banned-phrase calibration |
+| Cost posture | Strongest reasoning only where depth matters; hard turn/token/story caps |
+
+## Why this shape
+
+- **`scripts/take-writer/` already owns the editorial domain** — voice/persona (`persona.ts`, `narrative.ts`), the data bundle (`journalism.ts` `buildReport`), citation renumbering, OpenAI image generation, and the `editorial_takes` insert + draft/publish/tweet pipeline. We extend it rather than rebuild.
+- **Claude investigates → hands a structured findings dossier + citation ledger to Gemini → Gemini writes.** This split puts the strongest tool-use/reasoning where it matters while keeping the final prose on the model the voice was calibrated against. No voice re-tune required.
+- **Direct DB drill-downs, not the prod HTTP API.** A batch job hitting Postgres directly avoids the Cloudflare WAF bot-protection that bursting >20 req/min to `api.shorted.com.au` triggers (see project memory). `journalism.ts` already queries pg directly.
+
+## Architecture
+
+Daily Cloud Run Job runs three agent stages in sequence:
+
+```
+                    ┌─────────────────────────────────────────────┐
+  signal board ───▶ │ EDITOR (Claude Sonnet)                       │
+  + last-take/stock │  rank → novelty-gate → assignment desk       │
+                    │  [{code, angle, tier: take|deep_dive}, …]    │
+                    └───────────────────┬─────────────────────────┘
+                                        │ per assignment
+                    ┌───────────────────▼─────────────────────────┐
+  data tools ◀────▶ │ INVESTIGATOR (Sonnet=take / Opus=deep_dive)  │
+  (drill-downs)     │  agentic tool loop, turn-capped              │
+                    │  → findings dossier + citation ledger        │
+                    └───────────────────┬─────────────────────────┘
+                                        │ dossier + ledger
+                    ┌───────────────────▼─────────────────────────┐
+                    │ WRITER (Gemini 2.5 — tuned voice)            │
+                    │  dossier → prose, cites by ledger refId only │
+                    └───────────────────┬─────────────────────────┘
+                                        │
+   VALIDATE (drop any citation not in ledger) → IMAGES (OpenAI, existing)
+                                        │
+   INSERT editorial_takes (tier, body_md, citations) → existing publish/tweet queue
+```
+
+### Stage 1 — Editor agent (Claude Sonnet)
+
+**Input:** the day's signal board (per-stock computed signals already produced by `journalism.ts`: short slopes 7/30/90d, short% change, price changes 1/3/6/12m, price↔shorts correlation, news counts, sentiment trend, director-trade net value, peer-relative short%), plus the **most recent take per stock** (queried from `editorial_takes`).
+
+**Output:** an *assignment desk* — a ranked list of story assignments, each `{ stockCode, angle, tier: "take" | "deep_dive", rationale }`.
+
+**Novelty gate (load-bearing):** the editor commissions a story for a stock **only if there is a material new development since that stock's last take** — new price-sensitive news, a short-position regime change (slope/level shift beyond a threshold), or a new director trade. Stocks with no new development since last coverage are skipped. This prevents day-3 duplicate slop.
+
+**Caps:** at most `MAX_TAKES_PER_DAY` (default 10) Takes and `MAX_DEEPDIVES_PER_DAY` (default 2) deep-dives commissioned per run.
+
+### Stage 2 — Investigation agent (Claude; Sonnet for Takes, Opus for deep-dives)
+
+An agentic tool-calling loop. Given the assignment's angle + tier, the agent calls data tools to gather evidence, builds a **findings dossier**, and registers every retrieved source in a **citation ledger**. The loop is **turn-capped** (`MAX_TURNS_TAKE` default 6, `MAX_TURNS_DEEPDIVE` default 14) and **token-budgeted** per investigation; on cap it must finalize the dossier with what it has.
+
+**Data tools (the "investigation skill").** Thin TypeScript functions over `journalism.ts`'s existing pg queries, exposed as a Claude tool registry. **Incremental drill-downs, not bulk re-fetches** — the agent already receives the aggregated bundle summary in its opening context; tools zoom in:
+
+| Tool | Returns |
+|---|---|
+| `zoom_window(code, date, days)` | short% + price + news + director trades in a ±`days` window around a date (e.g. the 3 days around a spike) |
+| `follow_peer(code, peerCode)` | a named peer's short/price series for divergence comparison |
+| `report_line(code, metric)` | one financial-report line (revenue, EBITDA, EPS, guidance, cash flow, net profit) from `financial_report_extractions` |
+| `align_events(code)` | timeline aligning director-trade dates against price/short moves |
+| `news_detail(articleId)` | full record for one `news_articles` row (headline, summary, sentiment, url, date) |
+| `search_news(query, code?)` | keyword search across recent `news_articles` |
+
+Each tool returns records carrying a **stable source ID** (`news_articles.id`, report extraction id, director-trade announcement url). The agent's harness appends each newly-seen source to the citation ledger as `{ refId, type: "news"|"report"|"director", url, source, headline, date }`.
+
+**Findings dossier (handoff structure):** a JSON object the writer consumes —
+```
+{
+  stockCode, tier, angle,
+  threads: [ { claim, evidenceRefIds: [refId, …], note } ],
+  timeline?: [ { date, event, refIds } ],   // deep-dives
+  keyNumbers: [ { label, value, refId } ],
+  ledger: [ { refId, type, url, source, headline, date } ]
+}
+```
+
+### Stage 3 — Writer (Gemini 2.5, existing voice)
+
+Consumes the dossier and writes the body in the Shorted voice via the existing `narrative.ts` machinery (system prompt, banned-phrase post-validation, slug generation).
+
+- **Take tier:** the existing tight 4-section structure (background / recent events / the data / outlook).
+- **Deep-dive tier:** long-form, variable markdown headings the writer derives from the dossier `threads`/`timeline` (e.g. `## The probe timeline`, `## What the shorts saw first`). 600–1200 words.
+
+**Hard grounding rule:** the writer is instructed to make factual claims only from the dossier and to cite **only by ledger `refId`**. It may not introduce a `[ref-N]` for a source not in the ledger.
+
+### Stage 4 — Validate, image, insert
+
+- **Validate-before-insert:** parse the written body's citation markers; drop/flag any marker whose `refId` is not in the ledger. If a piece has dangling citations above a threshold, it is held as a draft and logged rather than auto-published — never publish fabricated sources.
+- **Citation renumbering:** reuse the existing source-order renumber so rendered `[ref-N]` are contiguous; persist the unified `citations` JSONB (existing column from migration 000037).
+- **Images:** unchanged — existing OpenAI `gpt-image` hero + inline image generation (`newsroom.ts`).
+- **Insert:** into `editorial_takes` with the new `tier` column, `body_md`, `citations`, `model` set to the writer model. `published_at` stays NULL (existing admin/auto-publish queue and twitter bot pipeline unchanged).
+
+## Schema change
+
+**Migration 000038** (`000038_editorial_takes_tier.up.sql` / `.down.sql`):
+```sql
+ALTER TABLE editorial_takes
+  ADD COLUMN IF NOT EXISTS tier VARCHAR(20) NOT NULL DEFAULT 'take';
+-- allowed: 'take' | 'deep_dive'
+```
+Down migration drops the column. No other schema change — `body_md`, `citations` (JSONB), `hero_image_url`, `inline_images`, `model`, `word_count` all already exist.
+
+## Cost controls
+
+- **Model tiering:** Sonnet for editor + Take investigations; Opus only for the ≤2 deep-dives/day.
+- **Turn caps:** `MAX_TURNS_TAKE`=6, `MAX_TURNS_DEEPDIVE`=14.
+- **Story caps:** `MAX_TAKES_PER_DAY`=10, `MAX_DEEPDIVES_PER_DAY`=2.
+- **Incremental tools** avoid re-sending the full 365-day series each turn.
+- **Per-run cost logging:** total input/output tokens + model breakdown logged at end of run for the Cost Guardian to observe.
+- Rough expected envelope: **~$2–5 per daily run** at these caps.
+
+All caps are env-configurable so the run can be tuned or throttled without redeploy.
+
+## Scheduling / infra
+
+- New Cloud Run **Job** packaging `scripts/take-writer/` with a `newsroom-daily` entrypoint (extends the existing `newsroom` command).
+- **Cloud Scheduler** trigger, daily, region `australia-southeast1` (scheduler limitation — see project memory), invoking the job.
+- `min_instance_count = 0` (Jobs are run-to-completion; honors the cost guardrail rule).
+- New terraform module under `terraform/modules/` following the existing Cloud Run Job pattern (service account + Secret Manager IAM for `DATABASE_URL`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, GCS bucket), referenced from `terraform/environments/dev/main.tf`.
+- Secrets: add `ANTHROPIC_API_KEY` to Secret Manager (new). `@anthropic-ai/sdk` added to `scripts/take-writer/package.json` (currently only `@google/generative-ai` + `openai`).
+
+## New / changed files
+
+| File | Change |
+|---|---|
+| `scripts/take-writer/src/tools.ts` | **New.** Data-tool registry + dispatch over `journalism.ts` queries; citation-ledger accumulation. |
+| `scripts/take-writer/src/investigator.ts` | **New.** Claude agentic tool-calling loop → findings dossier. Turn/token caps. |
+| `scripts/take-writer/src/editor.ts` | **New.** Claude editor: signal board → novelty gate → assignment desk. |
+| `scripts/take-writer/src/journalism.ts` | Extend: expose existing internal queries as tool-callable drill-down functions; add "last take per stock" + signal-board helpers. |
+| `scripts/take-writer/src/narrative.ts` | Extend: accept a dossier; deep-dive long-form prompt path; ledger-`refId`-only citation instruction. |
+| `scripts/take-writer/src/newsroom.ts` | Rewire `runNewsroom` to the editor→investigator→writer pipeline; `newsroom-daily` entrypoint. |
+| `scripts/take-writer/src/index.ts` | Add `newsroom-daily` command + validate-before-insert step. |
+| `scripts/take-writer/package.json` | Add `@anthropic-ai/sdk`. |
+| `services/migrations/000038_editorial_takes_tier.{up,down}.sql` | **New.** `tier` column. |
+| `terraform/modules/newsroom-job/` | **New.** Cloud Run Job + Scheduler + IAM. |
+| `terraform/environments/dev/main.tf` | Reference the new module. |
+
+## Explicitly out of scope (→ Sub-project 2)
+
+- Tier-aware frontend layout, long-form heading treatment, embedded Visx charts/tables, deep-dive page design. SP1's long-form `body_md` renders acceptably in today's `TakeBody` via markdown headings.
+- Event-triggered / near-real-time hotline (SP1 is daily only).
+- Cross-stock comparative pieces beyond single-stock peer context.
+- Backend Go read API changes for `tier` (frontend can ignore the column until SP2).
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Cost overrun on agentic loop | Model tiering + turn/token/story caps, all env-configurable; per-run cost logging |
+| Hallucinated facts/citations about named public companies (defamation / false-market risk) | Citation ledger + writer cites by `refId` only + validate-before-insert holds drafts with dangling citations |
+| Voice drift | Writer stays on Gemini 2.5 with existing banned-phrase validation — no model swap on prose |
+| Daily duplicate coverage | Editor novelty gate against last take per stock |
+| WAF rate-limiting | Tools hit Postgres directly, not the prod HTTP API |
+| Investigator stalls / never finalizes | Turn cap forces dossier finalization with evidence gathered so far |

--- a/docs/superpowers/specs/2026-05-30-investigative-newsroom-design.md
+++ b/docs/superpowers/specs/2026-05-30-investigative-newsroom-design.md
@@ -90,9 +90,11 @@ Each tool returns records carrying a **stable source ID** (`news_articles.id`, r
 }
 ```
 
-### Stage 3 — Writer (Gemini 2.5, existing voice)
+### Stage 3 — Writer (Gemini, existing voice)
 
 Consumes the dossier and writes the body in the Shorted voice via the existing `narrative.ts` machinery (system prompt, banned-phrase post-validation, slug generation).
+
+**Writer model is env-configurable** (`WRITER_MODEL`), default `gemini-2.5-flash` — the model the voice/banned-phrase rules are calibrated against. A newer generation (e.g. `gemini-3.5-preview`) may be swapped in via this var, but is treated as **opt-in to evaluate, not default**: preview models carry instability risk for an unattended daily cron, and a generational jump (2.5→3.5) likely breaks the banned-phrase calibration, so it requires a voice spot-check + banned-phrase re-validation before becoming the default. Optionally `WRITER_MODEL_DEEPDIVE` can point deep-dive prose at a stronger Gemini tier (e.g. `gemini-2.5-pro`) while Takes stay on Flash.
 
 - **Take tier:** the existing tight 4-section structure (background / recent events / the data / outlook).
 - **Deep-dive tier:** long-form, variable markdown headings the writer derives from the dossier `threads`/`timeline` (e.g. `## The probe timeline`, `## What the shorts saw first`). 600–1200 words.

--- a/scripts/take-writer/package-lock.json
+++ b/scripts/take-writer/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@shorted/take-writer",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.69.0",
         "@google-cloud/storage": "^7.19.0",
         "@google/generative-ai": "^0.21.0",
         "@types/pg": "^8.20.0",
@@ -18,7 +19,37 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.69.0.tgz",
+      "integrity": "sha512-L92d2q47BSq+7slUqHBL1d2DwloulZotYGCTDt9AYRtPmYF+iK6rnwq9JaZwPPJgk+LenbcbQ/nj6gfaDFsl9w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -529,6 +560,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -540,6 +578,356 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
@@ -554,6 +942,31 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -594,6 +1007,121 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -622,6 +1150,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-retry": {
@@ -674,6 +1212,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -685,6 +1233,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/combined-stream": {
@@ -714,6 +1289,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/delayed-stream": {
@@ -799,6 +1384,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -868,6 +1460,16 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -875,6 +1477,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -919,6 +1531,24 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -1206,6 +1836,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -1213,6 +1850,19 @@
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jwa": {
@@ -1234,6 +1884,23 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1283,6 +1950,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1362,6 +2048,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pg": {
@@ -1453,6 +2156,55 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -1529,6 +2281,58 @@
         "node": ">=14"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1549,6 +2353,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -1557,6 +2378,20 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -1580,6 +2415,19 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/strnum": {
@@ -1655,10 +2503,77 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/tsx": {
@@ -1716,6 +2631,661 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1730,6 +3300,23 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/scripts/take-writer/package.json
+++ b/scripts/take-writer/package.json
@@ -6,9 +6,12 @@
   "type": "module",
   "scripts": {
     "draft": "tsx src/index.ts draft",
-    "pick": "tsx src/index.ts pick"
+    "pick": "tsx src/index.ts pick",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.69.0",
     "@google-cloud/storage": "^7.19.0",
     "@google/generative-ai": "^0.21.0",
     "@types/pg": "^8.20.0",
@@ -19,6 +22,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/scripts/take-writer/src/dossierwriter.test.ts
+++ b/scripts/take-writer/src/dossierwriter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildDossierPrompt, assembleTakeBody, assembleDeepDiveBody } from "./narrative.js";
+import { buildDossierPrompt, assembleTakeBody, assembleDeepDiveBody, synthesiseFromDossier, type DossierWriterDeps } from "./narrative.js";
 import { CitationLedger } from "./ledger.js";
 import type { Dossier } from "./investigator.js";
 
@@ -37,5 +37,51 @@ describe("assembleDeepDiveBody", () => {
     ]);
     expect(body).toContain("## The probe timeline\n\npara one");
     expect(body).toContain("## What the shorts saw\n\npara two");
+  });
+});
+
+describe("synthesiseFromDossier (grounding + parse retry)", () => {
+  it("drops invented citations and keeps only ledger-backed ones", async () => {
+    const l = new CitationLedger();
+    const ref = l.register({ type: "news", url: "https://x/1", source: "S", headline: "Probe", date: "2026-05-01" });
+    const d: Dossier = { stockCode: "DRO", tier: "take", angle: "a", summary: "s", threads: [], keyNumbers: [] };
+    const deps: DossierWriterDeps = {
+      generate: async () => JSON.stringify({
+        headline: "Shorts held through the probe", sentiment: "negative",
+        background: `Probe opened [${ref}].`, recent_events: `Then nothing [ref-9].`,
+        the_data: "14% short.", outlook: "Still climbing.",
+      }),
+      slug: async () => "dro-shorts-held",
+    };
+    const out = await synthesiseFromDossier(d, l, "DRO", deps);
+    expect(out.citations.map((c) => c.refId)).toEqual(["ref-1"]);   // only the real one survives
+    expect(out.droppedCitations).toContain("ref-9");                 // invented one dropped
+    expect(out.bodyMd).not.toContain("ref-9");
+    expect(out.slug).toBe("dro-shorts-held");
+    expect(out.tier).toBe("take");
+  });
+
+  it("retries once on unparseable JSON, then succeeds", async () => {
+    const l = new CitationLedger();
+    const d: Dossier = { stockCode: "DRO", tier: "take", angle: "a", summary: "s", threads: [], keyNumbers: [] };
+    let calls = 0;
+    const deps: DossierWriterDeps = {
+      generate: async () => {
+        calls++;
+        if (calls === 1) return "{not json";
+        return JSON.stringify({ headline: "h", sentiment: "neutral", background: "b", recent_events: "r", the_data: "d", outlook: "o" });
+      },
+      slug: async () => "dro-h",
+    };
+    const out = await synthesiseFromDossier(d, l, "DRO", deps);
+    expect(calls).toBe(2);
+    expect(out.headline).toBe("h");
+  });
+
+  it("throws if JSON is unparseable on both attempts", async () => {
+    const l = new CitationLedger();
+    const d: Dossier = { stockCode: "DRO", tier: "take", angle: "a", summary: "s", threads: [], keyNumbers: [] };
+    const deps: DossierWriterDeps = { generate: async () => "garbage", slug: async () => "x" };
+    await expect(synthesiseFromDossier(d, l, "DRO", deps)).rejects.toThrow(/unparseable/);
   });
 });

--- a/scripts/take-writer/src/dossierwriter.test.ts
+++ b/scripts/take-writer/src/dossierwriter.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { buildDossierPrompt, assembleTakeBody, assembleDeepDiveBody } from "./narrative.js";
+import { CitationLedger } from "./ledger.js";
+import type { Dossier } from "./investigator.js";
+
+const ledger = new CitationLedger();
+const r1 = ledger.register({ type: "news", url: "https://x/1", source: "S", headline: "Probe opened", date: "2026-05-01" });
+
+const dossier: Dossier = {
+  stockCode: "DRO", tier: "take", angle: "Probe vs shorts",
+  summary: "ASIC opened a probe; shorts held.",
+  threads: [{ claim: `Probe opened on 1 May [${r1}]`, evidenceRefIds: [r1] }],
+  keyNumbers: [{ label: "short %", value: "14%", refId: r1 }],
+};
+
+describe("buildDossierPrompt", () => {
+  it("lists ledger sources by refId so the writer can cite them", () => {
+    const p = buildDossierPrompt(dossier, ledger);
+    expect(p).toContain("ref-1");
+    expect(p).toContain("Probe opened");
+    expect(p).toContain("Probe vs shorts");
+  });
+});
+
+describe("assembleTakeBody", () => {
+  it("joins the four sections with blank lines", () => {
+    const body = assembleTakeBody({ background: "a", recent_events: "b", the_data: "c", outlook: "d" });
+    expect(body).toBe("a\n\nb\n\nc\n\nd");
+  });
+});
+
+describe("assembleDeepDiveBody", () => {
+  it("renders ## headings for each titled section", () => {
+    const body = assembleDeepDiveBody([
+      { heading: "The probe timeline", prose: "para one" },
+      { heading: "What the shorts saw", prose: "para two" },
+    ]);
+    expect(body).toContain("## The probe timeline\n\npara one");
+    expect(body).toContain("## What the shorts saw\n\npara two");
+  });
+});

--- a/scripts/take-writer/src/drilldowns.test.ts
+++ b/scripts/take-writer/src/drilldowns.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { zoomWindow, reportLine, searchNews, type Queryable } from "./drilldowns.js";
+
+function fakePg(capture: { sql: string; params: unknown[] }[], rows: unknown[]): Queryable {
+  return {
+    async query(sql: string, params?: unknown[]) {
+      capture.push({ sql, params: params ?? [] });
+      return { rows } as { rows: unknown[] };
+    },
+  };
+}
+
+describe("zoomWindow", () => {
+  it("queries shorts+prices+news in a +/- day window around a date", async () => {
+    const cap: { sql: string; params: unknown[] }[] = [];
+    const pg = fakePg(cap, []);
+    await zoomWindow(pg, "BHP", "2026-05-01", 3);
+    // 3 queries: shorts, prices, news — all parameterised with the code.
+    expect(cap.length).toBe(3);
+    expect(cap.every((c) => c.params.includes("BHP"))).toBe(true);
+    expect(cap.every((c) => c.params.some((p) => String(p).includes("2026-05-01")))).toBe(true);
+  });
+});
+
+describe("reportLine", () => {
+  it("returns the metric value + source record for a stock", async () => {
+    const cap: { sql: string; params: unknown[] }[] = [];
+    const pg = fakePg(cap, [{
+      report_url: "https://x/r.pdf", report_type: "annual_results",
+      report_title: "FY25", report_date: "2026-02-01",
+      metrics: { revenue: "A$1.2bn", ebitda: "A$300m" },
+    }]);
+    const out = await reportLine(pg, "BHP", "revenue");
+    expect(out?.value).toBe("A$1.2bn");
+    expect(out?.source.type).toBe("report");
+    expect(out?.source.url).toBe("https://x/r.pdf");
+  });
+
+  it("returns null when the metric is absent", async () => {
+    const pg = fakePg([], [{ report_url: "u", report_type: null, report_title: null, report_date: null, metrics: {} }]);
+    expect(await reportLine(pg, "BHP", "revenue")).toBeNull();
+  });
+});
+
+describe("searchNews", () => {
+  it("parameterises the query string and optional code", async () => {
+    const cap: { sql: string; params: unknown[] }[] = [];
+    const pg = fakePg(cap, []);
+    await searchNews(pg, "probe", "DRO");
+    expect(cap[0]!.params).toContain("DRO");
+    expect(cap[0]!.params.some((p) => String(p).includes("probe"))).toBe(true);
+  });
+});

--- a/scripts/take-writer/src/drilldowns.ts
+++ b/scripts/take-writer/src/drilldowns.ts
@@ -1,0 +1,202 @@
+// Incremental drill-down queries used by the investigation agent's
+// tools. Each zooms into a slice of the data the agent already has a
+// summary of — a window around a date, one peer, one report line — so
+// the loop stays cheap instead of re-sending 365-day series each turn.
+
+import type { LedgerSource } from "./ledger.js";
+
+/** Minimal slice of pg.Client we need — lets tests inject a fake. */
+export interface Queryable {
+  query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }>;
+}
+
+export interface WindowResult {
+  shorts: Array<{ date: string; pct: number }>;
+  prices: Array<{ date: string; close: number; volume: number }>;
+  news: Array<{ id: string; date: string; source: string; headline: string; url: string; sentiment: string | null }>;
+}
+
+export async function zoomWindow(
+  pg: Queryable,
+  code: string,
+  date: string,
+  days: number,
+): Promise<WindowResult> {
+  const lo = `${date} -${days} days`;
+  const hi = `${date} +${days} days`;
+  const shortsQ = pg.query(
+    `SELECT to_char("DATE",'YYYY-MM-DD') AS date,
+            "PERCENT_OF_TOTAL_PRODUCT_IN_ISSUE_REPORTED_AS_SHORT_POSITIONS" AS pct
+     FROM shorts
+     WHERE "PRODUCT_CODE"=$1 AND "DATE" BETWEEN $2::timestamp AND $3::timestamp
+     ORDER BY "DATE" ASC`,
+    [code, lo, hi],
+  );
+  const pricesQ = pg.query(
+    `SELECT to_char(date,'YYYY-MM-DD') AS date, close, volume
+     FROM stock_prices
+     WHERE stock_code=$1 AND date BETWEEN $2::date AND $3::date
+     ORDER BY date ASC`,
+    [code, lo, hi],
+  );
+  const newsQ = pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url, sentiment
+     FROM news_articles
+     WHERE stock_code=$1 AND published_at BETWEEN $2::timestamp AND $3::timestamp
+     ORDER BY published_at ASC LIMIT 40`,
+    [code, lo, hi],
+  );
+  const [s, p, n] = await Promise.all([shortsQ, pricesQ, newsQ]);
+  return {
+    shorts: (s.rows as Array<{ date: string; pct: string }>).map((r) => ({ date: r.date, pct: Number(r.pct) })),
+    prices: (p.rows as Array<{ date: string; close: string; volume: string }>).map((r) => ({ date: r.date, close: Number(r.close), volume: Number(r.volume) })),
+    news: n.rows as WindowResult["news"],
+  };
+}
+
+export interface ReportLineResult {
+  value: string;
+  reportType: string | null;
+  reportDate: string | null;
+  source: LedgerSource;
+}
+
+export async function reportLine(
+  pg: Queryable,
+  code: string,
+  metric: string,
+): Promise<ReportLineResult | null> {
+  const { rows } = await pg.query(
+    `SELECT report_url, report_type, report_title,
+            to_char(report_date,'YYYY-MM-DD') AS report_date, metrics
+     FROM financial_report_extractions
+     WHERE stock_code=$1
+     ORDER BY report_date DESC NULLS LAST, extracted_at DESC
+     LIMIT 6`,
+    [code],
+  );
+  for (const r of rows as Array<{ report_url: string; report_type: string | null; report_title: string | null; report_date: string | null; metrics: Record<string, unknown> | null }>) {
+    const m = r.metrics ?? {};
+    if (metric in m && m[metric] != null) {
+      return {
+        value: String(m[metric]),
+        reportType: r.report_type,
+        reportDate: r.report_date,
+        source: {
+          type: "report",
+          url: r.report_url,
+          source: r.report_type ?? "report",
+          headline: r.report_title ?? "(financial report)",
+          date: r.report_date ?? "",
+        },
+      };
+    }
+  }
+  return null;
+}
+
+export interface FollowPeerResult {
+  shorts: Array<{ date: string; pct: number }>;
+  prices: Array<{ date: string; close: number }>;
+}
+
+export async function followPeer(
+  pg: Queryable,
+  peerCode: string,
+  days = 180,
+): Promise<FollowPeerResult> {
+  const sQ = pg.query(
+    `SELECT to_char("DATE",'YYYY-MM-DD') AS date,
+            "PERCENT_OF_TOTAL_PRODUCT_IN_ISSUE_REPORTED_AS_SHORT_POSITIONS" AS pct
+     FROM shorts WHERE "PRODUCT_CODE"=$1 AND "DATE" > NOW() - $2::interval ORDER BY "DATE" ASC`,
+    [peerCode, `${days} days`],
+  );
+  const pQ = pg.query(
+    `SELECT to_char(date,'YYYY-MM-DD') AS date, close FROM stock_prices
+     WHERE stock_code=$1 AND date > NOW() - $2::interval ORDER BY date ASC`,
+    [peerCode, `${days} days`],
+  );
+  const [s, p] = await Promise.all([sQ, pQ]);
+  return {
+    shorts: (s.rows as Array<{ date: string; pct: string }>).map((r) => ({ date: r.date, pct: Number(r.pct) })),
+    prices: (p.rows as Array<{ date: string; close: string }>).map((r) => ({ date: r.date, close: Number(r.close) })),
+  };
+}
+
+export interface AlignEventsItem {
+  date: string;
+  kind: "director_trade" | "news";
+  detail: string;
+  source: LedgerSource;
+}
+
+export async function alignEvents(
+  pg: Queryable,
+  code: string,
+  days = 180,
+): Promise<AlignEventsItem[]> {
+  const tradesQ = pg.query(
+    `SELECT to_char(trade_date,'YYYY-MM-DD') AS date, director_name, trade_type,
+            total_value, announcement_url
+     FROM director_trades WHERE stock_code=$1 AND trade_date > NOW() - $2::interval
+     ORDER BY trade_date DESC LIMIT 50`,
+    [code, `${days} days`],
+  );
+  const newsQ = pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url
+     FROM news_articles WHERE stock_code=$1 AND is_price_sensitive=true
+       AND published_at > NOW() - $2::interval ORDER BY published_at DESC LIMIT 40`,
+    [code, `${days} days`],
+  );
+  const [t, n] = await Promise.all([tradesQ, newsQ]);
+  const out: AlignEventsItem[] = [];
+  for (const r of t.rows as Array<{ date: string; director_name: string; trade_type: string; total_value: string | null; announcement_url: string | null }>) {
+    out.push({
+      date: r.date,
+      kind: "director_trade",
+      detail: `${r.director_name} ${r.trade_type}${r.total_value ? ` A$${r.total_value}` : ""}`,
+      source: { type: "director", url: r.announcement_url ?? "", source: "director trade", headline: `${r.director_name} ${r.trade_type}`, date: r.date },
+    });
+  }
+  for (const r of n.rows as Array<{ id: string; date: string; source: string; headline: string; url: string }>) {
+    out.push({ date: r.date, kind: "news", detail: r.headline, source: { type: "news", url: r.url, source: r.source, headline: r.headline, date: r.date } });
+  }
+  out.sort((a, b) => (a.date < b.date ? 1 : -1));
+  return out;
+}
+
+export interface NewsDetailResult {
+  id: string; date: string; source: string; headline: string; url: string;
+  sentiment: string | null; summary: string | null; ledgerSource: LedgerSource;
+}
+
+export async function newsDetail(pg: Queryable, articleId: string): Promise<NewsDetailResult | null> {
+  const { rows } = await pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url, sentiment, summary
+     FROM news_articles WHERE id=$1::uuid LIMIT 1`,
+    [articleId],
+  );
+  const r = (rows as Array<{ id: string; date: string; source: string; headline: string; url: string; sentiment: string | null; summary: string | null }>)[0];
+  if (!r) return null;
+  return { ...r, ledgerSource: { type: "news", url: r.url, source: r.source, headline: r.headline, date: r.date } };
+}
+
+export interface SearchNewsItem {
+  id: string; date: string; source: string; headline: string; url: string; ledgerSource: LedgerSource;
+}
+
+export async function searchNews(pg: Queryable, query: string, code?: string): Promise<SearchNewsItem[]> {
+  const params: unknown[] = [`%${query}%`];
+  let codeClause = "";
+  if (code) { params.push(code); codeClause = `AND stock_code=$${params.length}`; }
+  const { rows } = await pg.query(
+    `SELECT id::text, to_char(published_at,'YYYY-MM-DD') AS date, source, headline, url
+     FROM news_articles
+     WHERE (headline ILIKE $1 OR summary ILIKE $1) ${codeClause}
+     ORDER BY published_at DESC LIMIT 25`,
+    params,
+  );
+  return (rows as Array<{ id: string; date: string; source: string; headline: string; url: string }>).map((r) => ({
+    ...r, ledgerSource: { type: "news", url: r.url, source: r.source, headline: r.headline, date: r.date },
+  }));
+}

--- a/scripts/take-writer/src/editor.test.ts
+++ b/scripts/take-writer/src/editor.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { hasNewDevelopment } from "./editor.js";
+import type { SignalBoardRow } from "./journalism.js";
+
+const baseRow = (over: Partial<SignalBoardRow> = {}): SignalBoardRow => ({
+  stockCode: "BHP",
+  name: "BHP",
+  industry: "Materials",
+  lastTakeDate: "2026-05-20",
+  recentPriceSensitiveHeadlines: [],
+  signals: {
+    shortSlope90d: 0, shortSlope30d: 0, shortSlope7d: 0,
+    currentShortPct: 5, shortPct90dAvg: 5, shortPctChange90d: 0,
+    shortPctMaxIn90d: 6, shortPctMinIn90d: 4,
+    currentPrice: 40, priceChange1m: 0, priceChange3m: 0, priceChange6m: 0, priceChange12m: 0,
+    priceShortsCorrelation30d: 0,
+    newsArticlesLast30d: 0, newsArticlesLast7d: 0, priceSensitiveLast30d: 0,
+    sentimentMix: { positive: 0, negative: 0, neutral: 0 }, sentimentTrendLast30d: "n/a",
+    directorTradesLast90d: 0, directorNetValueLast90d: 0, directorMostRecentDate: null,
+    peerSectorAverageShort: 5, peerRelative: "at", topRecentEvents: [],
+  },
+  ...over,
+});
+
+describe("hasNewDevelopment", () => {
+  it("is true when never covered before", () => {
+    expect(hasNewDevelopment(baseRow({ lastTakeDate: null }))).toBe(true);
+  });
+
+  it("is true when a price-sensitive headline landed after the last take", () => {
+    const row = baseRow({
+      lastTakeDate: "2026-05-20",
+      recentPriceSensitiveHeadlines: [{ date: "2026-05-25", headline: "ASIC probe" }],
+    });
+    expect(hasNewDevelopment(row)).toBe(true);
+  });
+
+  it("is true on a short-position regime change since the last take", () => {
+    const row = baseRow({ lastTakeDate: "2026-05-20", signals: { ...baseRow().signals, shortPctChange90d: 3.5 } });
+    expect(hasNewDevelopment(row)).toBe(true);
+  });
+
+  it("is true on a fresh director trade after the last take", () => {
+    const row = baseRow({ lastTakeDate: "2026-05-20", signals: { ...baseRow().signals, directorMostRecentDate: "2026-05-28" } });
+    expect(hasNewDevelopment(row)).toBe(true);
+  });
+
+  it("is false when nothing material happened since the last take", () => {
+    expect(hasNewDevelopment(baseRow())).toBe(false);
+  });
+});

--- a/scripts/take-writer/src/editor.ts
+++ b/scripts/take-writer/src/editor.ts
@@ -1,0 +1,102 @@
+// Editor agent — the assignment desk. Reads the day's signal board,
+// applies a novelty gate (don't re-cover a stock without a new
+// development), and asks Claude to commission the day's stories with an
+// angle and a tier (take | deep_dive).
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { Client as PgClient } from "pg";
+import { buildSignalBoard, type SignalBoardRow } from "./journalism.js";
+
+export interface Assignment {
+  stockCode: string;
+  angle: string;
+  tier: "take" | "deep_dive";
+  rationale: string;
+}
+
+export interface EditorOptions {
+  poolSize?: number;
+  maxTakes?: number;
+  maxDeepDives?: number;
+  model?: string;
+}
+
+const SHORT_REGIME_CHANGE_PCT = 2.0; // |current - 90d avg| beyond this = regime change
+
+/**
+ * Pure novelty gate. A stock is worth covering if it has never been
+ * covered, OR something material happened after the last take:
+ *  - a price-sensitive headline dated after lastTakeDate
+ *  - a short-position regime change (|shortPctChange90d| >= threshold)
+ *  - a director trade dated after lastTakeDate
+ */
+export function hasNewDevelopment(row: SignalBoardRow): boolean {
+  if (!row.lastTakeDate) return true;
+  const since = row.lastTakeDate;
+  if (row.recentPriceSensitiveHeadlines.some((h) => h.date > since)) return true;
+  if (Math.abs(row.signals.shortPctChange90d ?? 0) >= SHORT_REGIME_CHANGE_PCT) return true;
+  if (row.signals.directorMostRecentDate && row.signals.directorMostRecentDate > since) return true;
+  return false;
+}
+
+const EDITOR_SYSTEM = `You are the editor of Shorted, an ASX short-position
+publication. From the signal board, commission the day's stories. Be
+selective — only stories with a genuine angle a reader would click.
+
+For each story pick:
+- angle: one sharp sentence naming what the story IS (not a headline).
+- tier: "deep_dive" only when there is a rich, multi-thread story worth
+  600-1200 words (a probe with a timeline, a director-vs-data divergence,
+  a sector unwind). Otherwise "take".
+
+Return STRICT JSON: {"assignments":[{"stockCode","angle","tier","rationale"}]}.
+No prose outside the JSON.`;
+
+export async function commissionAssignments(
+  pg: PgClient,
+  opts: EditorOptions = {},
+): Promise<Assignment[]> {
+  const maxTakes = opts.maxTakes ?? 10;
+  const maxDeepDives = opts.maxDeepDives ?? 2;
+  const model = opts.model ?? process.env.EDITOR_MODEL ?? "claude-sonnet-4-6";
+
+  const board = await buildSignalBoard(pg, opts.poolSize ?? 30);
+  const fresh = board.filter(hasNewDevelopment);
+  if (fresh.length === 0) return [];
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY not set");
+  const client = new Anthropic({ apiKey });
+
+  const boardText = fresh.map((r) => {
+    const s = r.signals;
+    return [
+      `${r.stockCode} (${r.name ?? "?"}, ${r.industry ?? "?"})`,
+      `  short ${s.currentShortPct?.toFixed(1)}% (Δ90d ${s.shortPctChange90d?.toFixed(1)}), price 3m ${s.priceChange3m?.toFixed(0)}%, corr ${s.priceShortsCorrelation30d?.toFixed(2)}`,
+      `  news30d ${s.newsArticlesLast30d} (ps ${s.priceSensitiveLast30d}), sentiment ${s.sentimentTrendLast30d}, director net A$${s.directorNetValueLast90d.toFixed(0)}`,
+      `  last covered: ${r.lastTakeDate ?? "never"}; recent price-sensitive: ${r.recentPriceSensitiveHeadlines.map((h) => `${h.date} ${h.headline}`).join(" | ") || "none"}`,
+    ].join("\n");
+  }).join("\n\n");
+
+  const resp = await client.messages.create({
+    model,
+    max_tokens: 2000,
+    system: EDITOR_SYSTEM,
+    messages: [{
+      role: "user",
+      content: `Signal board (${fresh.length} stocks with a new development):\n\n${boardText}\n\nCommission up to ${maxTakes} takes and ${maxDeepDives} deep-dives. Return the JSON now.`,
+    }],
+  });
+
+  const text = resp.content.filter((b): b is Anthropic.Messages.TextBlock => b.type === "text").map((b) => b.text).join("");
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return [];
+  let parsed: { assignments?: Assignment[] };
+  try { parsed = JSON.parse(jsonMatch[0]); } catch { return []; }
+  const all = (parsed.assignments ?? []).filter((a) => a.stockCode && (a.tier === "take" || a.tier === "deep_dive"));
+
+  // Enforce caps defensively (the model may over-commission).
+  const deepDives = all.filter((a) => a.tier === "deep_dive").slice(0, maxDeepDives);
+  const takes = all.filter((a) => a.tier === "take").slice(0, maxTakes);
+  return [...deepDives, ...takes].map((a) => ({ ...a, stockCode: a.stockCode.toUpperCase() }));
+}

--- a/scripts/take-writer/src/editor.ts
+++ b/scripts/take-writer/src/editor.ts
@@ -9,6 +9,7 @@ import { buildSignalBoard, type SignalBoardRow } from "./journalism.js";
 
 export interface Assignment {
   stockCode: string;
+  industry: string | null;
   angle: string;
   tier: "take" | "deep_dive";
   rationale: string;
@@ -91,12 +92,17 @@ export async function commissionAssignments(
   const text = resp.content.filter((b): b is Anthropic.Messages.TextBlock => b.type === "text").map((b) => b.text).join("");
   const jsonMatch = text.match(/\{[\s\S]*\}/);
   if (!jsonMatch) return [];
-  let parsed: { assignments?: Assignment[] };
+  type RawAssignment = { stockCode: string; angle: string; tier: "take" | "deep_dive"; rationale: string };
+  let parsed: { assignments?: RawAssignment[] };
   try { parsed = JSON.parse(jsonMatch[0]); } catch { return []; }
   const all = (parsed.assignments ?? []).filter((a) => a.stockCode && (a.tier === "take" || a.tier === "deep_dive"));
 
   // Enforce caps defensively (the model may over-commission).
   const deepDives = all.filter((a) => a.tier === "deep_dive").slice(0, maxDeepDives);
   const takes = all.filter((a) => a.tier === "take").slice(0, maxTakes);
-  return [...deepDives, ...takes].map((a) => ({ ...a, stockCode: a.stockCode.toUpperCase() }));
+  const industryByCode = new Map(fresh.map((r) => [r.stockCode, r.industry]));
+  return [...deepDives, ...takes].map((a) => {
+    const code = a.stockCode.toUpperCase();
+    return { ...a, stockCode: code, industry: industryByCode.get(code) ?? null };
+  });
 }

--- a/scripts/take-writer/src/index.ts
+++ b/scripts/take-writer/src/index.ts
@@ -12,7 +12,7 @@ import { Client as PgClient } from "pg";
 import { buildReport } from "./journalism.js";
 import { synthesiseNarrative, narrativeToBodyMd } from "./narrative.js";
 import { buildAgenda, formatAgendaCandidate } from "./agenda.js";
-import { runNewsroom } from "./newsroom.js";
+import { runNewsroom, runNewsroomDaily } from "./newsroom.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -97,7 +97,8 @@ Commands:
   discover  Rank candidate stocks: top-shorted minus ETFs minus no-news
   run       End-to-end: discover headline + draft + image + insert (+ publish + tweet)
   agenda    Editorial briefing — ranked story candidates with angles
-  newsroom  Loop: agenda → top-N narratives → insert as drafts/publish
+  newsroom        Loop: agenda → top-N narratives → insert as drafts/publish
+  newsroom-daily  Investigative daily run: editor -> agentic investigation -> tiered writer
   narrative Multi-section journalism-engine Take for one --stock=CODE
 
 run flags:
@@ -308,6 +309,18 @@ async function main(): Promise<void> {
       await runNewsroom({
         poolSize: args.poolSize,
         topN: args.topN ?? 3,
+        autoPublish,
+        withImages,
+      });
+      break;
+    }
+    case "newsroom-daily": {
+      const autoPublish = args.autoPublish ?? false;
+      const withImages = args.withImages ?? (autoPublish && !args.noImages);
+      await runNewsroomDaily({
+        poolSize: args.poolSize,
+        maxTakes: args.topN ?? Number(process.env.MAX_TAKES_PER_DAY ?? 10),
+        maxDeepDives: Number(process.env.MAX_DEEPDIVES_PER_DAY ?? 2),
         autoPublish,
         withImages,
       });

--- a/scripts/take-writer/src/investigator.test.ts
+++ b/scripts/take-writer/src/investigator.test.ts
@@ -67,4 +67,18 @@ describe("investigate", () => {
     expect(dossier.summary).toBe(assignment.angle); // non-string summary -> angle fallback
     expect(dossier.keyNumbers.length).toBe(1);     // only the well-formed keyNumber kept
   });
+
+  it("defaults missing refIds to [] on timeline items", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const create = vi.fn().mockResolvedValueOnce({
+      stop_reason: "tool_use",
+      content: [{ type: "tool_use", id: "t1", name: "emit_dossier", input: {
+        summary: "s", threads: [], keyNumbers: [],
+        timeline: [{ date: "2026-05-01", event: "probe opened" }],  // no refIds
+      } }],
+    });
+    const ledger = new CitationLedger();
+    const d = await investigate(create as any, pg, { ...assignment, tier: "deep_dive" as const }, ledger, { maxTurns: 4, model: "claude-opus-4-8" });
+    expect(d.timeline![0]!.refIds).toEqual([]);
+  });
 });

--- a/scripts/take-writer/src/investigator.test.ts
+++ b/scripts/take-writer/src/investigator.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { investigate, type MessagesCreate } from "./investigator.js";
+import { CitationLedger } from "./ledger.js";
+
+const assignment = { stockCode: "DRO", angle: "Probe vs shorts", tier: "take" as const, rationale: "x" };
+
+describe("investigate", () => {
+  it("runs a tool round then finalises the dossier from emit_dossier", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [{ id: "1", date: "2026-05-01", source: "S", headline: "Probe opened", url: "https://x/1" }] }) };
+    const create: MessagesCreate = vi.fn()
+      // round 1: call a tool
+      .mockResolvedValueOnce({
+        stop_reason: "tool_use",
+        content: [{ type: "tool_use", id: "t1", name: "search_news", input: { query: "probe" } }],
+      })
+      // round 2: emit the dossier via the emit_dossier tool
+      .mockResolvedValueOnce({
+        stop_reason: "tool_use",
+        content: [{ type: "tool_use", id: "t2", name: "emit_dossier", input: {
+          summary: "ASIC opened a probe; shorts held.",
+          threads: [{ claim: "Probe opened 1 May", evidenceRefIds: ["ref-1"] }],
+          keyNumbers: [{ label: "short %", value: "14%" }],
+        } }],
+      });
+
+    const ledger = new CitationLedger();
+    const dossier = await investigate(create as MessagesCreate, pg, assignment, ledger, { maxTurns: 6, model: "claude-sonnet-4-6" });
+    expect(dossier.summary).toContain("probe");
+    expect(dossier.threads[0]!.evidenceRefIds).toEqual(["ref-1"]);
+    expect(ledger.size()).toBe(1); // search_news registered the source
+    expect((create as any).mock.calls.length).toBe(2);
+  });
+
+  it("finalises a minimal dossier if the turn cap is hit without emit_dossier", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const create: MessagesCreate = vi.fn().mockResolvedValue({
+      stop_reason: "tool_use",
+      content: [{ type: "tool_use", id: "t", name: "align_events", input: {} }],
+    });
+    const ledger = new CitationLedger();
+    const dossier = await investigate(create as MessagesCreate, pg, assignment, ledger, { maxTurns: 2, model: "claude-sonnet-4-6" });
+    expect(dossier.stockCode).toBe("DRO");
+    expect(Array.isArray(dossier.threads)).toBe(true);
+    expect((create as any).mock.calls.length).toBe(2); // stopped at the cap
+  });
+});

--- a/scripts/take-writer/src/investigator.test.ts
+++ b/scripts/take-writer/src/investigator.test.ts
@@ -43,4 +43,28 @@ describe("investigate", () => {
     expect(Array.isArray(dossier.threads)).toBe(true);
     expect((create as any).mock.calls.length).toBe(2); // stopped at the cap
   });
+
+  it("nudges once on a text-only stop, then finalises on emit_dossier", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const create = vi.fn()
+      .mockResolvedValueOnce({ stop_reason: "end_turn", content: [{ type: "text", text: "I think the probe matters." }] })
+      .mockResolvedValueOnce({ stop_reason: "tool_use", content: [{ type: "tool_use", id: "t2", name: "emit_dossier", input: { summary: "Done.", threads: [], keyNumbers: [] } }] });
+    const ledger = new CitationLedger();
+    const dossier = await investigate(create as any, pg, assignment, ledger, { maxTurns: 4, model: "claude-sonnet-4-6" });
+    expect(dossier.summary).toBe("Done.");
+    expect(create.mock.calls.length).toBe(2);
+  });
+
+  it("sanitises malformed emit_dossier output (non-array threads, bad summary)", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const create = vi.fn().mockResolvedValueOnce({
+      stop_reason: "tool_use",
+      content: [{ type: "tool_use", id: "t1", name: "emit_dossier", input: { summary: 42, threads: "nope", keyNumbers: [{ label: "x", value: "1" }, { bad: true }] } }],
+    });
+    const ledger = new CitationLedger();
+    const dossier = await investigate(create as any, pg, assignment, ledger, { maxTurns: 4, model: "claude-sonnet-4-6" });
+    expect(dossier.threads).toEqual([]);          // non-array dropped
+    expect(dossier.summary).toBe(assignment.angle); // non-string summary -> angle fallback
+    expect(dossier.keyNumbers.length).toBe(1);     // only the well-formed keyNumber kept
+  });
 });

--- a/scripts/take-writer/src/investigator.test.ts
+++ b/scripts/take-writer/src/investigator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { investigate, type MessagesCreate } from "./investigator.js";
 import { CitationLedger } from "./ledger.js";
 
-const assignment = { stockCode: "DRO", angle: "Probe vs shorts", tier: "take" as const, rationale: "x" };
+const assignment = { stockCode: "DRO", industry: null, angle: "Probe vs shorts", tier: "take" as const, rationale: "x" };
 
 describe("investigate", () => {
   it("runs a tool round then finalises the dossier from emit_dossier", async () => {

--- a/scripts/take-writer/src/investigator.ts
+++ b/scripts/take-writer/src/investigator.ts
@@ -84,6 +84,12 @@ invent sources or numbers. When done, call emit_dossier exactly once.
 Keep it to ${a.tier === "deep_dive" ? "at most 10" : "at most 4"} investigative tool calls before emitting.`;
 }
 
+/**
+ * Run the agentic investigation loop and return a Dossier.
+ * NOTE: this may THROW if the injected `create` (Anthropic API call)
+ * fails — callers running this in a batch MUST wrap each invocation in
+ * try/catch so one failed assignment doesn't abort the whole run.
+ */
 export async function investigate(
   create: MessagesCreate,
   pg: Queryable,
@@ -108,7 +114,17 @@ export async function investigate(
     });
 
     const toolUses = resp.content.filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use");
-    if (toolUses.length === 0) break; // model stopped without tools
+    if (toolUses.length === 0) {
+      // Model replied with text but called no tool. Nudge it back to
+      // emit_dossier once; if it still won't, finalise with what we have
+      // rather than silently discarding the investigation.
+      if (resp.stop_reason === "end_turn" && turn < maxTurns - 1) {
+        messages.push({ role: "assistant", content: resp.content });
+        messages.push({ role: "user", content: "You have not called emit_dossier yet. Call emit_dossier now with your findings, citing only refIds the tools returned." });
+        continue;
+      }
+      break;
+    }
 
     // Did it emit the dossier? Finalise.
     const emit = toolUses.find((t) => t.name === "emit_dossier");
@@ -136,9 +152,23 @@ function finalise(assignment: Assignment, input: Partial<Dossier>): Dossier {
     stockCode: assignment.stockCode,
     tier: assignment.tier,
     angle: assignment.angle,
-    summary: input.summary ?? assignment.angle,
-    threads: input.threads ?? [],
-    timeline: input.timeline,
-    keyNumbers: input.keyNumbers ?? [],
+    summary: typeof input.summary === "string" && input.summary.trim() ? input.summary : assignment.angle,
+    threads: Array.isArray(input.threads)
+      ? input.threads.filter(
+          (t): t is DossierThread =>
+            typeof t === "object" && t !== null &&
+            typeof (t as DossierThread).claim === "string" &&
+            Array.isArray((t as DossierThread).evidenceRefIds),
+        )
+      : [],
+    timeline: Array.isArray(input.timeline) ? input.timeline : undefined,
+    keyNumbers: Array.isArray(input.keyNumbers)
+      ? input.keyNumbers.filter(
+          (n): n is DossierKeyNumber =>
+            typeof n === "object" && n !== null &&
+            typeof (n as DossierKeyNumber).label === "string" &&
+            typeof (n as DossierKeyNumber).value === "string",
+        )
+      : [],
   };
 }

--- a/scripts/take-writer/src/investigator.ts
+++ b/scripts/take-writer/src/investigator.ts
@@ -1,0 +1,144 @@
+// Investigation agent — the agentic core. Given an assignment, it runs
+// Claude in a tool-calling loop over the drill-down tools, registering
+// every retrieved source into the ledger, and finalises a structured
+// Dossier via a special emit_dossier tool. Turn-capped; if the cap is
+// hit before emit_dossier, we finalise with whatever was gathered.
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { Queryable } from "./drilldowns.js";
+import type { CitationLedger } from "./ledger.js";
+import { TOOL_DEFS, dispatchTool } from "./tools.js";
+import type { Assignment } from "./editor.js";
+
+export interface DossierThread { claim: string; evidenceRefIds: string[]; note?: string }
+export interface DossierTimelineItem { date: string; event: string; refIds: string[] }
+export interface DossierKeyNumber { label: string; value: string; refId?: string }
+export interface Dossier {
+  stockCode: string;
+  tier: "take" | "deep_dive";
+  angle: string;
+  summary: string;
+  threads: DossierThread[];
+  timeline?: DossierTimelineItem[];
+  keyNumbers: DossierKeyNumber[];
+}
+
+/** The subset of Anthropic's client.messages.create we depend on. */
+export type MessagesCreate = (body: Anthropic.MessageCreateParamsNonStreaming) => Promise<Anthropic.Message>;
+
+export interface InvestigateOptions {
+  maxTurns?: number;
+  model: string;
+  maxTokens?: number;
+}
+
+const EMIT_DOSSIER_TOOL: Anthropic.Tool = {
+  name: "emit_dossier",
+  description: "Call this ONCE when your investigation is complete to hand off your findings. Cite evidence ONLY by the refIds returned to you by other tools.",
+  input_schema: {
+    type: "object",
+    properties: {
+      summary: { type: "string", description: "2-3 sentence neutral summary of what you found." },
+      threads: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            claim: { type: "string" },
+            evidenceRefIds: { type: "array", items: { type: "string" } },
+            note: { type: "string" },
+          },
+          required: ["claim", "evidenceRefIds"],
+        },
+      },
+      timeline: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { date: { type: "string" }, event: { type: "string" }, refIds: { type: "array", items: { type: "string" } } },
+          required: ["date", "event"],
+        },
+      },
+      keyNumbers: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { label: { type: "string" }, value: { type: "string" }, refId: { type: "string" } },
+          required: ["label", "value"],
+        },
+      },
+    },
+    required: ["summary", "threads", "keyNumbers"],
+  },
+};
+
+function systemPrompt(a: Assignment): string {
+  return `You are an investigative reporter for Shorted (ASX short positions).
+Assignment: ${a.stockCode} — ${a.angle}
+Tier: ${a.tier} (${a.tier === "deep_dive" ? "rich, multi-thread; build a timeline" : "tight, single sharp thread"}).
+
+Investigate using the tools. Drill into spikes, follow peers, align
+director trades to price, pull reported numbers. Every factual claim in
+your dossier MUST be backed by a refId a tool returned to you — do not
+invent sources or numbers. When done, call emit_dossier exactly once.
+Keep it to ${a.tier === "deep_dive" ? "at most 10" : "at most 4"} investigative tool calls before emitting.`;
+}
+
+export async function investigate(
+  create: MessagesCreate,
+  pg: Queryable,
+  assignment: Assignment,
+  ledger: CitationLedger,
+  opts: InvestigateOptions,
+): Promise<Dossier> {
+  const maxTurns = opts.maxTurns ?? (assignment.tier === "deep_dive" ? 14 : 6);
+  const tools = [...TOOL_DEFS, EMIT_DOSSIER_TOOL];
+  const messages: Anthropic.MessageParam[] = [{
+    role: "user",
+    content: `Begin your investigation of ${assignment.stockCode}. Angle: ${assignment.angle}.`,
+  }];
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const resp = await create({
+      model: opts.model,
+      max_tokens: opts.maxTokens ?? 4000,
+      system: systemPrompt(assignment),
+      tools,
+      messages,
+    });
+
+    const toolUses = resp.content.filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use");
+    if (toolUses.length === 0) break; // model stopped without tools
+
+    // Did it emit the dossier? Finalise.
+    const emit = toolUses.find((t) => t.name === "emit_dossier");
+    if (emit) {
+      const input = emit.input as Partial<Dossier>;
+      return finalise(assignment, input);
+    }
+
+    // Otherwise run the requested tools and feed results back.
+    messages.push({ role: "assistant", content: resp.content });
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const t of toolUses) {
+      const result = await dispatchTool(pg, ledger, t.name, t.input as Record<string, unknown>, assignment.stockCode);
+      toolResults.push({ type: "tool_result", tool_use_id: t.id, content: result });
+    }
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  // Turn cap hit without emit_dossier — finalise minimally with what's gathered.
+  return finalise(assignment, {});
+}
+
+function finalise(assignment: Assignment, input: Partial<Dossier>): Dossier {
+  return {
+    stockCode: assignment.stockCode,
+    tier: assignment.tier,
+    angle: assignment.angle,
+    summary: input.summary ?? assignment.angle,
+    threads: input.threads ?? [],
+    timeline: input.timeline,
+    keyNumbers: input.keyNumbers ?? [],
+  };
+}

--- a/scripts/take-writer/src/investigator.ts
+++ b/scripts/take-writer/src/investigator.ts
@@ -161,7 +161,16 @@ function finalise(assignment: Assignment, input: Partial<Dossier>): Dossier {
             Array.isArray((t as DossierThread).evidenceRefIds),
         )
       : [],
-    timeline: Array.isArray(input.timeline) ? input.timeline : undefined,
+    timeline: Array.isArray(input.timeline)
+      ? input.timeline
+          .filter(
+            (t): t is DossierTimelineItem =>
+              typeof t === "object" && t !== null &&
+              typeof (t as DossierTimelineItem).date === "string" &&
+              typeof (t as DossierTimelineItem).event === "string",
+          )
+          .map((t) => ({ ...t, refIds: Array.isArray(t.refIds) ? t.refIds : [] }))
+      : undefined,
     keyNumbers: Array.isArray(input.keyNumbers)
       ? input.keyNumbers.filter(
           (n): n is DossierKeyNumber =>

--- a/scripts/take-writer/src/journalism.ts
+++ b/scripts/take-writer/src/journalism.ts
@@ -506,3 +506,61 @@ export async function buildReport(
   const signals = extractSignals(bundle);
   return { bundle, signals };
 }
+
+// --- Newsroom helpers ---
+
+/** Most recent editorial_takes.created_at for a stock (YYYY-MM-DD), or null. */
+export async function lastTakeDateForStock(
+  pg: PgClient,
+  code: string,
+): Promise<string | null> {
+  const { rows } = await pg.query<{ last: string | null }>(
+    `SELECT to_char(MAX(created_at), 'YYYY-MM-DD') AS last
+     FROM editorial_takes WHERE stock_code = $1`,
+    [code],
+  );
+  return rows[0]?.last ?? null;
+}
+
+export interface SignalBoardRow {
+  stockCode: string;
+  name: string | null;
+  industry: string | null;
+  signals: Signals;
+  lastTakeDate: string | null;
+  recentPriceSensitiveHeadlines: Array<{ date: string; headline: string }>;
+}
+
+/**
+ * Build a compact per-stock board for the editor agent: signals +
+ * when we last covered the stock + the few most recent price-sensitive
+ * headlines (so the editor can judge novelty). Pool comes from
+ * mv_top_shorts (most-shorted first).
+ */
+export async function buildSignalBoard(
+  pg: PgClient,
+  poolSize = 30,
+): Promise<SignalBoardRow[]> {
+  const { rows } = await pg.query<{ product_code: string }>(
+    `SELECT product_code FROM mv_top_shorts ORDER BY current_percent DESC LIMIT $1`,
+    [poolSize],
+  );
+  const board: SignalBoardRow[] = [];
+  for (const r of rows) {
+    const code = r.product_code;
+    const report = await buildReport(pg, code);
+    const lastTakeDate = await lastTakeDateForStock(pg, code);
+    board.push({
+      stockCode: code,
+      name: report.bundle.meta.name,
+      industry: report.bundle.meta.industry,
+      signals: report.signals,
+      lastTakeDate,
+      recentPriceSensitiveHeadlines: report.bundle.news
+        .filter((a) => a.isPriceSensitive)
+        .slice(0, 5)
+        .map((a) => ({ date: a.publishedAt.slice(0, 10), headline: a.headline })),
+    });
+  }
+  return board;
+}

--- a/scripts/take-writer/src/ledger.test.ts
+++ b/scripts/take-writer/src/ledger.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { CitationLedger, compactCitations } from "./ledger.js";
+
+const src = (over: Partial<import("./ledger.js").LedgerSource> = {}) => ({
+  type: "news" as const,
+  url: "https://ex.com/a",
+  source: "Stockhead",
+  headline: "A headline",
+  date: "2026-05-01",
+  ...over,
+});
+
+describe("CitationLedger", () => {
+  it("assigns sequential refIds in registration order", () => {
+    const l = new CitationLedger();
+    expect(l.register(src({ url: "https://ex.com/a" }))).toBe("ref-1");
+    expect(l.register(src({ url: "https://ex.com/b" }))).toBe("ref-2");
+  });
+
+  it("dedupes by type+url, returning the existing refId", () => {
+    const l = new CitationLedger();
+    const first = l.register(src({ url: "https://ex.com/a" }));
+    const again = l.register(src({ url: "https://ex.com/a", headline: "changed" }));
+    expect(again).toBe(first);
+    expect(l.size()).toBe(1);
+  });
+
+  it("knows whether a refId is in the ledger", () => {
+    const l = new CitationLedger();
+    l.register(src());
+    expect(l.has("ref-1")).toBe(true);
+    expect(l.has("ref-9")).toBe(false);
+  });
+});
+
+describe("compactCitations", () => {
+  it("drops markers not in the ledger and renumbers cited ones in first-appearance order", () => {
+    const l = new CitationLedger();
+    l.register(src({ url: "https://ex.com/a", type: "news" }));     // ref-1
+    l.register(src({ url: "https://ex.com/b", type: "report" }));   // ref-2
+    l.register(src({ url: "https://ex.com/c", type: "news" }));     // ref-3
+    // Body cites ref-3 then ref-1, and a bogus ref-8 that must be dropped.
+    const body = "First [ref-3]. Then [ref-1]. Bogus [ref-8].";
+    const { body: out, citations } = compactCitations(body, l);
+    expect(out).toBe("First [ref-1]. Then [ref-2]. Bogus .");
+    expect(citations.map((c) => c.refId)).toEqual(["ref-1", "ref-2"]);
+    expect(citations[0]!.url).toBe("https://ex.com/c");
+    expect(citations[1]!.url).toBe("https://ex.com/a");
+    expect(citations[1]!.type).toBe("news");
+  });
+
+  it("reports dangling markers it dropped", () => {
+    const l = new CitationLedger();
+    l.register(src());
+    const { dropped } = compactCitations("ok [ref-1] bad [ref-7]", l);
+    expect(dropped).toEqual(["ref-7"]);
+  });
+});

--- a/scripts/take-writer/src/ledger.test.ts
+++ b/scripts/take-writer/src/ledger.test.ts
@@ -62,4 +62,13 @@ describe("compactCitations", () => {
     const { citations } = compactCitations("see [ref-1]", l);
     expect(citations[0]!.type).toBe("trade");
   });
+
+  it("returns empty results for an empty body", () => {
+    const l = new CitationLedger();
+    l.register({ type: "news", url: "https://ex.com/a", source: "S", headline: "h", date: "2026-05-01" });
+    const { body, citations, dropped } = compactCitations("", l);
+    expect(body).toBe("");
+    expect(citations).toEqual([]);
+    expect(dropped).toEqual([]);
+  });
 });

--- a/scripts/take-writer/src/ledger.test.ts
+++ b/scripts/take-writer/src/ledger.test.ts
@@ -55,4 +55,11 @@ describe("compactCitations", () => {
     const { dropped } = compactCitations("ok [ref-1] bad [ref-7]", l);
     expect(dropped).toEqual(["ref-7"]);
   });
+
+  it("maps a director-type source to Citation type 'trade'", () => {
+    const l = new CitationLedger();
+    l.register(src({ url: "https://ex.com/d", type: "director" }));
+    const { citations } = compactCitations("see [ref-1]", l);
+    expect(citations[0]!.type).toBe("trade");
+  });
 });

--- a/scripts/take-writer/src/ledger.test.ts
+++ b/scripts/take-writer/src/ledger.test.ts
@@ -31,6 +31,14 @@ describe("CitationLedger", () => {
     expect(l.has("ref-1")).toBe(true);
     expect(l.has("ref-9")).toBe(false);
   });
+
+  it("does not collapse distinct url-less sources to one refId", () => {
+    const l = new CitationLedger();
+    const a = l.register({ type: "director", url: "", source: "director trade", headline: "Jane Doe sell", date: "2026-05-01" });
+    const b = l.register({ type: "director", url: "", source: "director trade", headline: "John Roe buy", date: "2026-05-02" });
+    expect(a).not.toBe(b);
+    expect(l.size()).toBe(2);
+  });
 });
 
 describe("compactCitations", () => {

--- a/scripts/take-writer/src/ledger.ts
+++ b/scripts/take-writer/src/ledger.ts
@@ -25,7 +25,10 @@ export class CitationLedger {
   private seq = 0;
 
   private key(s: LedgerSource): string {
-    return `${s.type}:${s.url}`;
+    // Url-less sources (e.g. director trades with no announcement link)
+    // must not all collapse to one key, or distinct trades share a refId
+    // and get mis-attributed. Fall back to date+headline.
+    return s.url ? `${s.type}:${s.url}` : `${s.type}:${s.date}:${s.headline}`;
   }
 
   /** Register a retrieved source; returns its stable refId. Idempotent on type+url. */

--- a/scripts/take-writer/src/ledger.ts
+++ b/scripts/take-writer/src/ledger.ts
@@ -67,7 +67,7 @@ export function compactCitations(
 ): { body: string; citations: Citation[]; dropped: string[] } {
   const remap = new Map<string, string>();
   const ordered: LedgerSource[] = [];
-  const dropped: string[] = [];
+  const dropped = new Set<string>();
   let assigned = 0;
 
   for (const m of body.matchAll(MARKER)) {
@@ -75,7 +75,7 @@ export function compactCitations(
     if (remap.has(id)) continue;
     const srcRec = ledger.get(id);
     if (!srcRec) {
-      if (!dropped.includes(id)) dropped.push(id);
+      dropped.add(id);
       continue;
     }
     assigned += 1;
@@ -98,5 +98,5 @@ export function compactCitations(
     type: s.type === "director" ? "trade" : s.type, // Citation.type has no 'director'; map to 'trade'
   }));
 
-  return { body: outBody, citations, dropped };
+  return { body: outBody, citations, dropped: [...dropped] };
 }

--- a/scripts/take-writer/src/ledger.ts
+++ b/scripts/take-writer/src/ledger.ts
@@ -1,0 +1,102 @@
+// Citation ledger — the grounding spine of the investigative newsroom.
+//
+// Every source the investigation agent actually retrieves via a data
+// tool is registered here and handed a stable refId. The writer may
+// ONLY cite refIds that exist in the ledger; compactCitations() drops
+// any marker the writer invents and renumbers the survivors into the
+// contiguous ref-1..M sequence the frontend (LinkifiedNarrative +
+// editorial_takes.citations) already understands.
+
+import type { Citation } from "./narrative.js";
+
+export type LedgerSourceType = "news" | "report" | "director";
+
+export interface LedgerSource {
+  type: LedgerSourceType;
+  url: string;
+  source: string;
+  headline: string;
+  date: string; // YYYY-MM-DD
+}
+
+export class CitationLedger {
+  private byKey = new Map<string, string>();   // type:url -> refId
+  private byRefId = new Map<string, LedgerSource>();
+  private seq = 0;
+
+  private key(s: LedgerSource): string {
+    return `${s.type}:${s.url}`;
+  }
+
+  /** Register a retrieved source; returns its stable refId. Idempotent on type+url. */
+  register(s: LedgerSource): string {
+    const k = this.key(s);
+    const existing = this.byKey.get(k);
+    if (existing) return existing;
+    this.seq += 1;
+    const refId = `ref-${this.seq}`;
+    this.byKey.set(k, refId);
+    this.byRefId.set(refId, s);
+    return refId;
+  }
+
+  has(refId: string): boolean {
+    return this.byRefId.has(refId);
+  }
+
+  get(refId: string): LedgerSource | undefined {
+    return this.byRefId.get(refId);
+  }
+
+  size(): number {
+    return this.byRefId.size;
+  }
+}
+
+const MARKER = /\[(ref-\d+)\]/g;
+
+/**
+ * Walk the body, drop any [ref-N] not in the ledger, and renumber the
+ * cited-and-valid markers into contiguous ref-1..M in first-appearance
+ * order. Returns the rewritten body, the ordered Citation[] for the
+ * editorial_takes.citations column, and the dropped (dangling) marker ids.
+ */
+export function compactCitations(
+  body: string,
+  ledger: CitationLedger,
+): { body: string; citations: Citation[]; dropped: string[] } {
+  const remap = new Map<string, string>();
+  const ordered: LedgerSource[] = [];
+  const dropped: string[] = [];
+  let assigned = 0;
+
+  for (const m of body.matchAll(MARKER)) {
+    const id = m[1]!;
+    if (remap.has(id)) continue;
+    const srcRec = ledger.get(id);
+    if (!srcRec) {
+      if (!dropped.includes(id)) dropped.push(id);
+      continue;
+    }
+    assigned += 1;
+    const to = `ref-${assigned}`;
+    remap.set(id, to);
+    ordered.push(srcRec);
+  }
+
+  const outBody = body.replace(MARKER, (whole, id: string) => {
+    if (remap.has(id)) return `[${remap.get(id)}]`;
+    return ""; // drop dangling marker
+  });
+
+  const citations: Citation[] = ordered.map((s, i) => ({
+    refId: `ref-${i + 1}`,
+    url: s.url,
+    source: s.source,
+    headline: s.headline,
+    date: s.date,
+    type: s.type === "director" ? "trade" : s.type, // Citation.type has no 'director'; map to 'trade'
+  }));
+
+  return { body: outBody, citations, dropped };
+}

--- a/scripts/take-writer/src/narrative.ts
+++ b/scripts/take-writer/src/narrative.ts
@@ -566,29 +566,60 @@ const DEEPDIVE_DOSSIER_SCHEMA = {
   required: ["headline", "sentiment", "sections"],
 };
 
+/** Injectable LLM calls so synthesiseFromDossier is unit-testable. */
+export interface DossierWriterDeps {
+  /** Return the raw JSON text from the writer model for the given prompt. */
+  generate(prompt: string, deep: boolean): Promise<string>;
+  /** Return the raw slug text for a headline. */
+  slug(headline: string, stockCode: string): Promise<string>;
+}
+
+function geminiDeps(): DossierWriterDeps {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error("GEMINI_API_KEY not set");
+  const ai = new GoogleGenerativeAI(apiKey);
+  return {
+    async generate(prompt, deep) {
+      const model = ai.getGenerativeModel({
+        model: deep ? WRITER_MODEL_DEEPDIVE() : WRITER_MODEL(),
+        systemInstruction: NARRATIVE_SYSTEM_PROMPT,
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: deep ? DEEPDIVE_DOSSIER_SCHEMA : TAKE_DOSSIER_SCHEMA,
+          temperature: 0.7,
+          maxOutputTokens: deep ? 16000 : 8000,
+        },
+      });
+      const resp = await model.generateContent(prompt);
+      return resp.response.text();
+    },
+    async slug(headline, stockCode) {
+      const slugModel = ai.getGenerativeModel({
+        model: WRITER_MODEL(),
+        generationConfig: { temperature: 0.2, maxOutputTokens: 500 },
+      });
+      const resp = await slugModel.generateContent(
+        SLUG_PROMPT.replace("{{HEADLINE}}", headline).replace("{{STOCK_CODE}}", stockCode),
+      );
+      return resp.response.text();
+    },
+  };
+}
+
 /** Write a tiered Take from a grounded dossier. Cites only ledger refIds;
- *  compactCitations drops anything invented. */
+ *  compactCitations drops anything invented. `deps` is injectable for tests
+ *  (defaults to the Gemini-backed implementation).
+ *  NOTE: deps.generate/deps.slug may THROW on API error — the batch caller
+ *  wraps each assignment in try/catch. */
 export async function synthesiseFromDossier(
   dossier: Dossier,
   ledger: CitationLedger,
   stockCode: string,
+  deps: DossierWriterDeps = geminiDeps(),
 ): Promise<DossierTake> {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) throw new Error("GEMINI_API_KEY not set");
-  const ai = new GoogleGenerativeAI(apiKey);
   const deep = dossier.tier === "deep_dive";
-  const model = ai.getGenerativeModel({
-    model: deep ? WRITER_MODEL_DEEPDIVE() : WRITER_MODEL(),
-    systemInstruction: NARRATIVE_SYSTEM_PROMPT,
-    generationConfig: {
-      responseMimeType: "application/json",
-      responseSchema: deep ? DEEPDIVE_DOSSIER_SCHEMA : TAKE_DOSSIER_SCHEMA,
-      temperature: 0.7,
-      maxOutputTokens: deep ? 16000 : 8000,
-    },
-  });
 
-  const prompt = [
+  const basePrompt = [
     buildDossierPrompt(dossier, ledger),
     "",
     deep
@@ -596,18 +627,35 @@ export async function synthesiseFromDossier(
       : "Write the four sections (background, recent_events, the_data, outlook). Cite [ref-N] inline. Only cite refIds in CITABLE SOURCES.",
   ].join("\n");
 
-  let raw = "";
+  const proseFor = (p: Record<string, unknown>): string =>
+    deep
+      ? ((p.sections as Array<{ prose: string }>) ?? []).map((s) => s.prose).join("\n") + "\n" + String(p.headline ?? "")
+      : [p.background, p.recent_events, p.the_data, p.outlook, p.headline].join("\n");
+
   let parsed: Record<string, unknown> = {};
+  let parsedOk = false;
+  let hits: string[] = [];
   for (let attempt = 1; attempt <= 2; attempt++) {
-    const resp = await model.generateContent(
-      attempt === 1 ? prompt : prompt + `\n\nIMPORTANT: your previous draft used banned terms. Remove every one.`,
-    );
-    raw = resp.response.text();
-    parsed = JSON.parse(raw);
-    const proseForBan = deep
-      ? (parsed.sections as Array<{ prose: string }> ?? []).map((s) => s.prose).join("\n") + "\n" + String(parsed.headline ?? "")
-      : [parsed.background, parsed.recent_events, parsed.the_data, parsed.outlook, parsed.headline].join("\n");
-    if (findBanned(proseForBan).length === 0) break;
+    const prompt = attempt === 1
+      ? basePrompt
+      : basePrompt + `\n\nIMPORTANT: your previous draft used these banned terms: ${hits.join(", ")}. Re-write removing every one of them. Also re-check the headline.`;
+    const text = await deps.generate(prompt, deep);
+    let candidate: Record<string, unknown>;
+    try {
+      candidate = JSON.parse(text);
+    } catch {
+      console.error(`[dossierwriter] ${stockCode}: attempt ${attempt} JSON.parse failed`);
+      if (attempt < 2) continue;
+      if (!parsedOk) throw new Error(`writer returned unparseable JSON for ${stockCode} after 2 attempts`);
+      break; // keep the last good parse
+    }
+    parsed = candidate;
+    parsedOk = true;
+    hits = findBanned(proseFor(parsed));
+    if (hits.length === 0) break;
+  }
+  if (hits.length > 0) {
+    console.warn(`[dossierwriter] ${stockCode}: shipping with unresolved banned phrases: ${hits.join(", ")}`);
   }
 
   const rawBody = deep
@@ -621,12 +669,8 @@ export async function synthesiseFromDossier(
 
   const { body, citations, dropped } = compactCitations(rawBody, ledger);
 
-  // Slug pass (reuse the existing low-temp slug model behaviour).
-  const slugModel = ai.getGenerativeModel({ model: WRITER_MODEL(), generationConfig: { temperature: 0.2, maxOutputTokens: 500 } });
-  const slugResp = await slugModel.generateContent(
-    SLUG_PROMPT.replace("{{HEADLINE}}", String(parsed.headline ?? "")).replace("{{STOCK_CODE}}", stockCode),
-  );
-  const slug = slugResp.response.text().trim().toLowerCase()
+  const slugRaw = await deps.slug(String(parsed.headline ?? ""), stockCode);
+  const slug = slugRaw.trim().toLowerCase()
     .replace(/[^a-z0-9\s-]+/g, "").replace(/\s+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").slice(0, 80);
 
   return {

--- a/scripts/take-writer/src/narrative.ts
+++ b/scripts/take-writer/src/narrative.ts
@@ -15,6 +15,8 @@
 
 import { GoogleGenerativeAI, SchemaType } from "@google/generative-ai";
 import { type JournalismReport, type NewsArticle } from "./journalism.js";
+import { CitationLedger, compactCitations } from "./ledger.js";
+import type { Dossier } from "./investigator.js";
 
 export interface Citation {
   refId: string;             // ref-1, ref-2, … or report-1, report-2
@@ -475,4 +477,165 @@ export function narrativeToBodyMd(n: NarrativeTake): string {
     "",
     n.outlook,
   ].join("\n");
+}
+
+// ---- Dossier-aware writer (investigative newsroom) ----
+
+const WRITER_MODEL = () => process.env.WRITER_MODEL ?? "gemini-2.5-flash";
+const WRITER_MODEL_DEEPDIVE = () => process.env.WRITER_MODEL_DEEPDIVE ?? WRITER_MODEL();
+
+/** Build the writer prompt from a dossier + its ledger. The writer may
+ *  only cite the refIds listed here. */
+export function buildDossierPrompt(dossier: Dossier, ledger: CitationLedger): string {
+  const sources: string[] = [];
+  for (let i = 1; ledger.has(`ref-${i}`); i++) {
+    const s = ledger.get(`ref-${i}`)!;
+    sources.push(`[ref-${i}] (${s.date}, ${s.source}, ${s.type}): ${s.headline}`);
+  }
+  const threads = dossier.threads
+    .map((t, i) => `${i + 1}. ${t.claim}${t.note ? ` — ${t.note}` : ""} (evidence: ${t.evidenceRefIds.join(", ") || "none"})`)
+    .join("\n");
+  const numbers = dossier.keyNumbers
+    .map((n) => `- ${n.label}: ${n.value}${n.refId ? ` [${n.refId}]` : ""}`)
+    .join("\n");
+  const timeline = (dossier.timeline ?? [])
+    .map((t) => `- ${t.date}: ${t.event} (${t.refIds.join(", ")})`)
+    .join("\n");
+  return [
+    `Subject: ${dossier.stockCode}`,
+    `Angle: ${dossier.angle}`,
+    `Investigation summary: ${dossier.summary}`,
+    "",
+    "=== FINDINGS (threads) ===",
+    threads || "(none)",
+    "",
+    "=== KEY NUMBERS ===",
+    numbers || "(none)",
+    timeline ? `\n=== TIMELINE ===\n${timeline}` : "",
+    "",
+    "=== CITABLE SOURCES (cite ONLY these refIds, inline as [ref-N]) ===",
+    sources.join("\n") || "(none)",
+  ].join("\n");
+}
+
+export function assembleTakeBody(s: { background: string; recent_events: string; the_data: string; outlook: string }): string {
+  return [s.background, "", s.recent_events, "", s.the_data, "", s.outlook].join("\n");
+}
+
+export function assembleDeepDiveBody(sections: Array<{ heading: string; prose: string }>): string {
+  return sections.map((s) => `## ${s.heading}\n\n${s.prose}`).join("\n\n");
+}
+
+export interface DossierTake {
+  slug: string;
+  headline: string;
+  sentiment: "positive" | "negative" | "neutral";
+  tier: "take" | "deep_dive";
+  bodyMd: string;
+  citations: Citation[];
+  droppedCitations: string[];
+}
+
+const TAKE_DOSSIER_SCHEMA = {
+  type: SchemaType.OBJECT,
+  properties: {
+    headline: { type: SchemaType.STRING },
+    sentiment: { type: SchemaType.STRING, enum: ["positive", "negative", "neutral"] },
+    background: { type: SchemaType.STRING },
+    recent_events: { type: SchemaType.STRING },
+    the_data: { type: SchemaType.STRING },
+    outlook: { type: SchemaType.STRING },
+  },
+  required: ["headline", "sentiment", "background", "recent_events", "the_data", "outlook"],
+};
+
+const DEEPDIVE_DOSSIER_SCHEMA = {
+  type: SchemaType.OBJECT,
+  properties: {
+    headline: { type: SchemaType.STRING },
+    sentiment: { type: SchemaType.STRING, enum: ["positive", "negative", "neutral"] },
+    sections: {
+      type: SchemaType.ARRAY,
+      items: {
+        type: SchemaType.OBJECT,
+        properties: { heading: { type: SchemaType.STRING }, prose: { type: SchemaType.STRING } },
+        required: ["heading", "prose"],
+      },
+    },
+  },
+  required: ["headline", "sentiment", "sections"],
+};
+
+/** Write a tiered Take from a grounded dossier. Cites only ledger refIds;
+ *  compactCitations drops anything invented. */
+export async function synthesiseFromDossier(
+  dossier: Dossier,
+  ledger: CitationLedger,
+  stockCode: string,
+): Promise<DossierTake> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error("GEMINI_API_KEY not set");
+  const ai = new GoogleGenerativeAI(apiKey);
+  const deep = dossier.tier === "deep_dive";
+  const model = ai.getGenerativeModel({
+    model: deep ? WRITER_MODEL_DEEPDIVE() : WRITER_MODEL(),
+    systemInstruction: NARRATIVE_SYSTEM_PROMPT,
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseSchema: deep ? DEEPDIVE_DOSSIER_SCHEMA : TAKE_DOSSIER_SCHEMA,
+      temperature: 0.7,
+      maxOutputTokens: deep ? 16000 : 8000,
+    },
+  });
+
+  const prompt = [
+    buildDossierPrompt(dossier, ledger),
+    "",
+    deep
+      ? "Write a long-form investigation (600-1200 words). Derive 3-5 section headings from the findings. Cite [ref-N] inline wherever a fact comes from a source. Only cite refIds in CITABLE SOURCES."
+      : "Write the four sections (background, recent_events, the_data, outlook). Cite [ref-N] inline. Only cite refIds in CITABLE SOURCES.",
+  ].join("\n");
+
+  let raw = "";
+  let parsed: Record<string, unknown> = {};
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const resp = await model.generateContent(
+      attempt === 1 ? prompt : prompt + `\n\nIMPORTANT: your previous draft used banned terms. Remove every one.`,
+    );
+    raw = resp.response.text();
+    parsed = JSON.parse(raw);
+    const proseForBan = deep
+      ? (parsed.sections as Array<{ prose: string }> ?? []).map((s) => s.prose).join("\n") + "\n" + String(parsed.headline ?? "")
+      : [parsed.background, parsed.recent_events, parsed.the_data, parsed.outlook, parsed.headline].join("\n");
+    if (findBanned(proseForBan).length === 0) break;
+  }
+
+  const rawBody = deep
+    ? assembleDeepDiveBody((parsed.sections as Array<{ heading: string; prose: string }>) ?? [])
+    : assembleTakeBody({
+        background: String(parsed.background ?? ""),
+        recent_events: String(parsed.recent_events ?? ""),
+        the_data: String(parsed.the_data ?? ""),
+        outlook: String(parsed.outlook ?? ""),
+      });
+
+  const { body, citations, dropped } = compactCitations(rawBody, ledger);
+
+  // Slug pass (reuse the existing low-temp slug model behaviour).
+  const slugModel = ai.getGenerativeModel({ model: WRITER_MODEL(), generationConfig: { temperature: 0.2, maxOutputTokens: 500 } });
+  const slugResp = await slugModel.generateContent(
+    SLUG_PROMPT.replace("{{HEADLINE}}", String(parsed.headline ?? "")).replace("{{STOCK_CODE}}", stockCode),
+  );
+  const slug = slugResp.response.text().trim().toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, "").replace(/\s+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").slice(0, 80);
+
+  return {
+    slug,
+    headline: String(parsed.headline ?? ""),
+    sentiment: (parsed.sentiment as DossierTake["sentiment"]) ?? "neutral",
+    tier: dossier.tier,
+    bodyMd: body,
+    citations,
+    droppedCitations: dropped,
+  };
 }

--- a/scripts/take-writer/src/newsroom.ts
+++ b/scripts/take-writer/src/newsroom.ts
@@ -14,11 +14,10 @@ import { Client as PgClient } from "pg";
 import OpenAI from "openai";
 import { Storage } from "@google-cloud/storage";
 import { buildAgenda, type AgendaCandidate, type AgendaAngle } from "./agenda.js";
-import { synthesiseNarrative, narrativeToBodyMd, type NarrativeTake } from "./narrative.js";
+import { synthesiseNarrative, narrativeToBodyMd, type NarrativeTake, synthesiseFromDossier, type DossierTake } from "./narrative.js";
 import Anthropic from "@anthropic-ai/sdk";
-import { commissionAssignments, type Assignment } from "./editor.js";
+import { commissionAssignments } from "./editor.js";
 import { investigate } from "./investigator.js";
-import { synthesiseFromDossier, type DossierTake } from "./narrative.js";
 import { CitationLedger } from "./ledger.js";
 
 const GCS_BUCKET = process.env.GCS_LOGO_BUCKET ?? "shorted-company-logos";
@@ -335,12 +334,12 @@ async function insertTake(
 }
 
 /** Hold a piece as a draft (don't auto-publish) when grounding is weak:
- *  any dangling citation the writer invented, or a deep-dive with no
- *  citations at all. Never auto-publish ungrounded claims about a named
- *  company. */
+ *  any dangling citation the writer invented, OR zero retrieved-source
+ *  citations at all (regardless of tier). Never auto-publish ungrounded
+ *  claims about a named company — a human reviews held drafts. */
 export function shouldHoldAsDraft(t: { droppedCitations: string[]; citations: unknown[]; tier?: "take" | "deep_dive" }): boolean {
   if (t.droppedCitations.length > 0) return true;
-  if (t.tier === "deep_dive" && t.citations.length === 0) return true;
+  if (t.citations.length === 0) return true;
   return false;
 }
 
@@ -354,6 +353,7 @@ async function insertDossierTake(
   writerModel: string,
 ): Promise<void> {
   const publishedClause = publish ? "NOW()" : "NULL";
+  // ON CONFLICT preserves published_at: re-runs never silently flip a reviewed draft's publish state.
   await pg.query(
     `INSERT INTO editorial_takes (
        slug, headline, stock_code, body_md, sentiment, word_count, model, tier,
@@ -388,6 +388,9 @@ export async function runNewsroomDaily(opts: DailyOptions): Promise<void> {
   if (!dbUrl) throw new Error("DATABASE_URL not set");
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
   if (!anthropicKey) throw new Error("ANTHROPIC_API_KEY not set");
+  if (opts.withImages && !process.env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY not set (required for --with-images)");
+  }
 
   const takeModel = process.env.INVESTIGATOR_MODEL_TAKE ?? "claude-sonnet-4-6";
   const deepModel = process.env.INVESTIGATOR_MODEL_DEEPDIVE ?? "claude-opus-4-8";
@@ -441,15 +444,15 @@ export async function runNewsroomDaily(opts: DailyOptions): Promise<void> {
         console.log(`${tag} -> "${take.headline}" (${take.citations.length} cites, ${take.droppedCitations.length} dropped)`);
 
         const hold = shouldHoldAsDraft(take);
-        if (hold && opts.autoPublish) {
-          console.warn(`${tag}   holding as draft (grounding weak: dropped ${take.droppedCitations.join(",") || "none"})`);
+        if (hold) {
+          console.warn(`${tag}   weak grounding (dropped ${take.droppedCitations.join(",") || "none"}; ${take.citations.length} cites) — held as draft`);
         }
         const publishThis = opts.autoPublish && !hold;
 
         let heroUrl: string | null = null;
         let inlineImages: InlineImageRow[] = [];
         if (opts.withImages && openai && storage) {
-          const candidate = { stockCode: a.stockCode, industry: null } as unknown as AgendaCandidate;
+          const candidate = { stockCode: a.stockCode, industry: a.industry } as unknown as AgendaCandidate;
           const narrativeShim = { slug: take.slug, headline: take.headline } as unknown as NarrativeTake;
           const img = await generateHero(openai, storage, candidate, narrativeShim);
           heroUrl = img.url; totalCost += img.costUsd;

--- a/scripts/take-writer/src/newsroom.ts
+++ b/scripts/take-writer/src/newsroom.ts
@@ -336,7 +336,10 @@ async function insertTake(
 /** Hold a piece as a draft (don't auto-publish) when grounding is weak:
  *  any dangling citation the writer invented, OR zero retrieved-source
  *  citations at all (regardless of tier). Never auto-publish ungrounded
- *  claims about a named company — a human reviews held drafts. */
+ *  claims about a named company — a human reviews held drafts.
+ *  NOTE: this gates on citation MARKERS resolving, not on every claim
+ *  being cited — an uncited invented number can still pass. Claim-level
+ *  grounding is the model's responsibility via the system prompt. */
 export function shouldHoldAsDraft(t: { droppedCitations: string[]; citations: unknown[]; tier?: "take" | "deep_dive" }): boolean {
   if (t.droppedCitations.length > 0) return true;
   if (t.citations.length === 0) return true;
@@ -388,6 +391,7 @@ export async function runNewsroomDaily(opts: DailyOptions): Promise<void> {
   if (!dbUrl) throw new Error("DATABASE_URL not set");
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
   if (!anthropicKey) throw new Error("ANTHROPIC_API_KEY not set");
+  if (!process.env.GEMINI_API_KEY) throw new Error("GEMINI_API_KEY not set (required by the writer)");
   if (opts.withImages && !process.env.OPENAI_API_KEY) {
     throw new Error("OPENAI_API_KEY not set (required for --with-images)");
   }

--- a/scripts/take-writer/src/newsroom.ts
+++ b/scripts/take-writer/src/newsroom.ts
@@ -15,6 +15,11 @@ import OpenAI from "openai";
 import { Storage } from "@google-cloud/storage";
 import { buildAgenda, type AgendaCandidate, type AgendaAngle } from "./agenda.js";
 import { synthesiseNarrative, narrativeToBodyMd, type NarrativeTake } from "./narrative.js";
+import Anthropic from "@anthropic-ai/sdk";
+import { commissionAssignments, type Assignment } from "./editor.js";
+import { investigate } from "./investigator.js";
+import { synthesiseFromDossier, type DossierTake } from "./narrative.js";
+import { CitationLedger } from "./ledger.js";
 
 const GCS_BUCKET = process.env.GCS_LOGO_BUCKET ?? "shorted-company-logos";
 const SITE_URL = process.env.SHORTED_SITE_URL ?? "https://shorted.com.au";
@@ -327,6 +332,148 @@ async function insertTake(
       JSON.stringify(inlineImages),
     ],
   );
+}
+
+/** Hold a piece as a draft (don't auto-publish) when grounding is weak:
+ *  any dangling citation the writer invented, or a deep-dive with no
+ *  citations at all. Never auto-publish ungrounded claims about a named
+ *  company. */
+export function shouldHoldAsDraft(t: { droppedCitations: string[]; citations: unknown[]; tier?: "take" | "deep_dive" }): boolean {
+  if (t.droppedCitations.length > 0) return true;
+  if (t.tier === "deep_dive" && t.citations.length === 0) return true;
+  return false;
+}
+
+async function insertDossierTake(
+  pg: PgClient,
+  take: DossierTake,
+  stockCode: string,
+  heroUrl: string | null,
+  inlineImages: InlineImageRow[],
+  publish: boolean,
+  writerModel: string,
+): Promise<void> {
+  const publishedClause = publish ? "NOW()" : "NULL";
+  await pg.query(
+    `INSERT INTO editorial_takes (
+       slug, headline, stock_code, body_md, sentiment, word_count, model, tier,
+       citations, hero_image_url, inline_images, published_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11::jsonb,${publishedClause})
+     ON CONFLICT (slug) DO UPDATE SET
+       headline=EXCLUDED.headline, body_md=EXCLUDED.body_md, tier=EXCLUDED.tier,
+       sentiment=EXCLUDED.sentiment, word_count=EXCLUDED.word_count,
+       citations=EXCLUDED.citations,
+       hero_image_url=COALESCE(EXCLUDED.hero_image_url, editorial_takes.hero_image_url),
+       inline_images=CASE WHEN jsonb_array_length(EXCLUDED.inline_images) > 0
+                          THEN EXCLUDED.inline_images ELSE editorial_takes.inline_images END,
+       updated_at=NOW()`,
+    [
+      take.slug, take.headline, stockCode, take.bodyMd, take.sentiment,
+      take.bodyMd.split(/\s+/).filter(Boolean).length, writerModel, take.tier,
+      JSON.stringify(take.citations), heroUrl, JSON.stringify(inlineImages),
+    ],
+  );
+}
+
+export interface DailyOptions {
+  poolSize?: number;
+  maxTakes?: number;
+  maxDeepDives?: number;
+  autoPublish: boolean;
+  withImages: boolean;
+}
+
+export async function runNewsroomDaily(opts: DailyOptions): Promise<void> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error("DATABASE_URL not set");
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (!anthropicKey) throw new Error("ANTHROPIC_API_KEY not set");
+
+  const takeModel = process.env.INVESTIGATOR_MODEL_TAKE ?? "claude-sonnet-4-6";
+  const deepModel = process.env.INVESTIGATOR_MODEL_DEEPDIVE ?? "claude-opus-4-8";
+  const maxTurnsTake = Number(process.env.MAX_TURNS_TAKE ?? 6);
+  const maxTurnsDeep = Number(process.env.MAX_TURNS_DEEPDIVE ?? 14);
+
+  const pg = new PgClient({ connectionString: dbUrl });
+  await pg.connect();
+  const client = new Anthropic({ apiKey: anthropicKey });
+  const create = (body: Anthropic.MessageCreateParamsNonStreaming) => client.messages.create(body) as Promise<Anthropic.Message>;
+
+  let openai: OpenAI | null = null;
+  let storage: Storage | null = null;
+  if (opts.withImages) {
+    const key = process.env.OPENAI_API_KEY;
+    if (!key) throw new Error("OPENAI_API_KEY not set (required for --with-images)");
+    openai = new OpenAI({ apiKey: key });
+    storage = new Storage();
+  }
+
+  let totalCost = 0;
+  let published = 0, drafted = 0, held = 0, failed = 0;
+
+  try {
+    console.log(`\n[newsroom-daily] commissioning (pool ${opts.poolSize ?? 30}, <=${opts.maxTakes ?? 10} takes, <=${opts.maxDeepDives ?? 2} deep-dives)...`);
+    const assignments = await commissionAssignments(pg, {
+      poolSize: opts.poolSize,
+      maxTakes: opts.maxTakes,
+      maxDeepDives: opts.maxDeepDives,
+    });
+    if (assignments.length === 0) {
+      console.log("[newsroom-daily] nothing new to cover today.");
+      return;
+    }
+    console.log(`[newsroom-daily] ${assignments.length} assignments:`);
+    for (const a of assignments) console.log(`  - ${a.stockCode} [${a.tier}] ${a.angle}`);
+
+    for (const [i, a] of assignments.entries()) {
+      const tag = `[${i + 1}/${assignments.length}] ${a.stockCode}`;
+      const t0 = Date.now();
+      try {
+        const ledger = new CitationLedger();
+        const dossier = await investigate(create, pg, a, ledger, {
+          model: a.tier === "deep_dive" ? deepModel : takeModel,
+          maxTurns: a.tier === "deep_dive" ? maxTurnsDeep : maxTurnsTake,
+        });
+        const writerModel = a.tier === "deep_dive"
+          ? (process.env.WRITER_MODEL_DEEPDIVE ?? process.env.WRITER_MODEL ?? "gemini-2.5-flash")
+          : (process.env.WRITER_MODEL ?? "gemini-2.5-flash");
+        const take = await synthesiseFromDossier(dossier, ledger, a.stockCode);
+        console.log(`${tag} -> "${take.headline}" (${take.citations.length} cites, ${take.droppedCitations.length} dropped)`);
+
+        const hold = shouldHoldAsDraft(take);
+        if (hold && opts.autoPublish) {
+          console.warn(`${tag}   holding as draft (grounding weak: dropped ${take.droppedCitations.join(",") || "none"})`);
+        }
+        const publishThis = opts.autoPublish && !hold;
+
+        let heroUrl: string | null = null;
+        let inlineImages: InlineImageRow[] = [];
+        if (opts.withImages && openai && storage) {
+          const candidate = { stockCode: a.stockCode, industry: null } as unknown as AgendaCandidate;
+          const narrativeShim = { slug: take.slug, headline: take.headline } as unknown as NarrativeTake;
+          const img = await generateHero(openai, storage, candidate, narrativeShim);
+          heroUrl = img.url; totalCost += img.costUsd;
+          const inl = await generateInlineImages(openai, storage, candidate, narrativeShim, 2);
+          inlineImages = inl.images; totalCost += inl.costUsd;
+        }
+
+        await insertDossierTake(pg, take, a.stockCode, heroUrl, inlineImages, publishThis, writerModel);
+        if (publishThis) published++;
+        else if (hold) held++;
+        else drafted++;
+        console.log(`${tag}   ${publishThis ? "published" : "draft"} /news/${take.slug} (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+      } catch (err) {
+        failed++;
+        console.log(`${tag}   FAILED: ${String((err as Error).message ?? err).slice(0, 160)}`);
+      }
+    }
+  } finally {
+    await pg.end();
+  }
+
+  console.log("\n=== Newsroom-daily briefing ===");
+  console.log(`  published: ${published}  drafted: ${drafted}  held(weak grounding): ${held}  failed: ${failed}`);
+  console.log(`  image cost: $${totalCost.toFixed(3)} (LLM token cost logged by providers)`);
 }
 
 export async function runNewsroom(opts: NewsroomOptions): Promise<NewsroomResult[]> {

--- a/scripts/take-writer/src/publishguard.test.ts
+++ b/scripts/take-writer/src/publishguard.test.ts
@@ -8,6 +8,9 @@ describe("shouldHoldAsDraft", () => {
   it("holds a deep_dive with zero citations (ungrounded long-form)", () => {
     expect(shouldHoldAsDraft({ droppedCitations: [], citations: [], tier: "deep_dive" } as any)).toBe(true);
   });
+  it("holds a take with zero citations (ungrounded)", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: [], citations: [], tier: "take" })).toBe(true);
+  });
   it("allows a clean grounded take through", () => {
     expect(shouldHoldAsDraft({ droppedCitations: [], citations: [{ refId: "ref-1" } as any], tier: "take" } as any)).toBe(false);
   });

--- a/scripts/take-writer/src/publishguard.test.ts
+++ b/scripts/take-writer/src/publishguard.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { shouldHoldAsDraft } from "./newsroom.js";
+
+describe("shouldHoldAsDraft", () => {
+  it("holds when there are dropped (dangling) citations", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: ["ref-9"], citations: [{ refId: "ref-1" } as any] })).toBe(true);
+  });
+  it("holds a deep_dive with zero citations (ungrounded long-form)", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: [], citations: [], tier: "deep_dive" } as any)).toBe(true);
+  });
+  it("allows a clean grounded take through", () => {
+    expect(shouldHoldAsDraft({ droppedCitations: [], citations: [{ refId: "ref-1" } as any], tier: "take" } as any)).toBe(false);
+  });
+});

--- a/scripts/take-writer/src/signalboard.test.ts
+++ b/scripts/take-writer/src/signalboard.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from "vitest";
+import { lastTakeDateForStock } from "./journalism.js";
+
+describe("lastTakeDateForStock", () => {
+  it("returns the most recent created_at for a stock, or null", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [{ last: "2026-05-20" }] }) } as any;
+    expect(await lastTakeDateForStock(pg, "BHP")).toBe("2026-05-20");
+  });
+  it("returns null when no take exists", async () => {
+    const pg = { query: vi.fn().mockResolvedValue({ rows: [] }) } as any;
+    expect(await lastTakeDateForStock(pg, "BHP")).toBeNull();
+  });
+});

--- a/scripts/take-writer/src/tools.test.ts
+++ b/scripts/take-writer/src/tools.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { TOOL_DEFS, dispatchTool } from "./tools.js";
+import { CitationLedger } from "./ledger.js";
+
+describe("TOOL_DEFS", () => {
+  it("declares the expected tools with input schemas", () => {
+    const names = TOOL_DEFS.map((t) => t.name).sort();
+    expect(names).toEqual(
+      ["align_events", "follow_peer", "news_detail", "report_line", "search_news", "zoom_window"].sort(),
+    );
+    for (const t of TOOL_DEFS) {
+      expect(t.input_schema.type).toBe("object");
+    }
+  });
+});
+
+describe("dispatchTool", () => {
+  it("runs search_news and registers each returned source in the ledger", async () => {
+    const ledger = new CitationLedger();
+    const pg = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ id: "1", date: "2026-05-01", source: "Stockhead", headline: "Probe", url: "https://x/1" }],
+      }),
+    };
+    const out = await dispatchTool(pg, ledger, "search_news", { query: "probe", code: "DRO" });
+    expect(ledger.size()).toBe(1);
+    expect(ledger.has("ref-1")).toBe(true);
+    // The agent-facing result embeds the refId so the model can cite it.
+    expect(out).toContain("ref-1");
+    expect(out).toContain("Probe");
+  });
+
+  it("returns an error string for an unknown tool instead of throwing", async () => {
+    const ledger = new CitationLedger();
+    const pg = { query: vi.fn() };
+    const out = await dispatchTool(pg, ledger, "nope", {});
+    expect(out.toLowerCase()).toContain("unknown tool");
+  });
+});

--- a/scripts/take-writer/src/tools.ts
+++ b/scripts/take-writer/src/tools.ts
@@ -1,0 +1,125 @@
+// Anthropic tool registry for the investigation agent. Each tool wraps
+// a drill-down query. dispatchTool registers every source the tool
+// surfaces into the citation ledger (handing back stable refIds) so the
+// writer can cite only what was actually retrieved.
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { CitationLedger, LedgerSource } from "./ledger.js";
+import {
+  zoomWindow, reportLine, followPeer, alignEvents, newsDetail, searchNews,
+  type Queryable,
+} from "./drilldowns.js";
+
+export const TOOL_DEFS: Anthropic.Tool[] = [
+  {
+    name: "zoom_window",
+    description: "Zoom into the short %, price, and news in a +/- day window around a specific date — use to investigate a spike or a price move you noticed in the summary.",
+    input_schema: {
+      type: "object",
+      properties: {
+        date: { type: "string", description: "Centre date YYYY-MM-DD" },
+        days: { type: "number", description: "Half-window in days (e.g. 3)" },
+      },
+      required: ["date"],
+    },
+  },
+  {
+    name: "report_line",
+    description: "Pull one reported financial metric (revenue, ebitda, eps, dividend, guidance, cash_flow, net_profit) from the company's most recent filings. Returns the value and a citable source.",
+    input_schema: {
+      type: "object",
+      properties: { metric: { type: "string", description: "Metric key, e.g. 'revenue'" } },
+      required: ["metric"],
+    },
+  },
+  {
+    name: "follow_peer",
+    description: "Pull a named sector peer's short %/price history to compare divergence against the subject stock.",
+    input_schema: {
+      type: "object",
+      properties: { peerCode: { type: "string" }, days: { type: "number" } },
+      required: ["peerCode"],
+    },
+  },
+  {
+    name: "align_events",
+    description: "Return a merged timeline of director trades and price-sensitive news for the subject, newest first — use to align director activity against price/short moves.",
+    input_schema: { type: "object", properties: { days: { type: "number" } } },
+  },
+  {
+    name: "news_detail",
+    description: "Fetch the full record (summary, sentiment, url) for one news article by its id.",
+    input_schema: {
+      type: "object",
+      properties: { articleId: { type: "string" } },
+      required: ["articleId"],
+    },
+  },
+  {
+    name: "search_news",
+    description: "Keyword-search recent news headlines/summaries (optionally scoped to a stock code) to find a specific thread.",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" }, code: { type: "string" } },
+      required: ["query"],
+    },
+  },
+];
+
+/** Register a source and return "[refId] headline (source, date)" for the agent. */
+function cite(ledger: CitationLedger, s: LedgerSource): string {
+  const refId = ledger.register(s);
+  return `[${refId}] ${s.headline} (${s.source}, ${s.date})`;
+}
+
+export async function dispatchTool(
+  pg: Queryable,
+  ledger: CitationLedger,
+  name: string,
+  input: Record<string, unknown>,
+  subjectCode?: string,
+): Promise<string> {
+  try {
+    switch (name) {
+      case "zoom_window": {
+        const code = subjectCode ?? String(input.code ?? "");
+        const w = await zoomWindow(pg, code, String(input.date), Number(input.days ?? 3));
+        const newsLines = w.news.map((n) => cite(ledger, { type: "news", url: n.url, source: n.source, headline: n.headline, date: n.date }));
+        return JSON.stringify({
+          shorts: w.shorts, prices: w.prices,
+          news: newsLines,
+        });
+      }
+      case "report_line": {
+        const code = subjectCode ?? String(input.code ?? "");
+        const r = await reportLine(pg, code, String(input.metric));
+        if (!r) return JSON.stringify({ found: false });
+        const ref = cite(ledger, r.source);
+        return JSON.stringify({ found: true, value: r.value, reportType: r.reportType, date: r.reportDate, citation: ref });
+      }
+      case "follow_peer": {
+        const r = await followPeer(pg, String(input.peerCode), Number(input.days ?? 180));
+        return JSON.stringify(r);
+      }
+      case "align_events": {
+        const code = subjectCode ?? String(input.code ?? "");
+        const items = await alignEvents(pg, code, Number(input.days ?? 180));
+        return JSON.stringify(items.map((it) => ({ date: it.date, kind: it.kind, detail: it.detail, citation: cite(ledger, it.source) })));
+      }
+      case "news_detail": {
+        const r = await newsDetail(pg, String(input.articleId));
+        if (!r) return JSON.stringify({ found: false });
+        const ref = cite(ledger, r.ledgerSource);
+        return JSON.stringify({ found: true, headline: r.headline, summary: r.summary, sentiment: r.sentiment, date: r.date, citation: ref });
+      }
+      case "search_news": {
+        const items = await searchNews(pg, String(input.query), input.code ? String(input.code) : subjectCode);
+        return JSON.stringify(items.map((it) => ({ id: it.id, citation: cite(ledger, it.ledgerSource) })));
+      }
+      default:
+        return `ERROR: unknown tool "${name}"`;
+    }
+  } catch (err) {
+    return `ERROR running ${name}: ${String((err as Error).message ?? err).slice(0, 200)}`;
+  }
+}

--- a/scripts/take-writer/vitest.config.ts
+++ b/scripts/take-writer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/services/edge-worker/worker.js
+++ b/services/edge-worker/worker.js
@@ -121,11 +121,17 @@ const worker = {
       return proxyWithHeaders(request, shortsApiOrigin, "BYPASS");
     }
 
-    // gRPC/Connect streaming indicators -> pass-through
+    // gRPC/Connect streaming indicators -> pass-through to the Shorts API.
+    // IMPORTANT: chat and market-data Connect requests ALSO carry these headers,
+    // so they must be excluded here and fall through to their own path-based
+    // routes below — otherwise every browser Connect call (which always sends
+    // `connect-protocol-version`) gets misrouted to the Shorts origin and 404s.
     if (
-      request.headers.get("connect-protocol-version") ||
-      request.headers.get("grpc-timeout") ||
-      request.headers.get("x-grpc-web")
+      (request.headers.get("connect-protocol-version") ||
+        request.headers.get("grpc-timeout") ||
+        request.headers.get("x-grpc-web")) &&
+      !path.includes("/chat.v1.") &&
+      !path.includes("/marketdata.v1.")
     ) {
       return proxyWithHeaders(request, shortsApiOrigin, "BYPASS");
     }

--- a/services/migrations/000038_editorial_takes_tier.down.sql
+++ b/services/migrations/000038_editorial_takes_tier.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE editorial_takes DROP COLUMN IF EXISTS tier;

--- a/services/migrations/000038_editorial_takes_tier.up.sql
+++ b/services/migrations/000038_editorial_takes_tier.up.sql
@@ -1,0 +1,8 @@
+-- Tiered editorial output: most takes are tight 4-section "take"s; a
+-- couple per day are promoted to long-form "deep_dive" investigations.
+-- The investigative newsroom (scripts/take-writer) sets this.
+ALTER TABLE editorial_takes
+  ADD COLUMN IF NOT EXISTS tier VARCHAR(20) NOT NULL DEFAULT 'take';
+
+-- Allowed values: 'take' | 'deep_dive'. Enforced in app, documented here.
+COMMENT ON COLUMN editorial_takes.tier IS 'take | deep_dive';

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -144,7 +144,7 @@ module "shorts_api" {
   postgres_username = var.postgres_username
 
   scheduler_region             = "australia-southeast1"
-  enable_key_metrics_scheduler = false  # Disabled: secret INTERNAL_METRICS_SCHEDULER_SECRET not accessible to terraform SA (secretmanager.versions.get denied)
+  enable_key_metrics_scheduler = false # Disabled: secret INTERNAL_METRICS_SCHEDULER_SECRET not accessible to terraform SA (secretmanager.versions.get denied)
 
   depends_on = [
   ]
@@ -234,10 +234,10 @@ module "grafana_dashboards" {
 module "weekly_report_generator" {
   source = "../../modules/weekly-report-generator"
 
-  project_id       = var.project_id
-  region           = var.region
-  scheduler_region = "australia-southeast1" # Cloud Scheduler only available in southeast1
-  environment      = "production"
+  project_id           = var.project_id
+  region               = var.region
+  scheduler_region     = "australia-southeast1" # Cloud Scheduler only available in southeast1
+  environment          = "production"
   image_url            = var.weekly_report_generator_image
   gemini_secret_exists = var.gemini_secret_exists
 
@@ -280,29 +280,29 @@ module "asx_announcement_crawler" {
 module "cloudflare_edge" {
   source = "../../modules/cloudflare-edge"
 
-  cloudflare_zone_id   = var.cloudflare_zone_id
-  domain               = "api.shorted.com.au"
-  environment          = "dev"
+  cloudflare_zone_id = var.cloudflare_zone_id
+  domain             = "api.shorted.com.au"
+  environment        = "dev"
 
-  shorts_api_origin    = module.shorts_api.service_url
-  chat_service_origin  = module.chat_service.service_url
-  market_data_origin   = module.market_data.service_url
+  shorts_api_origin       = module.shorts_api.service_url
+  chat_service_origin     = module.chat_service.service_url
+  market_data_origin      = module.market_data.service_url
   frontend_origin         = "https://shorted.com.au"
-  create_frontend_records = true  # Enable frontend DNS management via Cloudflare
+  create_frontend_records = true # Enable frontend DNS management via Cloudflare
 
   cache_ttl_seconds    = 30
   top_shorts_cache_ttl = 60
   stock_data_cache_ttl = 30
   news_cache_ttl       = 120
 
-  rate_limit_enabled   = true
-  api_rate_limit_requests = 60
+  rate_limit_enabled         = true
+  api_rate_limit_requests    = 60
   search_rate_limit_requests = 20
 
   waf_enabled            = true
   bot_protection_enabled = false
 
-  cache_purge_secret     = var.cache_purge_secret
+  cache_purge_secret = var.cache_purge_secret
 }
 
 output "edge_url" {
@@ -313,4 +313,20 @@ output "edge_url" {
 output "edge_worker_name" {
   description = "Name of the Cloudflare edge worker."
   value       = module.cloudflare_edge.worker_name
+}
+
+# Newsroom Daily Job (take-writer — generates and publishes daily takes)
+module "newsroom_job" {
+  source = "../../modules/newsroom-job"
+
+  project_id       = var.project_id
+  region           = var.region
+  scheduler_region = "australia-southeast1" # Cloud Scheduler only available in southeast1
+  environment      = "production"
+  image_url        = var.newsroom_job_image
+
+  gemini_secret_exists    = var.gemini_secret_exists
+  anthropic_secret_exists = var.anthropic_secret_exists
+
+  depends_on = []
 }

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -110,7 +110,7 @@ variable "grafana_auth" {
   description = "Grafana service account token"
   type        = string
   sensitive   = true
-  default     = ""  # NOTE: Grafana dashboards not yet configured — set real token to enable
+  default     = "" # NOTE: Grafana dashboards not yet configured — set real token to enable
 }
 
 # ---- Cloudflare Edge ----
@@ -157,4 +157,16 @@ variable "gemini_secret_exists" {
   description = "Whether the Gemini API secret exists in Secret Manager"
   type        = bool
   default     = true
+}
+
+variable "anthropic_secret_exists" {
+  description = "Whether ANTHROPIC_API_KEY secret exists in Secret Manager"
+  type        = bool
+  default     = true
+}
+
+variable "newsroom_job_image" {
+  description = "Docker image URL for the newsroom daily take-writer job"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/take-writer:latest"
 }

--- a/terraform/modules/newsroom-job/main.tf
+++ b/terraform/modules/newsroom-job/main.tf
@@ -1,0 +1,248 @@
+/**
+ * Newsroom Job Module
+ *
+ * Manages:
+ * - Cloud Run Job for daily take-writer newsroom generation
+ * - Service account and IAM permissions (Secret Manager + GCS)
+ * - Cloud Scheduler job (daily, 06:00 AEST = 20:00 UTC)
+ */
+
+locals {
+  service_name = "newsroom-daily"
+  labels = {
+    service     = "newsroom-daily"
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+# Service Account for the Cloud Run job
+resource "google_service_account" "newsroom" {
+  account_id   = "newsroom-job"
+  display_name = "Newsroom Daily Job"
+  description  = "Service account for the daily take-writer newsroom Cloud Run job"
+  project      = var.project_id
+}
+
+# Grant Secret Manager access for DATABASE_URL
+resource "google_secret_manager_secret_iam_member" "database_url" {
+  secret_id = "DATABASE_URL"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.newsroom.email}"
+  project   = var.project_id
+}
+
+# Grant Secret Manager access for OPENAI_API_KEY
+resource "google_secret_manager_secret_iam_member" "openai_api_key" {
+  secret_id = "OPENAI_API_KEY"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.newsroom.email}"
+  project   = var.project_id
+}
+
+# Grant Secret Manager access for GEMINI_API_KEY (optional — created only if secret exists)
+resource "google_secret_manager_secret_iam_member" "gemini_api_key" {
+  count     = var.gemini_secret_exists ? 1 : 0
+  secret_id = "GEMINI_API_KEY"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.newsroom.email}"
+  project   = var.project_id
+}
+
+# Grant Secret Manager access for ANTHROPIC_API_KEY (optional — created only if secret exists)
+resource "google_secret_manager_secret_iam_member" "anthropic_api_key" {
+  count     = var.anthropic_secret_exists ? 1 : 0
+  secret_id = "ANTHROPIC_API_KEY"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.newsroom.email}"
+  project   = var.project_id
+}
+
+# Grant access to OpenTelemetry OTLP headers secret
+resource "google_secret_manager_secret_iam_member" "otel_headers" {
+  secret_id = "OTEL_EXPORTER_OTLP_HEADERS"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.newsroom.email}"
+  project   = var.project_id
+}
+
+# Grant GCS object read/write access for company logos
+resource "google_storage_bucket_iam_member" "newsroom_gcs" {
+  bucket = var.gcs_logo_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.newsroom.email}"
+}
+
+# Cloud Run Job (v2)
+resource "google_cloud_run_v2_job" "newsroom" {
+  name     = local.service_name
+  location = var.region
+  project  = var.project_id
+
+  labels = local.labels
+
+  template {
+    task_count = 1
+
+    template {
+      service_account = google_service_account.newsroom.email
+
+      max_retries = 0
+      timeout     = "1800s" # 30 minutes
+
+      containers {
+        image = var.image_url
+        args  = ["newsroom-daily", "--auto-publish", "--with-images"]
+
+        env {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+
+        env {
+          name  = "GCS_LOGO_BUCKET"
+          value = var.gcs_logo_bucket
+        }
+
+        env {
+          name  = "MAX_TAKES_PER_DAY"
+          value = var.max_takes_per_day
+        }
+
+        env {
+          name  = "MAX_DEEPDIVES_PER_DAY"
+          value = var.max_deepdives_per_day
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = "DATABASE_URL"
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name = "OPENAI_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = "OPENAI_API_KEY"
+              version = "latest"
+            }
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.gemini_secret_exists ? [1] : []
+          content {
+            name = "GEMINI_API_KEY"
+            value_source {
+              secret_key_ref {
+                secret  = "GEMINI_API_KEY"
+                version = "latest"
+              }
+            }
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.anthropic_secret_exists ? [1] : []
+          content {
+            name = "ANTHROPIC_API_KEY"
+            value_source {
+              secret_key_ref {
+                secret  = "ANTHROPIC_API_KEY"
+                version = "latest"
+              }
+            }
+          }
+        }
+
+        # OpenTelemetry configuration (traces + metrics to Grafana Cloud)
+        env {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.otel_endpoint
+        }
+
+        env {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "http/protobuf"
+        }
+
+        env {
+          name = "OTEL_EXPORTER_OTLP_HEADERS"
+          value_source {
+            secret_key_ref {
+              secret  = "OTEL_EXPORTER_OTLP_HEADERS"
+              version = "latest"
+            }
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "2"
+            memory = "2Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.database_url,
+    google_secret_manager_secret_iam_member.openai_api_key,
+    google_secret_manager_secret_iam_member.otel_headers,
+  ]
+}
+
+# Service account for Cloud Scheduler to invoke the job
+resource "google_service_account" "scheduler_invoker" {
+  account_id   = "newsroom-scheduler"
+  display_name = "Newsroom Daily Scheduler"
+  description  = "Service account for Cloud Scheduler to invoke the newsroom daily job"
+  project      = var.project_id
+}
+
+# Grant Cloud Run Invoker role to scheduler service account
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
+  name     = google_cloud_run_v2_job.newsroom.name
+  location = google_cloud_run_v2_job.newsroom.location
+  project  = var.project_id
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+# Cloud Scheduler Job — daily at 06:00 AEST (20:00 UTC previous day)
+resource "google_cloud_scheduler_job" "newsroom_daily" {
+  name             = "${local.service_name}-trigger"
+  description      = "Daily trigger for the take-writer newsroom job (06:00 AEST)"
+  schedule         = var.schedule
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "3600s"
+    min_backoff_duration = "30s"
+    max_backoff_duration = "600s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.newsroom.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+  }
+
+  depends_on = [
+    google_cloud_run_v2_job.newsroom,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker,
+  ]
+}

--- a/terraform/modules/newsroom-job/outputs.tf
+++ b/terraform/modules/newsroom-job/outputs.tf
@@ -1,0 +1,19 @@
+output "job_name" {
+  description = "Name of the Cloud Run job"
+  value       = google_cloud_run_v2_job.newsroom.name
+}
+
+output "job_id" {
+  description = "Full resource ID of the Cloud Run job"
+  value       = google_cloud_run_v2_job.newsroom.id
+}
+
+output "service_account_email" {
+  description = "Email of the newsroom job service account"
+  value       = google_service_account.newsroom.email
+}
+
+output "scheduler_job_name" {
+  description = "Name of the Cloud Scheduler job"
+  value       = google_cloud_scheduler_job.newsroom_daily.name
+}

--- a/terraform/modules/newsroom-job/variables.tf
+++ b/terraform/modules/newsroom-job/variables.tf
@@ -1,0 +1,69 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for Cloud Run job"
+  type        = string
+  default     = "australia-southeast2"
+}
+
+variable "scheduler_region" {
+  description = "GCP region for Cloud Scheduler (southeast1 — only region with Cloud Scheduler)"
+  type        = string
+  default     = "australia-southeast1"
+}
+
+variable "environment" {
+  description = "Environment name (development, staging, production)"
+  type        = string
+  default     = "production"
+}
+
+variable "image_url" {
+  description = "Docker image URL for the take-writer newsroom job"
+  type        = string
+}
+
+variable "schedule" {
+  description = "Cron schedule (UTC) — default 20:00 UTC = 06:00 AEST"
+  type        = string
+  default     = "0 20 * * *"
+}
+
+variable "gemini_secret_exists" {
+  description = "Whether GEMINI_API_KEY secret exists in Secret Manager"
+  type        = bool
+  default     = true
+}
+
+variable "anthropic_secret_exists" {
+  description = "Whether ANTHROPIC_API_KEY secret exists in Secret Manager"
+  type        = bool
+  default     = true
+}
+
+variable "gcs_logo_bucket" {
+  description = "GCS bucket name for company logos"
+  type        = string
+  default     = "shorted-company-logos"
+}
+
+variable "max_takes_per_day" {
+  description = "Maximum number of takes to generate per daily run"
+  type        = string
+  default     = "10"
+}
+
+variable "max_deepdives_per_day" {
+  description = "Maximum number of deep-dive takes to generate per daily run"
+  type        = string
+  default     = "2"
+}
+
+variable "otel_endpoint" {
+  description = "OpenTelemetry OTLP endpoint for traces and metrics"
+  type        = string
+  default     = "https://otlp-gateway-prod-au-southeast-1.grafana.net/otlp"
+}

--- a/web/src/@/components/docs/subscription-gate.tsx
+++ b/web/src/@/components/docs/subscription-gate.tsx
@@ -180,7 +180,7 @@ export function SubscriptionGate({
             Unlock API Access
           </CardTitle>
           <span className="text-2xl font-bold">
-            $29<span className="text-sm font-normal text-muted-foreground">/mo</span>
+            $20<span className="text-sm font-normal text-muted-foreground">/mo</span>
           </span>
         </div>
         <CardDescription>

--- a/web/src/@/components/ui/site-footer.tsx
+++ b/web/src/@/components/ui/site-footer.tsx
@@ -115,14 +115,18 @@ const SiteFooter = () => {
               <span>Not financial advice.</span>
             </div>
             <p className="text-sm text-muted-foreground mb-3">
-              Built by{" "}
+              Built with{" "}
+              <span aria-label="love" role="img" className="text-rose-500">
+                ❤️
+              </span>{" "}
+              in{" "}
               <a
-                href={siteConfig.links.twitter}
+                href="https://benebsworth.com"
                 target="_blank"
                 rel="noreferrer"
                 className="font-medium underline underline-offset-4 hover:text-foreground transition-colors"
               >
-                Ben Ebsworth
+                Melbourne
               </a>
             </p>
             <Badge


### PR DESCRIPTION
## Summary

Turns `scripts/take-writer/` from a single-LLM-call generator into a **daily investigative newsroom**, plus a small footer attribution change.

**Newsroom engine (Sub-project 1 of 2):**
- **Editor** (`editor.ts`) — Claude commissions the day's stories from a signal board, gated by a pure novelty check (won't re-cover a stock without a material new development).
- **Investigator** (`investigator.ts`) — Claude agentic tool-calling loop over incremental data drill-downs (`tools.ts` → `drilldowns.ts`), turn-capped, emits a structured `Dossier`. Sonnet for takes, Opus for deep-dives.
- **Grounding** (`ledger.ts`) — every tool-retrieved source is registered with a stable `refId`; the writer may cite only ledger refIds; `compactCitations` drops anything invented; `shouldHoldAsDraft` holds dangling/zero-citation pieces.
- **Writer** (`narrative.ts`) — Gemini (tuned voice preserved), tiered output (4-section take vs long-form deep-dive), `WRITER_MODEL` env-configurable.
- **Pipeline + CLI** (`newsroom.ts`, `index.ts`) — `newsroom-daily` command, model tiering, turn/story caps, per-assignment isolation, cost logging.
- **Schema**: migration `000038` adds `tier` to `editorial_takes`.
- **Infra**: `terraform/modules/newsroom-job/` — daily Cloud Run Job + Scheduler (southeast1, no min-instance).

**Footer**: "Built by Ben Ebsworth" → "Built with ❤️ in Melbourne" (links benebsworth.com).

Design spec: `docs/superpowers/specs/2026-05-30-investigative-newsroom-design.md` · Plan: `docs/superpowers/plans/2026-05-30-investigative-newsroom.md`

## Test Plan
- [x] 37 unit tests pass (`cd scripts/take-writer && npm test`); tsc clean
- [x] Grounding directly tested: invented citations dropped, ungrounded pieces held
- [ ] **Live end-to-end NOT yet run** (dev DB/Docker down, no `ANTHROPIC_API_KEY`)
- [ ] Apply-time prereqs: create `ANTHROPIC_API_KEY` secret; build/push `take-writer` image (no Dockerfile yet); resolve pre-existing duplicate `000016` migration before `make migrate-up`

> Note: commit `cc0fe5aa` (chat edge routing + Stripe label) is unrelated parallel work that rode along on this branch.