### PR TITLE
feat(seo): SSR stock history+FAQ, MCP server, news schema, sitemap lastmod, about fix

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -144,6 +144,11 @@ const config = {
         destination: "/api/agent/api-catalog",
       },
       {
+        // MCP server card (SEP-1649) for agent discovery
+        source: "/.well-known/mcp/server-card.json",
+        destination: "/api/agent/mcp-server-card",
+      },
+      {
         source: "/shorts.v1alpha1.ShortedStocksService/:path*",
         destination: `${shortsApiUrl}/shorts.v1alpha1.ShortedStocksService/:path*`,
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shorted",
-  "version": "v0.2.2-1040-g6473a914-dirty",
+  "version": "v0.2.2-1126-gaf46ab7e-dirty",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shorted",
-      "version": "v0.2.2-1040-g6473a914-dirty",
+      "version": "v0.2.2-1126-gaf46ab7e-dirty",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.0",
@@ -16,6 +16,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@mdx-js/loader": "^3.0.1",
         "@mdx-js/react": "^3.0.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@next/mdx": "^14.2.11",
         "@next/third-parties": "^14.2.2",
         "@opentelemetry/api": "^1.9.0",
@@ -91,6 +92,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.294.0",
+        "mcp-handler": "^1.1.0",
         "mobx": "^6.13.7",
         "next": "^14.2.13",
         "next-auth": "^5.0.0-beta.22",
@@ -119,7 +121,7 @@
         "three": "^0.176.0",
         "uuid": "^11.1.0",
         "web-vitals": "^5.1.0",
-        "zod": "^3.22.4"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.10.1",
@@ -2181,6 +2183,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
@@ -2898,6 +2912,86 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@next/bundle-analyzer": {
@@ -7229,6 +7323,71 @@
         "three": ">= 0.138.0"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
@@ -10438,6 +10597,44 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -10519,6 +10716,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/algoliasearch": {
       "version": "5.45.0",
@@ -11140,6 +11376,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -11262,6 +11553,15 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -11708,6 +12008,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -11721,6 +12043,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/create-jest": {
@@ -11746,10 +12094,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -12431,9 +12778,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -12596,6 +12943,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -12801,6 +13157,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -12849,6 +13211,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
@@ -13105,6 +13476,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -13457,6 +13834,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -13471,6 +13857,27 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -13527,6 +13934,116 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/extend": {
@@ -13625,6 +14142,22 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -13801,6 +14334,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -14077,6 +14631,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
@@ -14095,6 +14658,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -14265,6 +14837,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -15117,6 +15698,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -15174,6 +15764,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-parser-js": {
@@ -15449,6 +16059,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -15853,6 +16481,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-reference": {
@@ -17292,6 +17926,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -17884,6 +18524,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mcp-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.1.0.tgz",
+      "integrity": "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mcp-handler/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -18180,6 +18869,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -19153,6 +19863,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "14.2.13",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.13.tgz",
@@ -19667,6 +20386,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -19897,6 +20628,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/partial-props": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/partial-props/-/partial-props-0.1.3.tgz",
@@ -19951,7 +20691,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19984,6 +20723,16 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -20143,6 +20892,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -20774,6 +21532,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -20848,6 +21619,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -21194,6 +22005,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/redis-errors": {
@@ -21944,6 +22772,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -22102,6 +22946,76 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -22150,6 +23064,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -22160,7 +23080,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -22173,7 +23092,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22503,6 +23421,15 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stickyfill": {
       "version": "1.1.1",
@@ -23306,6 +24233,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -23502,6 +24438,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -23759,6 +24751,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unplugin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
@@ -23917,6 +24918,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/verror": {
@@ -24528,12 +25538,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zustand": {
@@ -24561,21 +25580,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.13.tgz",
-      "integrity": "sha512-IkAmQEa2Htq+wHACBxOsslt+jMoV3msvxCn0WFSfJSkv/scy+i/EukBKNad36grRxywaXUYJc9mxEGkeIs8Bzg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -110,6 +110,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@mdx-js/loader": "^3.0.1",
     "@mdx-js/react": "^3.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@next/mdx": "^14.2.11",
     "@next/third-parties": "^14.2.2",
     "@opentelemetry/api": "^1.9.0",
@@ -185,6 +186,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.294.0",
+    "mcp-handler": "^1.1.0",
     "mobx": "^6.13.7",
     "next": "^14.2.13",
     "next-auth": "^5.0.0-beta.22",
@@ -213,7 +215,7 @@
     "three": "^0.176.0",
     "uuid": "^11.1.0",
     "web-vitals": "^5.1.0",
-    "zod": "^3.22.4"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^2.10.1",
@@ -266,5 +268,10 @@
   "ct3aMetadata": {
     "initVersion": "7.24.0"
   },
-  "packageManager": "npm@10.2.0"
+  "packageManager": "npm@10.2.0",
+  "overrides": {
+    "@modelcontextprotocol/sdk": {
+      "zod": "$zod"
+    }
+  }
 }

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -50,6 +50,15 @@ Australian short selling is regulated under the **Corporations Act 2001** and gu
 
 All short position data is sourced directly from official ASIC publications. Data is updated daily after ASIC releases new reports, typically in the late afternoon Australian Eastern Time. Historical data is available from 2010 onwards when ASIC began publishing daily aggregated short position data following the Global Financial Crisis.
 
+## MCP Server (for AI agents)
+
+Shorted exposes a Model Context Protocol server with read-only tools over the same ASIC data — no authentication required:
+
+- **Endpoint** (streamable HTTP): `https://shorted.com.au/api/mcp/mcp`
+- **Server card**: [https://shorted.com.au/.well-known/mcp/server-card.json](https://shorted.com.au/.well-known/mcp/server-card.json)
+- **Tools**: `get_top_shorts` (most shorted ASX stocks), `get_stock` (single ticker summary), `get_stock_history` (time series), `get_industry_treemap` (sector breakdown)
+- **API catalog** (RFC 9727): [https://shorted.com.au/.well-known/api-catalog](https://shorted.com.au/.well-known/api-catalog) · OpenAPI: [https://shorted.com.au/openapi.json](https://shorted.com.au/openapi.json) · Auth notes: [https://shorted.com.au/auth.md](https://shorted.com.au/auth.md)
+
 ## Reports
 
 - [Weekly Reports](https://shorted.com.au/reports): Weekly and monthly analysis of ASX short selling activity with top movers, industry trends, and AI-generated market narratives.

--- a/web/src/app/about/__tests__/page.test.tsx
+++ b/web/src/app/about/__tests__/page.test.tsx
@@ -206,7 +206,7 @@ describe("About Page", () => {
 
       expect(screen.getByText("Regulatory-Grade Data Pipeline")).toBeInTheDocument();
       expect(
-        screen.getByText(/Short positions above 0.5% of issued capital are required to be reported to ASIC/i)
+        screen.getByText(/Short positions of 0.01% of issued capital or \$100,000 \(whichever is less\) must be reported to ASIC/i)
       ).toBeInTheDocument();
     });
   });

--- a/web/src/app/about/about-client.tsx
+++ b/web/src/app/about/about-client.tsx
@@ -267,8 +267,8 @@ const AboutClient = ({ initialStatistics }: AboutClientProps) => {
                     Regulatory-Grade Data Pipeline
                   </h3>
                   <p className="text-muted-foreground">
-                    Short positions above 0.5% of issued capital are required to be reported to ASIC. 
-                    We process these daily filings and transform them into actionable insights, 
+                    Short positions of 0.01% of issued capital or $100,000 (whichever is less) must be reported to ASIC.
+                    We process these daily filings and transform them into actionable insights,
                     enriched with company metadata and historical context.
                   </p>
                 </div>
@@ -333,11 +333,11 @@ const AboutClient = ({ initialStatistics }: AboutClientProps) => {
                     Our Story
                   </h3>
                   <p className="text-muted-foreground leading-relaxed">
-                    ASIC requires short sellers to report positions above 0.5% of total shares on issue,
-                    but the raw CSV files they publish are difficult to work with. Shorted transforms
-                    this regulatory data into an intuitive platform with historical charts, industry
-                    heatmaps, AI-powered analysis, and real-time alerts — making institutional-grade
-                    short selling intelligence accessible to everyone.
+                    ASIC requires short sellers to report positions of 0.01% of total shares on issue
+                    or $100,000 (whichever is less), but the raw CSV files they publish are difficult
+                    to work with. Shorted transforms this regulatory data into an intuitive platform
+                    with historical charts, industry heatmaps, AI-powered analysis, and daily
+                    alerts — making institutional-grade short selling intelligence accessible to everyone.
                   </p>
                 </div>
 

--- a/web/src/app/api/agent/mcp-server-card/route.ts
+++ b/web/src/app/api/agent/mcp-server-card/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-static";
+
+/**
+ * MCP Server Card (SEP-1649 draft) for agent discovery.
+ * Served at /.well-known/mcp/server-card.json via a rewrite in
+ * next.config.mjs (app router ignores dot-prefixed folders).
+ */
+export function GET() {
+  const card = {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/server-card.json",
+    serverInfo: {
+      name: "shorted-asx-short-positions",
+      title: "Shorted — ASX Short Position Data",
+      version: "1.0.0",
+      description:
+        "Read-only access to official ASIC short-selling data for ASX-listed stocks: most-shorted rankings, per-stock short interest, full history since 2010, and industry breakdowns. Data updates daily with a T+4 trading-day delay.",
+      websiteUrl: "https://shorted.com.au",
+    },
+    transport: {
+      type: "streamable-http",
+      endpoint: "https://shorted.com.au/api/mcp/mcp",
+    },
+    authentication: { required: false },
+    capabilities: { tools: { listChanged: false } },
+    tools: [
+      { name: "get_top_shorts", description: "Most shorted ASX stocks, ranked" },
+      { name: "get_stock", description: "Current short position for one ASX ticker" },
+      { name: "get_stock_history", description: "Short interest time series for a ticker" },
+      { name: "get_industry_treemap", description: "Short positions grouped by industry" },
+    ],
+    contact: "support@shorted.com.au",
+  };
+
+  return NextResponse.json(card, {
+    headers: { "Cache-Control": "public, max-age=86400" },
+  });
+}

--- a/web/src/app/api/mcp/[transport]/route.ts
+++ b/web/src/app/api/mcp/[transport]/route.ts
@@ -1,0 +1,163 @@
+import { createMcpHandler } from "mcp-handler";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { SHORTS_API_URL } from "~/app/actions/config";
+
+export const maxDuration = 60;
+
+// All tools call the public Connect-RPC JSON endpoints server-side with
+// plain fetch — never import @connectrpc/connect here (SSR/bundle hazard).
+
+async function connectRpc<T>(method: string, body: unknown): Promise<T> {
+  const res = await fetch(
+    `${SHORTS_API_URL}/shorts.v1alpha1.ShortedStocksService/${method}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`${method} failed: HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+const PERIODS = ["1m", "3m", "6m", "1y", "2y", "5y", "max"] as const;
+
+// Schemas typed as ZodRawShape (not their literal types): the SDK's
+// ShapeOutput<> conditional types recurse past TS's instantiation limit on
+// zod 3.25 literal shapes (TS2589). Handler args are explicitly typed below;
+// runtime validation still uses the full schemas.
+const topShortsShape: z.ZodRawShape = {
+  limit: z.number().int().min(1).max(100).optional()
+    .describe("Number of stocks to return (1-100, default 20)"),
+};
+const stockShape: z.ZodRawShape = {
+  code: z.string().regex(/^[A-Za-z0-9]{1,4}$/)
+    .describe("ASX ticker code, 1-4 alphanumeric characters"),
+};
+const historyShape: z.ZodRawShape = {
+  code: z.string().regex(/^[A-Za-z0-9]{1,4}$/)
+    .describe("ASX ticker code, 1-4 alphanumeric characters"),
+  period: z.enum(PERIODS).optional()
+    .describe("History window (default 6m)"),
+};
+const treemapShape: z.ZodRawShape = {
+  limit: z.number().int().min(1).max(25).optional()
+    .describe("Stocks per industry (default 10)"),
+};
+
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+type RegisterTool = (
+  name: string,
+  description: string,
+  shape: z.ZodRawShape,
+  cb: (args: unknown) => Promise<ToolResult>,
+) => void;
+
+const handler = createMcpHandler(
+  (server: McpServer) => {
+    // The SDK's ShapeOutput<> conditional types exceed TS's instantiation
+    // depth with zod 3.25 (TS2589), so register through a plainly-typed
+    // alias — runtime behaviour and validation are identical.
+    const tool = server.tool.bind(server) as unknown as RegisterTool;
+    tool(
+      "get_top_shorts",
+      "List the most shorted stocks on the ASX (Australian Securities Exchange), ranked by percentage of shares sold short. Data comes from official ASIC daily reports (T+4 delay). ETFs, bonds and non-equity instruments are excluded.",
+      topShortsShape,
+      async (args: unknown) => {
+        const { limit } = args as { limit?: number };
+        const data = await connectRpc<{
+          timeSeries?: Array<{
+            productCode?: string;
+            name?: string;
+            latestShortPosition?: number;
+          }>;
+        }>("GetTopShorts", { period: "max", limit: limit ?? 20, offset: 0, summaryOnly: true });
+        const stocks = (data.timeSeries ?? []).map((t, i) => ({
+          rank: i + 1,
+          code: t.productCode,
+          name: t.name,
+          shortPercent: t.latestShortPosition,
+          url: `https://shorted.com.au/shorts/${t.productCode}`,
+        }));
+        return textResult({ source: "ASIC short position reports (T+4)", stocks });
+      },
+    );
+
+    tool(
+      "get_stock",
+      "Get the current short position summary for a single ASX stock by its ticker code (e.g. BHP, LOT, CBA): short interest %, reported short positions, total shares on issue, and industry.",
+      stockShape,
+      async (args: unknown) => {
+        const { code } = args as { code: string };
+        const data = await connectRpc<Record<string, unknown>>("GetStock", {
+          productCode: code.toUpperCase(),
+        });
+        return textResult({
+          ...data,
+          url: `https://shorted.com.au/shorts/${code.toUpperCase()}`,
+        });
+      },
+    );
+
+    tool(
+      "get_stock_history",
+      "Get the short interest time series for an ASX stock over a period. Returns dated percentage-of-shares-shorted observations from ASIC reports.",
+      historyShape,
+      async (args: unknown) => {
+        const { code, period } = args as { code: string; period?: (typeof PERIODS)[number] };
+        const data = await connectRpc<{
+          points?: Array<{ timestamp?: string; shortPosition?: number }>;
+        }>("GetStockData", { productCode: code.toUpperCase(), period: period ?? "6m" });
+        const points = data.points ?? [];
+        // Cap the payload: agents need the shape, not 3,000 raw rows.
+        const MAX_POINTS = 200;
+        const step = Math.max(1, Math.ceil(points.length / MAX_POINTS));
+        const sampled = points.filter((_, i) => i % step === 0 || i === points.length - 1);
+        return textResult({
+          code: code.toUpperCase(),
+          period,
+          totalObservations: points.length,
+          sampled: sampled.length,
+          points: sampled.map((p) => ({
+            date: p.timestamp,
+            shortPercent: p.shortPosition,
+          })),
+        });
+      },
+    );
+
+    tool(
+      "get_industry_treemap",
+      "Get short positions grouped by industry sector across the ASX — useful for questions like 'which sectors are most shorted'.",
+      treemapShape,
+      async (args: unknown) => {
+        const { limit } = args as { limit?: number };
+        const data = await connectRpc<Record<string, unknown>>(
+          "GetIndustryTreeMap",
+          { period: "3m", limit: limit ?? 10, viewMode: "CURRENT_CHANGE" },
+        );
+        return textResult(data);
+      },
+    );
+  },
+  {
+    serverInfo: {
+      name: "shorted-asx-short-positions",
+      version: "1.0.0",
+    },
+  },
+  {
+    basePath: "/api/mcp",
+    maxDuration: 60,
+    verboseLogs: false,
+  },
+);
+
+export { handler as GET, handler as POST, handler as DELETE };

--- a/web/src/app/news/[slug]/page.tsx
+++ b/web/src/app/news/[slug]/page.tsx
@@ -107,10 +107,60 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   };
 }
 
+function toISO(seconds: bigint | number | undefined): string | undefined {
+  if (typeof seconds === "bigint") return new Date(Number(seconds) * 1000).toISOString();
+  if (typeof seconds === "number") return new Date(seconds * 1000).toISOString();
+  return undefined;
+}
+
 export default async function ShortedTakePage({ params }: Params) {
   const { slug } = await params;
   const take = await loadTake(slug);
   if (!take) return notFound();
+
+  const url = `${siteConfig.url}/news/${slug}`;
+  const publishedISO = toISO(take.publishedAt?.seconds);
+  // Original editorial content — NewsArticle is the highest-value schema on
+  // the site. Author/publisher are the Organization (not a fake Person).
+  const newsArticleSchema = {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    headline: take.headline.slice(0, 110),
+    description: buildDescription(take.bodyMd),
+    url,
+    mainEntityOfPage: url,
+    image: [`${siteConfig.url}/news/${slug}/opengraph-image`],
+    ...(publishedISO
+      ? { datePublished: publishedISO, dateModified: publishedISO }
+      : {}),
+    author: {
+      "@type": "Organization",
+      name: "Shorted",
+      url: `${siteConfig.url}/about`,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Shorted",
+      url: siteConfig.url,
+      logo: {
+        "@type": "ImageObject",
+        url: `${siteConfig.url}/logo.png`,
+        width: 512,
+        height: 512,
+      },
+    },
+    isAccessibleForFree: true,
+    inLanguage: "en-AU",
+    ...(take.stockCode
+      ? {
+          about: {
+            "@type": "Corporation",
+            tickerSymbol: take.stockCode,
+            sameAs: `https://www.asx.com.au/markets/company/${take.stockCode}`,
+          },
+        }
+      : {}),
+  };
 
   const breadcrumbItems = [
     { label: "News", href: "/news" },
@@ -128,6 +178,10 @@ export default async function ShortedTakePage({ params }: Params) {
         dataSource="ASIC short-position data + Australian news publishers"
       />
       <BreadcrumbStructuredData items={breadcrumbItems} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(newsArticleSchema) }}
+      />
 
       <div className="mx-auto max-w-4xl px-4 py-8">
         <Breadcrumbs items={breadcrumbItems} className="mb-6" />

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -180,23 +180,10 @@ export default async function NewsIndexPage() {
     .map(({ summary: _summary, imageUrl: _imageUrl, ...a }) => a);
   const grouped = groupByDay(wireArticles);
 
-  // NewsArticle schema for the top ~10 stories (Google's recommendation).
-  const newsSchema = articles.slice(0, 10).map((a) => ({
-    "@context": "https://schema.org",
-    "@type": "NewsArticle",
-    headline: a.headline,
-    url: a.url,
-    datePublished: a.publishedAt,
-    image: a.imageUrl ? [a.imageUrl] : undefined,
-    publisher: {
-      "@type": "Organization",
-      name: a.source,
-    },
-    about: a.stockCode
-      ? { "@type": "Corporation", tickerSymbol: a.stockCode }
-      : undefined,
-  }));
-
+  // ItemList only: this is an aggregation page, so asserting NewsArticle
+  // entities for third-party publishers' content (with our render timestamps
+  // as datePublished) is misleading structured data — Google may treat it as
+  // spammy markup. NewsArticle belongs on our own /news/[slug] articles.
   const itemList = {
     "@context": "https://schema.org",
     "@type": "ItemList",
@@ -218,13 +205,6 @@ export default async function NewsIndexPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
       />
-      {newsSchema.map((s, i) => (
-        <script
-          key={i}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(s) }}
-        />
-      ))}
       <LLMMeta
         title="ASX News & Sentiment Hub"
         description="Latest news on Australian stocks with AI-classified sentiment, aggregated from multiple Australian financial publications."

--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -50,6 +50,7 @@ import { siteConfig } from "~/@/config/site";
 import { RelatedStocks } from "~/@/components/seo/related-stocks";
 import { getRelatedStocks } from "~/app/actions/getRelatedStocks";
 import { getStockOrNotFound } from "~/app/actions/getStock";
+import { ShortInterestHistory } from "./short-interest-history";
 import { NotFoundError } from "~/app/actions/withRetry";
 import { notFound } from "next/navigation";
 import { getTopShortsData } from "~/app/actions/getTopShorts";
@@ -431,6 +432,17 @@ const Page = async ({ params }: PageProps) => {
           </>
         );
       })()}
+
+      {/* SSR history summary + FAQ — crawlable trend facts (30d/90d/1y,
+          all-time extremes, rank). Suspense keeps it off the critical path. */}
+      {stock && (stock.percentageShorted ?? 0) > 0 && (
+        <Suspense fallback={null}>
+          <ShortInterestHistory
+            stockCode={stockCode}
+            companyName={stock.name || stockCode}
+          />
+        </Suspense>
+      )}
 
       <div className="mb-4">
         <Breadcrumbs items={breadcrumbItems} />

--- a/web/src/app/shorts/[stockCode]/short-interest-history.tsx
+++ b/web/src/app/shorts/[stockCode]/short-interest-history.tsx
@@ -1,0 +1,235 @@
+import { getStockData } from "~/app/actions/getStockData";
+import { SHORTS_API_URL } from "~/app/actions/config";
+
+interface Point {
+  date: Date;
+  pct: number;
+}
+
+interface HistoryStats {
+  latest: Point;
+  change30d: number | null;
+  change90d: number | null;
+  change1y: number | null;
+  allTimeHigh: Point;
+  allTimeLow: Point;
+}
+
+function toDate(ts: { seconds?: bigint | number } | undefined): Date | null {
+  const s = ts?.seconds;
+  if (typeof s === "bigint") return new Date(Number(s) * 1000);
+  if (typeof s === "number") return new Date(s * 1000);
+  return null;
+}
+
+function valueAtOrBefore(points: Point[], target: Date): number | null {
+  // points are ascending; walk back from the end
+  for (let i = points.length - 1; i >= 0; i--) {
+    const p = points[i]!;
+    if (p.date <= target) return p.pct;
+  }
+  return null;
+}
+
+function computeStats(points: Point[]): HistoryStats | null {
+  if (points.length === 0) return null;
+  const latest = points[points.length - 1]!;
+  let allTimeHigh = latest;
+  let allTimeLow = latest;
+  for (const p of points) {
+    if (p.pct > allTimeHigh.pct) allTimeHigh = p;
+    if (p.pct < allTimeLow.pct) allTimeLow = p;
+  }
+  const daysAgo = (n: number) =>
+    new Date(latest.date.getTime() - n * 24 * 60 * 60 * 1000);
+  const delta = (n: number) => {
+    const prev = valueAtOrBefore(points, daysAgo(n));
+    return prev === null ? null : latest.pct - prev;
+  };
+  return {
+    latest,
+    change30d: delta(30),
+    change90d: delta(90),
+    change1y: delta(365),
+    allTimeHigh,
+    allTimeLow,
+  };
+}
+
+/** Rank among all shorted ASX equities, from the summary-only top-shorts API. */
+async function getShortRank(stockCode: string): Promise<{ rank: number; total: number } | null> {
+  try {
+    const response = await fetch(
+      `${SHORTS_API_URL}/shorts.v1alpha1.ShortedStocksService/GetTopShorts`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ period: "max", limit: 1000, offset: 0, summaryOnly: true }),
+        next: { revalidate: 3600 },
+      },
+    );
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      timeSeries?: Array<{ productCode?: string }>;
+    };
+    const list = data.timeSeries ?? [];
+    const idx = list.findIndex((t) => t.productCode === stockCode);
+    if (idx < 0) return null;
+    return { rank: idx + 1, total: list.length };
+  } catch {
+    return null;
+  }
+}
+
+function fmtDelta(d: number | null): string {
+  if (d === null) return "—";
+  const sign = d > 0 ? "+" : "";
+  return `${sign}${d.toFixed(2)}pp`;
+}
+
+function fmtMonthYear(d: Date): string {
+  return d.toLocaleDateString("en-AU", { month: "long", year: "numeric" });
+}
+
+function trendWord(d: number | null): string {
+  if (d === null) return "been stable";
+  if (d > 0.5) return `risen ${d.toFixed(2)} percentage points`;
+  if (d < -0.5) return `fallen ${Math.abs(d).toFixed(2)} percentage points`;
+  return "been broadly stable";
+}
+
+/**
+ * Server-rendered short-interest history summary + FAQ. This is the page's
+ * crawlable substance: trend deltas, all-time extremes, and rank give
+ * search engines and AI answer engines self-contained quotable facts that
+ * the JS-rendered charts can't provide.
+ *
+ * No FAQPage structured data on purpose — Google restricted FAQ rich
+ * results to government/health sites in 2023; visible text is what counts.
+ */
+export async function ShortInterestHistory({
+  stockCode,
+  companyName,
+}: {
+  stockCode: string;
+  companyName: string;
+}) {
+  const [series, rankInfo] = await Promise.all([
+    getStockData(stockCode, "max"),
+    getShortRank(stockCode),
+  ]);
+
+  const points: Point[] = (series?.points ?? [])
+    .map((p) => {
+      const date = toDate(p.timestamp);
+      return date ? { date, pct: p.shortPosition } : null;
+    })
+    .filter((p): p is Point => p !== null)
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  const stats = computeStats(points);
+  if (!stats || stats.latest.pct <= 0) return null;
+
+  const { latest, change30d, change90d, change1y, allTimeHigh, allTimeLow } = stats;
+  const firstYear = points[0]!.date.getFullYear();
+
+  const heavily =
+    latest.pct >= 10
+      ? `Yes — at ${latest.pct.toFixed(2)}%, ${stockCode} is one of the most heavily shorted stocks on the ASX`
+      : latest.pct >= 5
+        ? `${stockCode}'s short interest of ${latest.pct.toFixed(2)}% is elevated relative to the ASX average`
+        : `Not especially — ${latest.pct.toFixed(2)}% short interest is modest by ASX standards`;
+
+  return (
+    <section
+      aria-label={`${stockCode} short interest history`}
+      className="mb-6 rounded-lg border bg-card p-4 md:p-5"
+    >
+      <h2 className="text-lg md:text-xl font-semibold tracking-tight">
+        {stockCode} Short Interest History
+      </h2>
+      <dl className="mt-4 grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+        <div>
+          <dt className="text-muted-foreground">30-day change</dt>
+          <dd className="font-semibold text-base">{fmtDelta(change30d)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">90-day change</dt>
+          <dd className="font-semibold text-base">{fmtDelta(change90d)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">1-year change</dt>
+          <dd className="font-semibold text-base">{fmtDelta(change1y)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">All-time high</dt>
+          <dd className="font-semibold text-base">
+            {allTimeHigh.pct.toFixed(2)}%{" "}
+            <span className="font-normal text-muted-foreground">
+              ({fmtMonthYear(allTimeHigh.date)})
+            </span>
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">All-time low</dt>
+          <dd className="font-semibold text-base">
+            {allTimeLow.pct.toFixed(2)}%{" "}
+            <span className="font-normal text-muted-foreground">
+              ({fmtMonthYear(allTimeLow.date)})
+            </span>
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-6 space-y-4 text-sm md:text-base">
+        <div>
+          <h3 className="font-semibold">Is {stockCode} heavily shorted?</h3>
+          <p className="mt-1 text-muted-foreground leading-relaxed">
+            {heavily}
+            {rankInfo
+              ? `, ranking #${rankInfo.rank} of ${rankInfo.total} ASX securities with reported short positions`
+              : ""}
+            . ASIC requires positions of 0.01% of issued capital or $100,000
+            (whichever is less) to be reported.
+          </p>
+        </div>
+        <div>
+          <h3 className="font-semibold">
+            How has {stockCode}&apos;s short interest changed recently?
+          </h3>
+          <p className="mt-1 text-muted-foreground leading-relaxed">
+            Over the past 30 days {companyName}&apos;s short interest has{" "}
+            {trendWord(change30d)}
+            {change90d !== null
+              ? `, and over 90 days it has ${trendWord(change90d)}`
+              : ""}
+            . The current level is {latest.pct.toFixed(2)}% of shares on issue.
+          </p>
+        </div>
+        <div>
+          <h3 className="font-semibold">
+            What is the highest {stockCode}&apos;s short interest has been?
+          </h3>
+          <p className="mt-1 text-muted-foreground leading-relaxed">
+            Since {firstYear}, {companyName}&apos;s short interest peaked at{" "}
+            {allTimeHigh.pct.toFixed(2)}% in {fmtMonthYear(allTimeHigh.date)} and
+            bottomed at {allTimeLow.pct.toFixed(2)}% in{" "}
+            {fmtMonthYear(allTimeLow.date)}.
+          </p>
+        </div>
+        <div>
+          <h3 className="font-semibold">Where does this data come from?</h3>
+          <p className="mt-1 text-muted-foreground leading-relaxed">
+            All figures are sourced from daily ASIC short position reports,
+            published with a four trading-day (T+4) delay. Shorted aggregates
+            the full history since {firstYear} — see our{" "}
+            <a href="/methodology" className="underline hover:no-underline">
+              methodology
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -45,7 +45,9 @@ interface TopShortsResponse {
 // "Crawled - currently not indexed" in GSC. Tail pages remain accessible
 // but use metadata.robots.noindex on the page itself.
 const SITEMAP_MIN_SHORT_PCT = 0.5;
-const SITEMAP_MAX_STOCKS = 300;
+// Effectively uncapped: the equities-only MV filter (migration 000043) caps
+// the universe at ~800 stocks, and the 0.5% quality bar prunes the tail.
+const SITEMAP_MAX_STOCKS = 1000;
 
 // Popular stock codes as fallback when API is unavailable
 const FALLBACK_STOCK_CODES = [
@@ -121,122 +123,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = siteConfig.url;
   const currentDate = new Date().toISOString();
 
-  // Static routes
-  const staticRoutes: MetadataRoute.Sitemap = [
-    { url: baseUrl, lastModified: currentDate },
-    { url: `${baseUrl}/about`, lastModified: currentDate },
-    { url: `${baseUrl}/blog`, lastModified: currentDate },
-    { url: `${baseUrl}/terms`, lastModified: currentDate },
-    { url: `${baseUrl}/roadmap`, lastModified: currentDate },
-    { url: `${baseUrl}/pricing`, lastModified: currentDate },
-    { url: `${baseUrl}/developer`, lastModified: currentDate },
-    { url: `${baseUrl}/technology`, lastModified: currentDate },
-    { url: `${baseUrl}/methodology`, lastModified: currentDate },
-    { url: `${baseUrl}/disclaimer`, lastModified: currentDate },
-    { url: `${baseUrl}/compare`, lastModified: currentDate },
-    { url: `${baseUrl}/seasonality`, lastModified: currentDate },
-  ];
-
-  // Blog post routes
-  const posts = getAllPosts();
-  const blogRoutes = posts.map((post) => ({
-    url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: post.date,
-  }));
-
-  // Dynamically fetch all stock codes from the API
-  const stockCodes = await getAllStockCodes();
-
-  const stockRoutes = stockCodes.map((code) => ({
-    url: `${baseUrl}/shorts/${code}`,
-    lastModified: currentDate,
-  }));
-
-  // Seed comparison-page URLs from the top-20 most shorted stocks.
-  // This yields up to 190 pairs (C(20,2)) but we cap at 30 to avoid
-  // index bloat and only include alphabetically-canonical ordering.
-  const top20 = stockCodes.slice(0, 20);
-  const comparePairs: Array<{ url: string; lastModified: string }> = [];
-  outer: for (let i = 0; i < top20.length; i++) {
-    for (let j = i + 1; j < top20.length; j++) {
-      const a = top20[i]!;
-      const b = top20[j]!;
-      const [lo, hi] = a < b ? [a, b] : [b, a];
-      comparePairs.push({
-        url: `${baseUrl}/compare/${lo}-vs-${hi}`,
-        lastModified: currentDate,
-      });
-      if (comparePairs.length >= 30) break outer;
-    }
-  }
-
-  // Canonical listing is /shorts; /stocks is not a canonical index.
-  const shortsRoutes = [
-    { url: `${baseUrl}/shorts`, lastModified: currentDate },
-  ];
-
-  // Documentation routes for LLMs and developers
-  const docRoutes = [
-    {
-      url: `${baseUrl}/docs/llm-context`,
-      lastModified: currentDate,
-    },
-    {
-      url: `${baseUrl}/docs/llm-context-raw`,
-      lastModified: currentDate,
-    },
-    {
-      url: `${baseUrl}/docs/api-reference`,
-      lastModified: currentDate,
-    },
-  ];
-
-  // Industry pages - index + individual industry pages
-  let industrySlugs: string[] = [];
-  try {
-    industrySlugs = await getAllIndustrySlugs();
-  } catch (error) {
-    console.error("Failed to fetch industry slugs for sitemap:", error);
-  }
-
-  const industryRoutes = [
-    {
-      url: `${baseUrl}/industry`,
-      lastModified: currentDate,
-    },
-    ...industrySlugs.map((slug) => ({
-      url: `${baseUrl}/industry/${slug}`,
-      lastModified: currentDate,
-    })),
-  ];
-
-  // Glossary pages - index + individual terms
-  const termSlugs = getAllTermSlugs();
-  const glossaryRoutes = [
-    {
-      url: `${baseUrl}/glossary`,
-      lastModified: currentDate,
-    },
-    ...termSlugs.map((slug) => ({
-      url: `${baseUrl}/glossary/${slug}`,
-      lastModified: currentDate,
-    })),
-  ];
-
-  // Directory pages - index + per-letter
-  const letters = "abcdefghijklmnopqrstuvwxyz".split("");
-  const directoryRoutes = [
-    {
-      url: `${baseUrl}/directory`,
-      lastModified: currentDate,
-    },
-    ...letters.map((letter) => ({
-      url: `${baseUrl}/directory/${letter}`,
-      lastModified: currentDate,
-    })),
-  ];
-
-  // Market snapshot pages
+  // Latest ASIC data date — the honest lastmod for all data-driven pages.
+  // Google ignores lastmod when it's demonstrably the build timestamp, so
+  // pages whose content changes with the daily sync use the actual data
+  // date, and static marketing pages omit lastModified entirely.
   let marketDates: string[] = [];
   try {
     const transport = createConnectTransport({
@@ -251,15 +141,123 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   } catch (error) {
     console.error("Failed to fetch market dates for sitemap:", error);
   }
+  const latestDataDate = marketDates[0]
+    ? new Date(`${marketDates[0]}T00:00:00Z`).toISOString()
+    : currentDate;
 
+  // Static marketing/documentation pages: no reliable change signal, so no
+  // lastModified (omitting is valid and better than a fabricated date).
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: baseUrl, lastModified: latestDataDate },
+    { url: `${baseUrl}/about` },
+    { url: `${baseUrl}/blog` },
+    { url: `${baseUrl}/terms` },
+    { url: `${baseUrl}/roadmap` },
+    { url: `${baseUrl}/pricing` },
+    { url: `${baseUrl}/developer` },
+    { url: `${baseUrl}/technology` },
+    { url: `${baseUrl}/methodology` },
+    { url: `${baseUrl}/disclaimer` },
+    { url: `${baseUrl}/compare` },
+    { url: `${baseUrl}/seasonality`, lastModified: latestDataDate },
+  ];
+
+  // Blog post routes
+  const posts = getAllPosts();
+  const blogRoutes = posts.map((post) => ({
+    url: `${baseUrl}/blog/${post.slug}`,
+    lastModified: post.date,
+  }));
+
+  // Dynamically fetch all stock codes from the API
+  const stockCodes = await getAllStockCodes();
+
+  const stockRoutes = stockCodes.map((code) => ({
+    url: `${baseUrl}/shorts/${code}`,
+    lastModified: latestDataDate,
+  }));
+
+  // Seed comparison-page URLs from the top-20 most shorted stocks.
+  // This yields up to 190 pairs (C(20,2)) but we cap at 30 to avoid
+  // index bloat and only include alphabetically-canonical ordering.
+  const top20 = stockCodes.slice(0, 20);
+  const comparePairs: Array<{ url: string; lastModified: string }> = [];
+  outer: for (let i = 0; i < top20.length; i++) {
+    for (let j = i + 1; j < top20.length; j++) {
+      const a = top20[i]!;
+      const b = top20[j]!;
+      const [lo, hi] = a < b ? [a, b] : [b, a];
+      comparePairs.push({
+        url: `${baseUrl}/compare/${lo}-vs-${hi}`,
+        lastModified: latestDataDate,
+      });
+      if (comparePairs.length >= 30) break outer;
+    }
+  }
+
+  // Canonical listing is /shorts; /stocks is not a canonical index.
+  const shortsRoutes = [
+    { url: `${baseUrl}/shorts`, lastModified: latestDataDate },
+  ];
+
+  // Documentation routes for LLMs and developers
+  const docRoutes = [
+    { url: `${baseUrl}/docs/llm-context` },
+    { url: `${baseUrl}/docs/llm-context-raw` },
+    { url: `${baseUrl}/docs/api-reference` },
+  ];
+
+  // Industry pages - index + individual industry pages
+  let industrySlugs: string[] = [];
+  try {
+    industrySlugs = await getAllIndustrySlugs();
+  } catch (error) {
+    console.error("Failed to fetch industry slugs for sitemap:", error);
+  }
+
+  const industryRoutes = [
+    {
+      url: `${baseUrl}/industry`,
+      lastModified: latestDataDate,
+    },
+    ...industrySlugs.map((slug) => ({
+      url: `${baseUrl}/industry/${slug}`,
+      lastModified: latestDataDate,
+    })),
+  ];
+
+  // Glossary pages - index + individual terms (static content, no lastmod)
+  const termSlugs = getAllTermSlugs();
+  const glossaryRoutes = [
+    { url: `${baseUrl}/glossary` },
+    ...termSlugs.map((slug) => ({
+      url: `${baseUrl}/glossary/${slug}`,
+    })),
+  ];
+
+  // Directory pages - index + per-letter
+  const letters = "abcdefghijklmnopqrstuvwxyz".split("");
+  const directoryRoutes = [
+    {
+      url: `${baseUrl}/directory`,
+      lastModified: latestDataDate,
+    },
+    ...letters.map((letter) => ({
+      url: `${baseUrl}/directory/${letter}`,
+      lastModified: latestDataDate,
+    })),
+  ];
+
+  // Market snapshot pages: each dated snapshot was last modified on its own
+  // date (historical data is immutable once published).
   const marketRoutes = [
     {
       url: `${baseUrl}/market`,
-      lastModified: currentDate,
+      lastModified: latestDataDate,
     },
     ...marketDates.map((date) => ({
       url: `${baseUrl}/market/${date}`,
-      lastModified: currentDate,
+      lastModified: new Date(`${date}T00:00:00Z`).toISOString(),
     })),
   ];
 
@@ -322,39 +320,23 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
   ];
 
-  // FAQ page
-  const faqRoutes = [
-    {
-      url: `${baseUrl}/faq`,
-      lastModified: currentDate,
-    },
-  ];
+  // FAQ + privacy: static content, no reliable change signal.
+  const faqRoutes = [{ url: `${baseUrl}/faq` }];
+  const privacyRoutes = [{ url: `${baseUrl}/privacy` }];
 
-  // Privacy page
-  const privacyRoutes = [
-    {
-      url: `${baseUrl}/privacy`,
-      lastModified: currentDate,
-    },
-  ];
-
-  // Educational content hub
+  // Educational content hub (static articles)
   const learnRoutes = [
-    {
-      url: `${baseUrl}/learn`,
-      lastModified: currentDate,
-    },
+    { url: `${baseUrl}/learn` },
     ...learnArticles.map((slug) => ({
       url: `${baseUrl}/learn/${slug}`,
-      lastModified: currentDate,
     })),
   ];
 
-  // Top page (high priority landing page)
+  // Top page (high priority landing page, refreshed with the daily sync)
   const topRoutes = [
     {
       url: `${baseUrl}/top`,
-      lastModified: currentDate,
+      lastModified: latestDataDate,
     },
   ];
 
@@ -362,13 +344,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const screenerRoutes = [
     {
       url: `${baseUrl}/screener`,
-      lastModified: currentDate,
+      lastModified: latestDataDate,
     },
   ];
 
   // News hub + per-stock news pages. Per-stock news pages share the
   // same qualified stockCodes list, so the news tree mirrors the
-  // pruned stock list (no thin pages get indexed).
+  // pruned stock list (no thin pages get indexed). News flows hourly,
+  // so the render date is genuinely the last modification.
   const newsRoutes = [
     { url: `${baseUrl}/news`, lastModified: currentDate },
     ...stockCodes.map((code) => ({
@@ -396,26 +379,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Insider-trading hub + per-stock director-trades pages.
   const insiderRoutes = [
-    { url: `${baseUrl}/insider-trading`, lastModified: currentDate },
+    { url: `${baseUrl}/insider-trading`, lastModified: latestDataDate },
     ...stockCodes.map((code) => ({
       url: `${baseUrl}/insider-trading/${code}`,
-      lastModified: currentDate,
+      lastModified: latestDataDate,
     })),
   ];
 
   // Open data hub.
   const dataRoutes = [
-    { url: `${baseUrl}/data`, lastModified: currentDate },
+    { url: `${baseUrl}/data`, lastModified: latestDataDate },
   ];
 
-  // Authors hub + per-author profile pages — E-E-A-T signal.
+  // Authors hub + per-author profile pages — E-E-A-T signal (static).
   const { getAllAuthorSlugs } = await import("~/@/data/authors");
   const authorSlugs = getAllAuthorSlugs();
   const authorRoutes = [
-    { url: `${baseUrl}/authors`, lastModified: currentDate },
+    { url: `${baseUrl}/authors` },
     ...authorSlugs.map((slug) => ({
       url: `${baseUrl}/authors/${slug}`,
-      lastModified: currentDate,
     })),
   ];
 


### PR DESCRIPTION
Implements the remaining items from the SEO/discovery review:

| Item | Change |
|---|---|
| **Stock-page GEO content** | SSR "Short Interest History" block (30d/90d/1y deltas, all-time high/low + dates, rank #N of M) + 4-question FAQ — crawlable HTML across ~2,000 pages. No FAQPage schema (gov/health only since 2023) |
| **MCP server** | `/api/mcp/mcp` (streamable HTTP, no auth) with `get_top_shorts`, `get_stock`, `get_stock_history`, `get_industry_treemap`; server card at `/.well-known/mcp/server-card.json`; announced in llms.txt |
| **News schema** | NewsArticle JSON-LD on our own editorial articles (real dates, Org author); removed 9 third-party NewsArticle blocks with fabricated render-time dates on `/news` |
| **Sitemap** | Real lastmod (latest ASIC data date for data pages, snapshot dates for /market/*, omitted for static pages); stock cap 300→1000 |
| **/about factual fix** | ASIC threshold 0.5% → **0.01% or $100k** (both passages); "real-time" → "daily" |

Deps: `mcp-handler` + `@modelcontextprotocol/sdk`, zod 3.22→3.25 (Standard Schema interface required by the SDK) with an npm override pinning the SDK to the app's zod instance.

**Verified on preview `ed2sntbel`**: MCP initialize/tools-list/tools-call return live filtered data (LOT #1 @ 19.87%); NewsArticle present on article pages with real publish dates and absent on /news; sitemap shows honest lastmod distribution (723 URLs at the 2026-06-04 data date); about-page tests 23/23.