### PR TITLE
fix(seo): show short % once on stock OG card

### DIFF
--- a/web/src/app/shorts/[stockCode]/opengraph-image.tsx
+++ b/web/src/app/shorts/[stockCode]/opengraph-image.tsx
@@ -215,34 +215,19 @@ export default async function Image({
               Top Shorted
             </div>
 
-            <div
-              style={{
-                display: "flex",
-                alignItems: "baseline",
-                gap: 40,
-                marginTop: 12,
-              }}
-            >
+            {/* Stock code only — the short % is shown once, in the Short
+                Interest stat below. (Avoids a duplicate number and the Satori
+                flex-gap collapse that jammed "DMP" against the percentage.) */}
+            <div style={{ display: "flex", marginTop: 12 }}>
               <span
                 style={{
                   fontSize: 72,
                   fontWeight: 800,
                   color: "#FFA94D",
-                  letterSpacing: "0.04em",
                   textShadow: "0 0 30px rgba(255,169,77,0.3)",
                 }}
               >
                 {code}
-              </span>
-              <span
-                style={{
-                  fontSize: 56,
-                  fontWeight: 700,
-                  color: "#FFA94D",
-                  textShadow: "0 0 20px rgba(255,169,77,0.3)",
-                }}
-              >
-                {shortPct}
               </span>
             </div>
 


### PR DESCRIPTION
The stock social card rendered the short % twice — jammed against the ticker ("DMP15.3%", flex gap collapsed by Satori) and again in the "Short Interest" stat — reading as two stray numbers. Removes the percentage from the code line so "DMP" is just the ticker; the single % lives in the Short Interest stat. Verified locally (rendered ImageResponse).