### PR TITLE
feat(terraform): re-enable dev GCS backend with reconciled real state

### DIFF
--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -1,5 +1,9 @@
+# Real GCS backend (re-enabled June 2026). State previously went to a local
+# file, so every CI plan started from scratch and showed create-everything
+# instead of real diffs.
 terraform {
-  backend "local" {
-    path = "terraform.tfstate"
+  backend "gcs" {
+    bucket = "shorted-dev-aba5688f-terraform-state"
+    prefix = "env/dev"
   }
 }

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -25,10 +25,7 @@ terraform {
     }
   }
 
-  #   backend "gcs" {
-  #     bucket = "shorted-dev-aba5688f-terraform-state"
-  #     prefix = "env/dev"
-  #   }
+  # Backend lives in backend.tf (GCS, re-enabled June 2026).
 }
 
 provider "google" {
@@ -275,45 +272,11 @@ module "asx_announcement_crawler" {
 }
 
 # =============================================================================
-# Cloudflare Edge — Worker, DNS, WAF, rate limiting
+# Cloudflare Edge — managed by environments/prod ONLY.
+# There is a single shorted.com.au zone; dev previously co-managed the same
+# worker/DNS/rulesets, meaning a dev apply could overwrite prod's edge with
+# dev origins. Removed June 2026 when the dev GCS backend was re-enabled.
 # =============================================================================
-module "cloudflare_edge" {
-  source = "../../modules/cloudflare-edge"
-
-  cloudflare_zone_id = var.cloudflare_zone_id
-  domain             = "api.shorted.com.au"
-  environment        = "dev"
-
-  shorts_api_origin       = module.shorts_api.service_url
-  chat_service_origin     = module.chat_service.service_url
-  market_data_origin      = module.market_data.service_url
-  frontend_origin         = "https://shorted.com.au"
-  create_frontend_records = true # Enable frontend DNS management via Cloudflare
-
-  cache_ttl_seconds    = 30
-  top_shorts_cache_ttl = 60
-  stock_data_cache_ttl = 30
-  news_cache_ttl       = 120
-
-  rate_limit_enabled         = true
-  api_rate_limit_requests    = 60
-  search_rate_limit_requests = 20
-
-  waf_enabled            = true
-  bot_protection_enabled = false
-
-  cache_purge_secret = var.cache_purge_secret
-}
-
-output "edge_url" {
-  description = "Edge-proxied URL for the API."
-  value       = "https://api.shorted.com.au"
-}
-
-output "edge_worker_name" {
-  description = "Name of the Cloudflare edge worker."
-  value       = module.cloudflare_edge.worker_name
-}
 
 # Newsroom Daily Job (take-writer — generates and publishes daily takes)
 module "newsroom_job" {

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -74,11 +74,7 @@ output "artifact_registry_repository" {
   value       = "australia-southeast2-docker.pkg.dev/${var.project_id}/shorted"
 }
 
-# Cloudflare Edge Outputs
-output "cloudflare_edge_url" {
-  description = "Cloudflare edge worker URL"
-  value       = module.cloudflare_edge.worker_name
-}
+# Cloudflare edge is managed by environments/prod only (single zone).
 
 output "cloudflare_zone_id" {
   description = "Cloudflare zone ID"


### PR DESCRIPTION
Completes the IaC chain: PR plans now run against **persistent, reconciled dev state** instead of an empty local backend.

## Root cause
A committed `backend.tf` pinned dev to `backend "local"` — the GCS block in main.tf was commented out, and state in the (already-existing) bucket was 7 months stale.

## Changes
- `backend.tf` → GCS (`env/dev` prefix)
- **dev no longer manages the Cloudflare edge** — one zone, one owner (prod). Dev co-managing the same worker/DNS/rulesets meant a dev apply could overwrite prod's live edge worker with dev origins.

## State reconciliation (done directly; backups in ~/cf-migration-backups/)
| Action | What | Why |
|---|---|---|
| state rm ×9 | artifact registry, 6× required_apis, cms svc+SA | config intentionally dropped them; destroy would have **disabled live APIs / deleted all dev images**. cms left running unmanaged |
| import ×23 (23/23 clean) | live run services/jobs, SAs, schedulers, secrets | existed live but post-dated the stale state |

## Result
```
Plan: 67 to add, 9 to change, 0 to destroy
```
All truthful: the 67 are resources dev genuinely lacks (chat-service, newsroom-job, grafana dashboards — images never built for dev), the 9 are real config drift (cpu/memory/timeout deltas). **Zero destroys.** This PR's own plan job demonstrates the gate against real state.