### PR TITLE
feat(take-writer): serverless-portable newsroom (headless validator + runbook)

### DIFF
--- a/scripts/take-writer/Dockerfile
+++ b/scripts/take-writer/Dockerfile
@@ -12,6 +12,14 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
+# The newsroom pipeline (newsroom-daily) runs fully HEADLESS — no browser is
+# needed. The validator's full-page screenshot step uses Playwright/chromium
+# only when available; without a chromium binary it degrades gracefully to
+# per-image judging (see src/validator.ts). We deliberately do NOT install the
+# browser here to keep the image lean. To enable full-page screenshot
+# validation IN the container, uncomment:
+#   RUN npx playwright install --with-deps chromium
+
 COPY tsconfig.json ./
 COPY src ./src
 

--- a/scripts/take-writer/SERVERLESS.md
+++ b/scripts/take-writer/SERVERLESS.md
@@ -1,0 +1,103 @@
+# Serverless newsroom — portability runbook
+
+How to run the investigative newsroom (`take-writer`) as a Cloud Run Job. No
+infrastructure is provisioned by this doc — it documents the steps and the
+already-prepared pieces.
+
+## It already runs headless
+
+`newsroom-daily [--auto-publish] [--with-images]` is the serverless entrypoint.
+It uses only environment variables and ambient Application Default Credentials
+(ADC) — no browser, no local credential files:
+
+- Gemini / OpenAI / Postgres are reached over their network APIs.
+- GCS uses `new Storage()`, which picks up the job's service-account ADC.
+
+The **only** browser-bearing code path is the validator's full-page screenshot.
+That step now degrades gracefully: `src/validator.ts` dynamically imports
+Playwright and returns `null` if Playwright or a chromium binary isn't
+available (or if `VALIDATOR_SCREENSHOT=0`). When there's no screenshot, the
+judge falls back to **per-image** cohesion judging — it scores each layout image
+against its caption + the body, instead of also seeing a full-page render. The
+same code runs identically in a lean container.
+
+- Force-skip the screenshot: set `VALIDATOR_SCREENSHOT=0`.
+- Enable full-page screenshot validation in-container: add
+  `RUN npx playwright install --with-deps chromium` to the `Dockerfile`
+  (deliberately omitted by default to keep the image small).
+
+## Image
+
+`Dockerfile` (node:22-slim). The entrypoint is `npx tsx src/index.ts`, so the
+Cloud Run Job passes the command + flags as container args, e.g.
+`["newsroom-daily", "--auto-publish", "--with-images"]`.
+
+Build to the target project's Artifact Registry:
+
+```bash
+gcloud builds submit --project <PROJ> \
+  --tag <region>-docker.pkg.dev/<PROJ>/shorted/take-writer:latest .
+```
+
+Currently built to dev:
+`australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/take-writer:latest`.
+
+## Env / secrets the job needs
+
+Required:
+
+| Var | Purpose |
+|---|---|
+| `DATABASE_URL` | Postgres (editorial_takes etc.) |
+| `GEMINI_API_KEY` | editor / investigator / writer / validator models |
+| `OPENAI_API_KEY` | image generation (`--with-images`, validator auto-fix) |
+| `GCS_LOGO_BUCKET` | image upload bucket (default `shorted-company-logos`) |
+
+Optional model overrides:
+`EDITOR_MODEL`, `INVESTIGATOR_MODEL_TAKE`, `INVESTIGATOR_MODEL_DEEPDIVE`,
+`WRITER_MODEL`, `WRITER_MODEL_DEEPDIVE`, `ART_DIRECTOR_MODEL`, `VALIDATOR_MODEL`.
+
+Optional caps:
+`MAX_TAKES_PER_DAY`, `MAX_DEEPDIVES_PER_DAY`, `MAX_TURNS_TAKE`,
+`MAX_TURNS_DEEPDIVE`.
+
+Optional validator toggle: `VALIDATOR_SCREENSHOT=0` to force per-image-only.
+
+**GCS auth = the job's service account (ambient ADC). Do NOT set
+`GOOGLE_APPLICATION_CREDENTIALS` on the job** — that's a local-only mechanism.
+
+## Terraform (ready, not applied)
+
+`terraform/modules/newsroom-job/` defines a Cloud Run Job + Cloud Scheduler
+(scheduler in `australia-southeast1`). It is referenced in
+`terraform/environments/dev/main.tf` (`module "newsroom_job"`) but **NOT yet
+applied**. The prod environment does not reference it yet.
+
+To enable in an environment:
+
+1. Build the image to that env's Artifact Registry (see above).
+2. Ensure the secrets (`DATABASE_URL`, `GEMINI_API_KEY`, `OPENAI_API_KEY`)
+   exist in Secret Manager and the job's service account can read them + write
+   to the GCS bucket.
+3. `terraform apply`.
+
+## Local CLI usage (unchanged)
+
+```bash
+cd scripts/take-writer
+npx tsx src/index.ts newsroom-preview --stock=CODE   # investigate one stock, no DB write, no images
+npx tsx src/index.ts newsroom-daily [--auto-publish] [--with-images]
+npx tsx src/index.ts regen-images --slug=SLUG [--inline=2]
+npx tsx src/index.ts validate-article --slug=SLUG [--rounds=2]
+```
+
+Local image generation needs Google creds: set
+`GOOGLE_APPLICATION_CREDENTIALS` to the `ben@shorted.com.au` adc.json. (This is
+the local-only path; the Cloud Run Job uses its service-account ADC instead.)
+
+## Migration state
+
+Migrations `038` (tier) and `040` (layout_images) were applied to prod directly
+— the `migrate` tool is version-drifted, so they were run by hand (see project
+memory). A fresh environment needs both applied before the newsroom can write
+takes with tier + layout_images.

--- a/scripts/take-writer/src/validator.ts
+++ b/scripts/take-writer/src/validator.ts
@@ -10,7 +10,6 @@
 //     is ISR-cached up to 10 min, so only the image content changed).
 //  4. Report the cohesion score, layout notes, and what was regenerated.
 
-import { chromium } from "playwright";
 import { GoogleGenerativeAI, SchemaType } from "@google/generative-ai";
 import OpenAI from "openai";
 import { Storage } from "@google-cloud/storage";
@@ -23,8 +22,25 @@ import { type LayoutImage, generateOneLayoutImage } from "./art-director.js";
 const JUDGE_MODEL = (): string => process.env.VALIDATOR_MODEL ?? "gemini-3.5-flash";
 const SITE = (): string => process.env.SHORTED_SITE_URL ?? "https://shorted.com.au";
 
-async function screenshotArticle(slug: string): Promise<Buffer> {
-  const browser = await chromium.launch();
+async function screenshotArticle(slug: string): Promise<Buffer | null> {
+  if (process.env.VALIDATOR_SCREENSHOT === "0") return null;
+  // Playwright is an optional, browser-bearing dependency. In a lean
+  // serverless container (no chromium binary) the dynamic import or
+  // launch fails — degrade to per-image-only judging instead of crashing.
+  let chromium: typeof import("playwright").chromium;
+  try {
+    ({ chromium } = await import("playwright"));
+  } catch {
+    console.error("[validate] playwright not installed — skipping full-page screenshot, judging per-image only");
+    return null;
+  }
+  let browser: import("playwright").Browser;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    console.error(`[validate] chromium launch failed (${String((e as Error).message ?? e).slice(0, 80)}) — skipping screenshot, per-image only`);
+    return null;
+  }
   try {
     const page = await browser.newPage({ viewport: { width: 1280, height: 1000 } });
     await page.goto(`${SITE()}/news/${slug}`, { waitUntil: "networkidle", timeout: 45000 });
@@ -99,7 +115,7 @@ async function judge(
   headline: string,
   bodyMd: string,
   layoutImages: LayoutImage[],
-  screenshot: Buffer,
+  screenshot: Buffer | null,
   imageBufs: Buffer[],
 ): Promise<CohesionVerdict> {
   const model = ai.getGenerativeModel({
@@ -111,21 +127,26 @@ async function judge(
       ...({ thinkingConfig: { thinkingBudget: 0 } } as unknown as Record<string, unknown>),
     } as unknown as Parameters<GoogleGenerativeAI["getGenerativeModel"]>[0]["generationConfig"],
   });
-  const parts: Array<Record<string, unknown>> = [
-    {
-      text:
-        `You are the editor reviewing whether this published article LOOKS GOOD and is cohesive. Headline: "${headline}".\n\n` +
-        `Body (markdown):\n${bodyMd.slice(0, 4000)}\n\n` +
-        `Layout images (index: caption | placement | ratio):\n` +
-        `${layoutImages.map((li, i) => `${i}: "${li.caption}" | ${li.placement} | ${li.ratio}`).join("\n")}\n\n` +
-        `First image below = the FULL-PAGE SCREENSHOT of the rendered article (judge layout/flow/balance). ` +
-        `The remaining images = the individual layout images in order (judge each against its caption + the section it illustrates). ` +
-        `IMPORTANT: the large banner image at the very TOP of the screenshot is the HERO / brand thumbnail — it is INTENTIONALLY an abstract dark-amber brand image (used for social cards + the news grid), NOT meant to be topical. Do NOT penalise the article or lower the cohesion score because the hero is abstract or "off-topic"; ignore the hero entirely. Judge cohesion ONLY on the body layout images and the overall layout/flow. ` +
-        `Flag regenerate=true ONLY for a body layout image that is off-topic, garbled, generic-when-it-should-be-specific, contains text/charts/faces/logos, ` +
-        `or whose caption doesn't match. Give a corrected newBrief + newCaption for any flagged image.`,
-    },
-  ];
-  parts.push({ inlineData: { mimeType: "image/png", data: screenshot.toString("base64") } });
+  const common =
+    `You are the editor reviewing whether this published article LOOKS GOOD and is cohesive. Headline: "${headline}".\n\n` +
+    `Body (markdown):\n${bodyMd.slice(0, 4000)}\n\n` +
+    `Layout images (index: caption | placement | ratio):\n` +
+    `${layoutImages.map((li, i) => `${i}: "${li.caption}" | ${li.placement} | ${li.ratio}`).join("\n")}\n\n`;
+  const tail =
+    `IMPORTANT: the large banner image at the very TOP of the screenshot is the HERO / brand thumbnail — it is INTENTIONALLY an abstract dark-amber brand image (used for social cards + the news grid), NOT meant to be topical. Do NOT penalise the article or lower the cohesion score because the hero is abstract or "off-topic"; ignore the hero entirely. ` +
+    `Flag regenerate=true ONLY for a body layout image that is off-topic, garbled, generic-when-it-should-be-specific, contains text/charts/faces/logos, ` +
+    `or whose caption doesn't match. Give a corrected newBrief + newCaption for any flagged image.`;
+  const promptText = screenshot
+    ? common +
+      `First image below = the FULL-PAGE SCREENSHOT of the rendered article (judge layout/flow/balance). ` +
+      `The remaining images = the individual layout images in order (judge each against its caption + the section it illustrates). ` +
+      `Judge cohesion on the body layout images and the overall layout/flow. ` +
+      tail
+    : common +
+      `The images below are the article's layout images in order. No full-page render is available, so judge per-image fit/caption/quality and infer overall cohesion from the captions + body. Base cohesionScore on the body images. ` +
+      tail;
+  const parts: Array<Record<string, unknown>> = [{ text: promptText }];
+  if (screenshot) parts.push({ inlineData: { mimeType: "image/png", data: screenshot.toString("base64") } });
   for (const b of imageBufs) parts.push({ inlineData: { mimeType: "image/png", data: b.toString("base64") } });
   const resp = await model.generateContent(parts as unknown as Parameters<ReturnType<GoogleGenerativeAI["getGenerativeModel"]>["generateContent"]>[0]);
   return JSON.parse(resp.response.text()) as CohesionVerdict;
@@ -159,6 +180,7 @@ export async function validateArticle(slug: string, opts: { rounds?: number } = 
 
     console.error(`[validate] screenshotting ${slug}…`);
     const shot = await screenshotArticle(slug);
+    console.error("[validate] mode: " + (shot ? "screenshot+per-image" : "per-image only"));
     const imageBufs = await Promise.all(layout.map((li) => fetchPng(li.url)));
 
     for (let round = 1; round <= maxRounds; round++) {


### PR DESCRIPTION
Makes the newsroom cleanly portable to a Cloud Run job without provisioning anything. Validator's Playwright dependency is now dynamic + optional (degrades to per-image multimodal judging when no chromium binary, VALIDATOR_SCREENSHOT=0 to force-skip). Dockerfile documents the optional chromium install. New SERVERLESS.md runbook (image build, env/secrets, ambient ADC, the ready-but-unapplied newsroom-job terraform). newsroom-daily was already headless. Stays CLI-driven; cron unprovisioned.