### PR TITLE
perf(web): pin Vercel functions to syd1, homepage ISR, daily ISR page warming

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "installCommand": "npm run install:frontend",
   "buildCommand": "npm run build:frontend",
   "outputDirectory": "web/.next",
+  "regions": ["syd1"],
   "git": {
     "deploymentEnabled": false
   },
@@ -15,6 +16,10 @@
     {
       "path": "/api/homepage/warm-cache",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/pages/warm-cache",
+      "schedule": "0 17 * * *"
     }
   ]
 }

--- a/web/src/app/api/pages/warm-cache/route.ts
+++ b/web/src/app/api/pages/warm-cache/route.ts
@@ -1,0 +1,111 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getTopShortsData } from "~/app/actions/getTopShorts";
+
+// Warming fetches happen serially in small batches; allow enough wall time.
+export const maxDuration = 300;
+
+const STOCK_PAGES_TO_WARM = 30;
+const FETCH_BATCH_SIZE = 5;
+
+// Cloudflare's bot protection rejects non-browser user agents, so the
+// self-fetches that re-prime the ISR cache must present a browser UA.
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/**
+ * ISR page-cache warming endpoint.
+ *
+ * The existing warm-cache crons only warm the data layer (Redis/unstable_cache).
+ * This route refreshes the rendered HTML itself: it revalidates the homepage and
+ * the top shorted stock pages, then fetches each one so the ISR cache is
+ * re-primed with fresh data. Scheduled daily after the 2am AEST data sync so
+ * real users never pay the blocking-MISS render cost.
+ *
+ * Can be called manually or via Vercel Cron Job.
+ */
+export async function GET(request: NextRequest) {
+  // Optional: Protect endpoint with secret (same pattern as other warm-cache routes)
+  const secret = request.nextUrl.searchParams.get("secret");
+  const expectedSecret = process.env.CACHE_WARM_SECRET;
+
+  if (expectedSecret && secret !== expectedSecret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startTime = Date.now();
+  const results: Record<string, { success: boolean; error?: string; ms?: number }> = {};
+
+  try {
+    // Resolve the top shorted stocks to decide which pages are worth warming.
+    const topShorts = await getTopShortsData("max", STOCK_PAGES_TO_WARM, 0);
+    const stockCodes = (topShorts?.timeSeries ?? [])
+      .map((ts) => ts.productCode)
+      .filter((code): code is string => !!code && /^[A-Z0-9]{1,4}$/.test(code));
+
+    const paths = ["/", ...stockCodes.map((code) => `/shorts/${code}`)];
+
+    // Invalidate first so the warming fetch regenerates with post-sync data
+    // instead of just touching the existing stale entry.
+    for (const path of paths) {
+      revalidatePath(path);
+    }
+
+    // Re-prime in small batches to stay under Cloudflare's burst rate limit
+    // (>20 req/min from one client trips bot protection).
+    const origin = request.nextUrl.origin;
+    for (let i = 0; i < paths.length; i += FETCH_BATCH_SIZE) {
+      const batch = paths.slice(i, i + FETCH_BATCH_SIZE);
+      await Promise.allSettled(
+        batch.map(async (path) => {
+          const pageStart = Date.now();
+          try {
+            const res = await fetch(`${origin}${path}`, {
+              headers: { "User-Agent": BROWSER_UA },
+              cache: "no-store",
+            });
+            results[path] = {
+              success: res.ok,
+              ms: Date.now() - pageStart,
+              ...(res.ok ? {} : { error: `HTTP ${res.status}` }),
+            };
+          } catch (error) {
+            results[path] = {
+              success: false,
+              ms: Date.now() - pageStart,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }),
+      );
+      // Brief pause between batches to spread the burst.
+      if (i + FETCH_BATCH_SIZE < paths.length) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    }
+
+    const successCount = Object.values(results).filter((r) => r.success).length;
+    const totalCount = Object.keys(results).length;
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: `ISR pages warmed: ${successCount}/${totalCount} successful`,
+        results,
+        duration: `${Date.now() - startTime}ms`,
+        timestamp: new Date().toISOString(),
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        results,
+        duration: `${Date.now() - startTime}ms`,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -23,6 +23,11 @@ import { getEnhancedWeeklyReportData, getAvailableWeekSlugs } from "~/app/action
 import { BrowseByIndustry } from "./browse-by-industry";
 import { TrendingThisWeek } from "./trending-this-week";
 
+// ISR: serve the cached page instantly (stale-while-revalidate) and regenerate
+// in the background at most hourly. Without this the page is build-time static
+// and a regional cache eviction forces a blocking re-render on a live request.
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: siteConfig.fullTitle,
   description: siteConfig.description,

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "ignoreCommand": "git diff HEAD^ HEAD --quiet -- web/src/ web/public/ web/package.json web/package-lock.json web/next.config.mjs web/tsconfig.json proto/",
+  "regions": ["syd1"],
   "crons": [
     {
       "path": "/api/about/warm-cache",
@@ -8,6 +9,10 @@
     {
       "path": "/api/homepage/warm-cache",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/pages/warm-cache",
+      "schedule": "0 17 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Problem
Fresh loads of the landing page and /shorts/* pages were slow (3s+ TTFB on cache miss, one observed 29s outlier on the homepage).

Measured root causes:
1. **Vercel functions executed in iad1 (US East)** — no `regions` config — while Supabase + Cloud Run live in Australia. Every SSR data fetch was a trans-Pacific round trip (`x-vercel-id: syd1::iad1::…`).
2. **Homepage was build-time static** (no `revalidate`) — a regional edge-cache eviction forced a blocking re-render on a live request.
3. **Nothing warmed the rendered pages** — the existing warm-cache crons only warm the Redis/data layer, not the ISR HTML cache.

## Changes
- `vercel.json` + `web/vercel.json`: `"regions": ["syd1"]` + daily cron for the new warm route (17:00 UTC = 3am AEST, after the 2am data sync)
- `web/src/app/page.tsx`: `export const revalidate = 3600` (ISR, stale-while-revalidate)
- New `web/src/app/api/pages/warm-cache/route.ts`: `revalidatePath` + re-fetch of `/` and top-30 stock pages in WAF-friendly batches, so post-sync regeneration cost is paid by the cron instead of users

## Verification (preview deploy)
| Scenario | Before (prod, iad1) | After (preview, syd1) |
|---|---|---|
| Stock page MISS (warm fn) | ~3.1s | ~1.1s |
| Stock page HIT | ~0.17s | ~0.12–0.17s |
| Homepage | 0.2–0.8s, 29s outlier | ~0.17s HIT, non-blocking regen |

Warm route primed 29/30 pages in 19s (the 404 was ATBHQ, a 5-char deferred-settlement code — regex now matches generateStaticParams' `{1,4}` filter).