### PR TITLE
feat(terraform): Cloudflare Pro-plan performance + agent settings

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -354,10 +354,10 @@ module "edge" {
   create_frontend_records = true   # Proxy frontend through Cloudflare edge for caching + rate limiting
 
   # AI crawler policy: allow AI bots (llms.txt / Content-Signals / MCP
-  # discovery strategy). Flip to true once CLOUDFLARE_API_TOKEN has the
-  # "Zone -> Bot Management -> Edit" permission (current token 403s).
-  manage_ai_crawler_settings = false
+  # discovery strategy). Token re-scoped with Bot Management Edit June 2026.
+  manage_ai_crawler_settings = true
   ai_bots_protection         = "disabled"
+  markdown_for_agents        = "on"
 
   cache_ttl_seconds    = 60
   top_shorts_cache_ttl = 300

--- a/terraform/modules/cloudflare-edge/main.tf
+++ b/terraform/modules/cloudflare-edge/main.tf
@@ -332,6 +332,20 @@ resource "cloudflare_zone_settings_override" "security" {
     always_use_https         = "on"
     min_tls_version          = "1.2"
     automatic_https_rewrites = "on"
+
+    # ---- Performance (Pro plan, June 2026) ----
+    # 103 Early Hints from cached Link headers — browsers preload before
+    # the full response arrives.
+    early_hints = "on"
+    # QUIC + 0-RTT session resumption at the edge.
+    http3    = "on"
+    zero_rtt = "on"
+    # Speculation-rules prefetch of likely next navigations.
+    speed_brain = "on"
+    # Image recompression at the edge; lossless keeps og-image/PNG fidelity,
+    # webp only serves WebP to clients whose Accept allows it.
+    polish = "lossless"
+    webp   = "on"
   }
 }
 
@@ -457,4 +471,42 @@ resource "cloudflare_bot_management" "ai_crawl_control" {
 
   zone_id            = var.cloudflare_zone_id
   ai_bots_protection = var.ai_bots_protection
+}
+
+
+# =============================================================================
+# Tiered Cache — Smart Topology
+# =============================================================================
+# Cache misses at AU edge colos pull from the nearest upper-tier datacenter
+# to the origin instead of all independently hitting Vercel/Cloud Run —
+# higher effective HIT ratio and lower origin load.
+
+resource "cloudflare_tiered_cache" "smart" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "smart"
+}
+
+# =============================================================================
+# Markdown for Agents (content_converter zone setting)
+# =============================================================================
+# Serves a markdown rendition of HTML pages to clients sending
+# Accept: text/markdown — token-efficient pages for AI agents. Pro-plan
+# feature. Provider v4 (frozen at 4.52.7) has no resource for this zone
+# setting, so it is asserted via the API. Re-runs whenever the desired
+# value changes; requires CLOUDFLARE_API_TOKEN in the environment (present
+# in CI and local dev). Replace with a native resource on the provider v5
+# migration.
+
+resource "terraform_data" "markdown_for_agents" {
+  triggers_replace = var.markdown_for_agents
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      curl -sf -X PATCH \
+        "https://api.cloudflare.com/client/v4/zones/${var.cloudflare_zone_id}/settings/content_converter" \
+        -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+        -H "Content-Type: application/json" \
+        --data '{"value":"${var.markdown_for_agents}"}'
+    EOT
+  }
 }

--- a/terraform/modules/cloudflare-edge/variables.tf
+++ b/terraform/modules/cloudflare-edge/variables.tf
@@ -231,3 +231,14 @@ variable "ai_bots_protection" {
     error_message = "ai_bots_protection must be one of: block, disabled, only_on_ad_pages."
   }
 }
+
+variable "markdown_for_agents" {
+  description = "Cloudflare Markdown for Agents (content_converter zone setting). Serves markdown to Accept: text/markdown clients. Requires Pro+ plan."
+  type        = string
+  default     = "on"
+
+  validation {
+    condition     = contains(["on", "off"], var.markdown_for_agents)
+    error_message = "markdown_for_agents must be \"on\" or \"off\"."
+  }
+}


### PR DESCRIPTION
Zone is now on **Pro** and the API token has Bot Management Edit — this activates the gated AI-crawler resource and adds the Pro/free performance features as code:

| Setting | Value | Why |
|---|---|---|
| `manage_ai_crawler_settings` (prod) | **true** | `cloudflare_bot_management` live — `ai_bots_protection=disabled` pinned in state, dashboard can't silently regress the AI-crawler-allow policy |
| `early_hints` | on | 103 hints from cached Link headers → earlier resource loading |
| `http3` + `zero_rtt` | on | QUIC + 0-RTT resumption at the edge |
| `speed_brain` | on | speculation-rules prefetch of likely next navigations |
| `polish` + `webp` | lossless + on | edge image recompression; WebP only when Accept allows |
| `cloudflare_tiered_cache` | smart | AU edge misses pull via upper tier near origin → higher HIT ratio, less origin load |
| Markdown for Agents | on (API shim) | `content_converter` has no provider-v4 resource → `terraform_data` + PATCH; codifies the dashboard toggle |

`terraform validate` passes in both envs. Both envs share the single zone and assert identical values (same pattern as the existing `zone_settings_override`).