### PR TITLE
fix(seo): OG wordmark overlap + content-addressed image cache

### DIFF
--- a/web/src/app/reports/monthly/[slug]/opengraph-image.tsx
+++ b/web/src/app/reports/monthly/[slug]/opengraph-image.tsx
@@ -220,26 +220,9 @@ export default async function Image({
               justifyContent: "center",
             }}
           >
-            <div style={{ display: "flex", alignItems: "baseline", gap: 14 }}>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 800,
-                  color: "#00E5FF",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                SHORTED
-              </span>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 300,
-                  color: "#00E5FF",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                MONTHLY
+            <div style={{ display: "flex" }}>
+              <span style={{ fontSize: 46, fontWeight: 700, color: "#00E5FF" }}>
+                SHORTED MONTHLY
               </span>
             </div>
 

--- a/web/src/app/reports/weekly/[slug]/opengraph-image.tsx
+++ b/web/src/app/reports/weekly/[slug]/opengraph-image.tsx
@@ -219,26 +219,9 @@ export default async function Image({
               justifyContent: "center",
             }}
           >
-            <div style={{ display: "flex", alignItems: "baseline", gap: 14 }}>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 800,
-                  color: "#FFA94D",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                SHORTED
-              </span>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 300,
-                  color: "#FFA94D",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                REPORTS
+            <div style={{ display: "flex" }}>
+              <span style={{ fontSize: 46, fontWeight: 700, color: "#FFA94D" }}>
+                SHORTED REPORTS
               </span>
             </div>
 

--- a/web/src/app/reports/yearly/[slug]/opengraph-image.tsx
+++ b/web/src/app/reports/yearly/[slug]/opengraph-image.tsx
@@ -201,26 +201,9 @@ export default async function Image({
               justifyContent: "center",
             }}
           >
-            <div style={{ display: "flex", alignItems: "baseline", gap: 14 }}>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 800,
-                  color: "#00FF9C",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                SHORTED
-              </span>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 300,
-                  color: "#00FF9C",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                ANNUAL
+            <div style={{ display: "flex" }}>
+              <span style={{ fontSize: 46, fontWeight: 700, color: "#00FF9C" }}>
+                SHORTED ANNUAL
               </span>
             </div>
 

--- a/web/src/app/shorts/[stockCode]/opengraph-image.tsx
+++ b/web/src/app/shorts/[stockCode]/opengraph-image.tsx
@@ -176,26 +176,18 @@ export default async function Image({
               justifyContent: "center",
             }}
           >
-            <div style={{ display: "flex", alignItems: "baseline", gap: 14 }}>
+            {/* Single text node: Satori mismeasures adjacent flex spans with
+                synthetic font weights, causing "SHORTED" + "REPORTS" to overlap.
+                One span = one measurement = no overlap. */}
+            <div style={{ display: "flex" }}>
               <span
                 style={{
                   fontSize: 46,
-                  fontWeight: 800,
+                  fontWeight: 700,
                   color: "#FFA94D",
-                  letterSpacing: "0.04em",
                 }}
               >
-                SHORTED
-              </span>
-              <span
-                style={{
-                  fontSize: 46,
-                  fontWeight: 300,
-                  color: "#FFA94D",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                REPORTS
+                SHORTED REPORTS
               </span>
             </div>
 

--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -109,6 +109,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   let title = `${code} Short Position | Official ASIC Data (T+4)`;
   let description = `${code} short selling data from official ASIC reports. Current short interest %, historical trends, charts & analysis. Updated daily with T+4 delay. Free ASX short position tracking.`;
   let shouldNoindex = false;
+  // Content-addressed OG image version: changes when the short % changes, so
+  // the social card refreshes exactly when data does (and is served from
+  // immutable cache otherwise). Also moves off any stale/frozen cached URL.
+  let ogVersion = "default";
 
   try {
     const stock = await getStockOrNotFound(code);
@@ -116,6 +120,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       const companyName = stock.name ? `(${stock.name})` : "";
       const shortPct = stock.percentageShorted > 0 ? ` | ${stock.percentageShorted.toFixed(2)}% Shorted` : "";
       title = `${code} ${companyName} Short Position${shortPct} | ASIC Data`;
+      if (stock.percentageShorted > 0) ogVersion = stock.percentageShorted.toFixed(2);
 
       const dateStr = new Date().toLocaleDateString("en-AU", {
         month: "short",
@@ -137,6 +142,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   } catch {
     // Fall back to default title/description if fetch fails
   }
+
+  const ogImage = {
+    url: `${siteConfig.url}/shorts/${code}/opengraph-image?p=${ogVersion}`,
+    width: 1200,
+    height: 630,
+    alt: `${code} short position — ${siteConfig.name}`,
+  };
 
   return {
     title,
@@ -164,11 +176,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       siteName: siteConfig.name,
       type: "article",
       locale: "en_AU",
+      images: [ogImage],
     },
     twitter: {
       card: "summary_large_image",
       title: `${title} | ${siteConfig.name}`,
       description,
+      images: [ogImage],
     },
     alternates: {
       canonical: `${siteConfig.url}/shorts/${code}`,


### PR DESCRIPTION
Follow-up to #149. The data fetch fix from #149 deployed and works (cache-busted render shows 15.3%), but two issues remained on the live cards — both verified locally via a dev-server `ImageResponse` render.

## 1. SHORTED/REPORTS wordmark overlapped
next/og loads no custom font, so Satori mismeasures adjacent flex `<span>`s with synthetic weights (800/300) → the second word rendered on top of the first ("SHORTEDEPORTS"). Dropping `letterSpacing` did not help. **Fix:** render the wordmark as a single text node (one measurement → no inter-span overlap) on the stock + monthly/yearly/weekly report OG routes.

## 2. Stock card stayed "N/A" in production
Next 14 serves metadata images with `Cache-Control: immutable, max-age=31536000` at a stable URL, freezing the old (pre-#149) N/A render. Confirmed `export const revalidate` does **not** change that header. **Fix:** emit an explicit, content-addressed `og:image`/`twitter:image` URL keyed on the short % (`?p=15.28`) from `generateMetadata`. Verified Next 14.2.13 treats explicit `openGraph.images` as an override (single tag, no duplicate with the file convention). The URL changes exactly when the data changes → fresh card when it matters, immutable-cached otherwise, and immediately abandons the frozen stale URL.

## Verified locally
DMP renders **15.3%** (no N/A), wordmark no longer overlaps, single `og:image` + `twitter:image` tag at `?p=15.28`.