### PR TITLE
fix(web): MCP + rank fetches need WAF-safe headers against api.shorted.com.au

### DIFF
--- a/web/src/app/api/mcp/[transport]/route.ts
+++ b/web/src/app/api/mcp/[transport]/route.ts
@@ -9,16 +9,26 @@ export const maxDuration = 60;
 // plain fetch — never import @connectrpc/connect here (SSR/bundle hazard).
 
 async function connectRpc<T>(method: string, body: unknown): Promise<T> {
+  // .trim(): Vercel env vars can carry trailing newlines (documented gotcha).
+  // Connect-Protocol-Version + a UA are required: api.shorted.com.au sits
+  // behind the Cloudflare WAF, which serves an HTML 500 to bare fetches.
+  const base = SHORTS_API_URL.trim();
   const res = await fetch(
-    `${SHORTS_API_URL}/shorts.v1alpha1.ShortedStocksService/${method}`,
+    `${base}/shorts.v1alpha1.ShortedStocksService/${method}`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "Connect-Protocol-Version": "1",
+        "User-Agent":
+          "Mozilla/5.0 (compatible; ShortedMCP/1.0; +https://shorted.com.au)",
+      },
       body: JSON.stringify(body),
     },
   );
   if (!res.ok) {
-    throw new Error(`${method} failed: HTTP ${res.status}`);
+    const snippet = (await res.text()).replace(/<[^>]+>/g, " ").slice(0, 120);
+    throw new Error(`${method} failed: HTTP ${res.status} ${snippet}`);
   }
   return (await res.json()) as T;
 }

--- a/web/src/app/shorts/[stockCode]/short-interest-history.tsx
+++ b/web/src/app/shorts/[stockCode]/short-interest-history.tsx
@@ -59,11 +59,19 @@ function computeStats(points: Point[]): HistoryStats | null {
 /** Rank among all shorted ASX equities, from the summary-only top-shorts API. */
 async function getShortRank(stockCode: string): Promise<{ rank: number; total: number } | null> {
   try {
+    // trim + headers: Vercel env vars can carry trailing newlines, and the
+    // Cloudflare WAF in front of api.shorted.com.au serves an HTML 500 to
+    // fetches without a UA and Connect-Protocol-Version header.
     const response = await fetch(
-      `${SHORTS_API_URL}/shorts.v1alpha1.ShortedStocksService/GetTopShorts`,
+      `${SHORTS_API_URL.trim()}/shorts.v1alpha1.ShortedStocksService/GetTopShorts`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Connect-Protocol-Version": "1",
+          "User-Agent":
+            "Mozilla/5.0 (compatible; ShortedBot/1.0; +https://shorted.com.au)",
+        },
         body: JSON.stringify({ period: "max", limit: 1000, offset: 0, summaryOnly: true }),
         next: { revalidate: 3600 },
       },


### PR DESCRIPTION
Post-deploy validation of #159 found all MCP tool calls failing in prod with `HTTP 500`.

**Root cause:** in prod, `SHORTS_API_URL` resolves to `https://api.shorted.com.au` (from `NEXT_PUBLIC_API_URL`, which also carries a trailing `\n`). That host is behind the Cloudflare WAF, which serves an **HTML 500 error page to bare server-side fetches** (no User-Agent, no Connect-Protocol-Version). Reproduced and verified locally:

```
bare fetch            → 500 (Cloudflare HTML)
+ Connect-Protocol-Version: 1 + UA → 200
```

**Fix:** both raw-fetch sites (MCP `connectRpc`, stock-page `getShortRank`) now send `Connect-Protocol-Version: 1` + an identifying UA and `.trim()` the env URL. MCP tool errors now include a response-body snippet so the next failure isn't a blind status code.