### PR TITLE
fix(seo): dynamic OG images load short % reliably + self-healing cache

### DIFF
--- a/web/src/app/industry/[slug]/opengraph-image.tsx
+++ b/web/src/app/industry/[slug]/opengraph-image.tsx
@@ -10,6 +10,10 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Self-healing cache: regenerate daily so a transient fetch failure doesn't
+// freeze a broken image for a year via Next.js's default immutable cache.
+export const revalidate = 86400;
+
 let cachedBg: string | null = null;
 let cachedLogo: string | null = null;
 
@@ -82,7 +86,7 @@ async function getIndustryOGData(
       `${apiUrl}/shorts.v1alpha1.ShortedStocksService/GetIndustryTreeMap`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Connect-Protocol-Version": "1", "User-Agent": "shorted-og/1.0" },
         body: JSON.stringify({
           period: "3m",
           limit: 50,

--- a/web/src/app/reports/monthly/[slug]/opengraph-image.tsx
+++ b/web/src/app/reports/monthly/[slug]/opengraph-image.tsx
@@ -10,6 +10,10 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Self-healing cache: regenerate daily so a transient fetch failure doesn't
+// freeze a broken image for a year via Next.js's default immutable cache.
+export const revalidate = 86400;
+
 let cachedBg: string | null = null;
 let cachedLogo: string | null = null;
 
@@ -86,7 +90,7 @@ async function getTopStockForDate(
       `${apiUrl}/shorts.v1alpha1.ShortedStocksService/GetMarketByDate`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Connect-Protocol-Version": "1", "User-Agent": "shorted-og/1.0" },
         body: JSON.stringify({ date, limit: 1, offset: 0 }),
         next: { revalidate: 86400 },
       },

--- a/web/src/app/reports/weekly/[slug]/opengraph-image.tsx
+++ b/web/src/app/reports/weekly/[slug]/opengraph-image.tsx
@@ -10,6 +10,10 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Self-healing cache: regenerate daily so a transient fetch failure doesn't
+// freeze a broken image for a year via Next.js's default immutable cache.
+export const revalidate = 86400;
+
 let cachedBg: string | null = null;
 let cachedLogo: string | null = null;
 
@@ -81,7 +85,7 @@ async function getTopStockForDate(
         `${apiUrl}/shorts.v1alpha1.ShortedStocksService/GetMarketByDate`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", "Connect-Protocol-Version": "1", "User-Agent": "shorted-og/1.0" },
           body: JSON.stringify({ date: cursor, limit: 1, offset: 0 }),
           next: { revalidate: 86400 },
         },

--- a/web/src/app/reports/yearly/[slug]/opengraph-image.tsx
+++ b/web/src/app/reports/yearly/[slug]/opengraph-image.tsx
@@ -10,6 +10,10 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Self-healing cache: regenerate daily so a transient fetch failure doesn't
+// freeze a broken image for a year via Next.js's default immutable cache.
+export const revalidate = 86400;
+
 let cachedBg: string | null = null;
 let cachedLogo: string | null = null;
 
@@ -69,7 +73,7 @@ async function getTopStockForDate(
       `${apiUrl}/shorts.v1alpha1.ShortedStocksService/GetMarketByDate`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Connect-Protocol-Version": "1", "User-Agent": "shorted-og/1.0" },
         body: JSON.stringify({ date, limit: 1, offset: 0 }),
         next: { revalidate: 86400 },
       },

--- a/web/src/app/shorts/[stockCode]/opengraph-image.tsx
+++ b/web/src/app/shorts/[stockCode]/opengraph-image.tsx
@@ -2,6 +2,7 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { getStock } from "~/app/actions/getStock";
 
 export const alt = "Stock Short Position Data - Shorted.com.au";
 export const size = {
@@ -9,6 +10,12 @@ export const size = {
   height: 630,
 };
 export const contentType = "image/png";
+
+// Self-healing cache: regenerate the image daily (matches ASIC's T+4 daily
+// data cadence). Without this, Next.js serves the image with
+// `Cache-Control: immutable, max-age=31536000`, which would freeze any
+// transient render failure (e.g. an "N/A" short %) for a full year.
+export const revalidate = 86400;
 
 let cachedBg: string | null = null;
 let cachedLogo: string | null = null;
@@ -51,29 +58,20 @@ async function getStockData(
   percentageShorted: number;
 } | null> {
   try {
-    const apiUrl =
-      process.env.NEXT_PUBLIC_API_URL ??
-      process.env.NEXT_PUBLIC_SHORTS_SERVICE_ENDPOINT ??
-      "http://localhost:9091";
-    const res = await fetch(
-      `${apiUrl}/shorts.v1alpha1.ShortedStocksService/GetStock`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ productCode: code }),
-        next: { revalidate: 3600 },
-      },
-    );
-    if (!res.ok) return null;
-    const data = (await res.json()) as {
-      name?: string;
-      percentageShorted?: number;
-    };
+    // Reuse the canonical getStock action: it uses the Connect transport
+    // (which sends the `Connect-Protocol-Version` header the WAF requires —
+    // a bare fetch gets a 403 "automated access detected") and wraps
+    // withRetryAndNotFound to survive Cloud Run cold starts (min instances = 0).
+    const stock = await getStock(code);
+    if (!stock) return null;
     return {
-      name: data.name ?? "",
-      percentageShorted: data.percentageShorted ?? 0,
+      name: stock.name ?? "",
+      percentageShorted: stock.percentageShorted ?? 0,
     };
-  } catch {
+  } catch (err) {
+    // Surface failures in Vercel logs — the previous silent catch is why this
+    // rendered "N/A" undiagnosed.
+    console.error(`[opengraph-image] getStock failed for ${code}:`, err);
     return null;
   }
 }


### PR DESCRIPTION
## Problem

Social link-preview cards (e.g. https://shorted.com.au/shorts/DMP) rendered **N/A** instead of the short percentage, even though the page `<title>` showed the correct value (15.28%).

## Root cause (verified against production)

**1. The OG image's data fetch was failing.** The OG routes used a bare `fetch()` to `api.shorted.com.au`, which fails for two reasons:

| Request shape | Result |
|---|---|
| bare `fetch` (`Content-Type: application/json` only) | **403** — Cloudflare WAF blocks the curl-style UA / **500** — backend needs `Connect-Protocol-Version` |
| Connect transport (`Connect-Protocol-Version: 1` + non-curl UA) | **200** — `percentageShorted: 15.28` |

`generateMetadata` (the `<title>`) worked because it uses the `getStock` action, which goes through the Connect transport and sends both. The OG image used a divergent bare-fetch path that didn't.

**2. Broken images were frozen for a year.** Next.js served these with `Cache-Control: immutable, max-age=31536000`, so any bad render (or the daily-changing short %) persisted indefinitely.

## Fix

- `shorts/[stockCode]/opengraph-image.tsx` → reuse the `getStock` action (Connect client + `withRetryAndNotFound`, survives Cloud Run cold starts) + `console.error` on failure for visibility.
- `industry/[slug]`, `reports/{monthly,yearly,weekly}/[slug]` → add `Connect-Protocol-Version: 1` + a non-curl `User-Agent` to the fetch (kept existing parse logic).
- All 5 routes → `export const revalidate = 86400` for self-healing caching.

## Verify after deploy

```bash
curl -sD - -o /dev/null "https://<preview>/shorts/DMP/opengraph-image" | grep -i cache-control
```
Confirm `cache-control` is no longer `immutable, max-age=31536000`, and the regenerated PNG shows the real short % instead of N/A. If Next 14 still emits `immutable` despite `revalidate`, fallback is converting to an API route (pattern: `web/src/app/api/og/twitter/[type]/route.tsx`).