### PR TITLE
feat(terraform): codify Cloudflare AI Crawl Control in the edge module

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -353,6 +353,12 @@ module "edge" {
   frontend_origin      = "https://shorted.com.au"
   create_frontend_records = true   # Proxy frontend through Cloudflare edge for caching + rate limiting
 
+  # AI crawler policy: allow AI bots (llms.txt / Content-Signals / MCP
+  # discovery strategy). Flip to true once CLOUDFLARE_API_TOKEN has the
+  # "Zone -> Bot Management -> Edit" permission (current token 403s).
+  manage_ai_crawler_settings = false
+  ai_bots_protection         = "disabled"
+
   cache_ttl_seconds    = 60
   top_shorts_cache_ttl = 300
   stock_data_cache_ttl = 120

--- a/terraform/modules/cloudflare-edge/main.tf
+++ b/terraform/modules/cloudflare-edge/main.tf
@@ -438,3 +438,23 @@ resource "cloudflare_ruleset" "rate_limit_api" {
     }
   }
 }
+
+# =============================================================================
+# AI Crawl Control — bot management
+# =============================================================================
+# Codifies the zone's AI crawler policy so a dashboard toggle can't silently
+# reintroduce the managed robots.txt block (which serves "Disallow: /" to
+# GPTBot/ClaudeBot/CCBot above our own allow rules — observed June 2026).
+#
+# NOTE: provider v4 (last release 4.52.7) does not expose
+# is_robots_txt_managed or the content_converter ("Markdown for Agents")
+# zone setting — both are provider v5 / newer API surface. Markdown for
+# Agents is additionally unavailable on the Free plan (content_converter is
+# editable: false). Revisit both on a provider v5 migration or plan upgrade.
+
+resource "cloudflare_bot_management" "ai_crawl_control" {
+  count = var.manage_ai_crawler_settings ? 1 : 0
+
+  zone_id            = var.cloudflare_zone_id
+  ai_bots_protection = var.ai_bots_protection
+}

--- a/terraform/modules/cloudflare-edge/variables.tf
+++ b/terraform/modules/cloudflare-edge/variables.tf
@@ -199,3 +199,35 @@ variable "create_api_record" {
   type        = bool
   default     = true
 }
+
+# ---- AI crawler policy ----
+
+variable "manage_ai_crawler_settings" {
+  description = <<-EOT
+    Manage the zone's AI Crawl Control via Terraform (cloudflare_bot_management).
+    Requires the Cloudflare API token to have the "Zone → Bot Management → Edit"
+    permission — the default token scoped for Workers/DNS/cache returns 403.
+    Flip to true after re-scoping CLOUDFLARE_API_TOKEN.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "ai_bots_protection" {
+  description = <<-EOT
+    Cloudflare AI bots protection. "disabled" = allow AI crawlers (GPTBot,
+    ClaudeBot, CCBot…), which is deliberate: the site's discovery strategy
+    depends on AI crawler access (llms.txt, Content-Signals in robots.txt,
+    MCP server). "block" also injects a managed robots.txt with Disallow
+    rules ABOVE our own — which silently defeated the AI-allow policy until
+    it was switched off in June 2026. Keep "disabled" unless that strategy
+    changes.
+  EOT
+  type        = string
+  default     = "disabled"
+
+  validation {
+    condition     = contains(["block", "disabled", "only_on_ad_pages"], var.ai_bots_protection)
+    error_message = "ai_bots_protection must be one of: block, disabled, only_on_ad_pages."
+  }
+}


### PR DESCRIPTION
Moves the AI-crawler policy from a Cloudflare dashboard toggle into Terraform.

## What
- `cloudflare_bot_management.ai_crawl_control` in `terraform/modules/cloudflare-edge` with `ai_bots_protection = "disabled"` — the setting whose dashboard flip-side injected a managed robots.txt serving `Disallow: /` to GPTBot/ClaudeBot/CCBot above our allow rules (the critical SEO-audit finding). Codifying it prevents silent regression.
- Gated behind `manage_ai_crawler_settings` (**default false** → this PR is a plan no-op).

## Why gated
The current `CLOUDFLARE_API_TOKEN` (Workers/DNS/cache scope) returns 403 on `/zones/{id}/bot_management`. **To activate:** add *Zone → Bot Management → Edit* to the token in the Cloudflare dashboard, then set `manage_ai_crawler_settings = true` in `environments/prod/main.tf`.

## Investigated, not possible right now
| Setting | Blocker |
|---|---|
| `is_robots_txt_managed` | Terraform provider v5 only — v4 line ended at 4.52.7; v5 migration is a breaking module rewrite |
| Markdown for Agents (`content_converter`) | **Plan-gated**: zone is on Free, API reports `editable: false` — needs Pro+ regardless of tooling |

`terraform validate` passes; CI terraform-plan will confirm the no-op.