### PR TITLE
fix(news): lint error in mdx-figures blocking Vercel prod deploy

### DIFF
--- a/web/src/@/components/news/mdx-figures.ts
+++ b/web/src/@/components/news/mdx-figures.ts
@@ -31,7 +31,8 @@ function sanitizeCaption(caption: string): string {
 }
 
 function figureLine(img: LayoutImageLike): string {
-  const placement = img.placement?.trim() || "full";
+  const trimmed = img.placement?.trim();
+  const placement = trimmed ? trimmed : "full";
   const caption = img.caption ? sanitizeCaption(img.caption) : "";
   const captionAttr = caption ? ` caption="${caption}"` : "";
   return `<Figure src="${img.url}" placement="${placement}"${captionAttr} credit="AI-generated illustration" />`;


### PR DESCRIPTION
One-line lint fix (prefer-nullish-coalescing) in mdx-figures.ts that failed the deploy-vercel-prod job on the previous main deploy. Lint/tsc/jest all green.