### PR TITLE
fix(charts): per-stock chart tooltip follows the cursor

### DIFF
--- a/web/src/@/components/charts/StockChart.stories.tsx
+++ b/web/src/@/components/charts/StockChart.stories.tsx
@@ -86,11 +86,59 @@ export const DualAxis: Story = {
     await waitFor(() =>
       expect(canvasElement.querySelectorAll("circle").length).toBeGreaterThanOrEqual(2),
     );
-    // Tooltip (portal) shows both series labels.
+    // Tooltip shows both series labels.
     await waitFor(() => {
       expect(document.body.textContent).toMatch(/Price/);
       expect(document.body.textContent).toMatch(/Short %/);
     });
+  },
+};
+
+// Regression: the tooltip must follow the cursor vertically (not sit at a fixed
+// top anchor). A fixed anchor detaches the tooltip from the hovered point and,
+// on scrolled/sticky-header pages, floats it above the chart entirely.
+export const TooltipTracksCursor: Story = {
+  tags: ["no-visual"], // interaction-only regression; visuals covered by DualAxis
+  args: {
+    series: [priceSeries("PLS", "6m"), shortSeries("PLS", "6m")],
+    leftAxis: { side: "left", format: priceFmt },
+    rightAxis: { side: "right", format: shortFmt },
+    height: 400,
+  },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(capture(canvasElement)).toBeTruthy());
+    const rect = capture(canvasElement);
+    const box = rect.getBoundingClientRect();
+    const tipTop = () =>
+      canvasElement
+        .querySelector("[data-chart-tooltip]")
+        ?.getBoundingClientRect().top ?? null;
+
+    fireEvent.mouseMove(rect, {
+      clientX: box.left + box.width * 0.5,
+      clientY: box.top + box.height * 0.25,
+    });
+    let highTop: number | null = null;
+    await waitFor(() => {
+      highTop = tipTop();
+      expect(highTop).not.toBeNull();
+    });
+
+    fireEvent.mouseMove(rect, {
+      clientX: box.left + box.width * 0.5,
+      clientY: box.top + box.height * 0.75,
+    });
+    await waitFor(() => {
+      const lowTop = tipTop();
+      expect(lowTop).not.toBeNull();
+      // Tooltip moved down with the cursor.
+      expect(lowTop!).toBeGreaterThan(highTop! + 20);
+    });
+    // And it stays within the chart container (never floats above it).
+    const containerTop = canvasElement
+      .querySelector("[data-chart-container]")!
+      .getBoundingClientRect().top;
+    expect(highTop!).toBeGreaterThanOrEqual(containerTop - 1);
   },
 };
 

--- a/web/src/@/components/charts/StockChart.tsx
+++ b/web/src/@/components/charts/StockChart.tsx
@@ -17,7 +17,6 @@ import type BaseBrush from "@visx/brush/lib/BaseBrush";
 import type { Bounds } from "@visx/brush/lib/types";
 import { Line, AreaClosed } from "@visx/shape";
 import { curveMonotoneX } from "@visx/curve";
-import { useTooltipInPortal } from "@visx/tooltip";
 import { decimate } from "./decimate";
 import { useChartScales } from "./use-chart-scales";
 import { normalizeToPercentChange } from "./indicators";
@@ -75,10 +74,6 @@ function StockChartInner({
   // Unique per-instance prefix so SVG gradient ids never collide when multiple
   // StockCharts render on one page (e.g. several dashboard widgets).
   const gid = useId();
-  const { containerRef, TooltipInPortal } = useTooltipInPortal({
-    detectBounds: true,
-    scroll: true,
-  });
 
   const isMobile = width > 0 && width <= MOBILE_MAX;
   const compact = variant === "compact";
@@ -264,7 +259,7 @@ function StockChartInner({
   const brushTop = height - brushH + 4;
 
   return (
-    <div ref={containerRef} style={{ position: "relative" }}>
+    <div data-chart-container style={{ position: "relative" }}>
       <svg width={width} height={height} data-points={renderSeries[0]?.points.length ?? 0}>
         <Group left={margin.left} top={margin.top}>
           <Grid yScale={leftScale} width={innerW} />
@@ -399,24 +394,44 @@ function StockChartInner({
         )}
       </svg>
 
-      {hover && (
-        <TooltipInPortal
-          key={Math.round(hover.cx)}
-          left={hover.cx + margin.left + 12}
-          top={margin.top + 8}
-          style={{
-            position: "absolute",
-            background: chartTheme.tooltipBg,
-            border: "1px solid hsl(var(--border))",
-            borderRadius: 8,
-            padding: "8px 10px",
-            boxShadow: "0 4px 12px hsl(var(--foreground) / 0.1)",
-            pointerEvents: "none",
-          }}
-        >
-          <TooltipContent hover={hover} leftAxis={leftAxis} rightAxis={rightAxis} />
-        </TooltipInPortal>
-      )}
+      {hover &&
+        (() => {
+          // Position the tooltip next to the cursor, INSIDE the chart container.
+          // No portal / viewport math (which mis-measured on scrolled, sticky-
+          // header pages) — coordinates are relative to this relative wrapper.
+          const TIP_W = 168;
+          const TIP_H = 120;
+          const anchorX = hover.cx + margin.left;
+          const anchorY = hover.cy;
+          const left =
+            anchorX + 14 + TIP_W <= width
+              ? anchorX + 14
+              : Math.max(4, anchorX - 14 - TIP_W);
+          const top = Math.min(
+            Math.max(4, anchorY + 14),
+            Math.max(4, height - TIP_H),
+          );
+          return (
+            <div
+              data-chart-tooltip
+              style={{
+                position: "absolute",
+                left,
+                top,
+                maxWidth: TIP_W,
+                background: chartTheme.tooltipBg,
+                border: "1px solid hsl(var(--border))",
+                borderRadius: 8,
+                padding: "8px 10px",
+                boxShadow: "0 4px 12px hsl(var(--foreground) / 0.1)",
+                pointerEvents: "none",
+                zIndex: 20,
+              }}
+            >
+              <TooltipContent hover={hover} leftAxis={leftAxis} rightAxis={rightAxis} />
+            </div>
+          );
+        })()}
     </div>
   );
 }

--- a/web/src/@/components/charts/chart-tooltip.tsx
+++ b/web/src/@/components/charts/chart-tooltip.tsx
@@ -22,7 +22,8 @@ export interface HoverEntry {
   point: ChartPoint;
 }
 export interface HoverState {
-  cx: number; // crosshair x (px, inner coords)
+  cx: number; // crosshair x (px, relative to the svg/container)
+  cy: number; // cursor y (px, relative to the svg/container) — tooltip follows it
   t: number; // hovered time
   entries: HoverEntry[];
 }
@@ -59,7 +60,7 @@ export function useChartPointer(opts: {
         return;
       }
       const cx = xScale(new Date(entries[0]!.point.t)) ?? innerX;
-      setHover({ cx, t, entries });
+      setHover({ cx, cy: pt.y, t, entries });
     },
     [xScale, series, marginLeft],
   );


### PR DESCRIPTION
**Live bug:** on the per-stock page the price/short chart tooltip floated ~90px **above** the chart, detached from the hovered point.

**Root cause (verified via Playwright on the deployed page):** the tooltip used a fixed `top` anchor and `useTooltipInPortal`, whose viewport/scroll math mis-measured the vertical offset on the real sticky-header, scrolled page (horizontal was correct; vertical was off by a constant). It also never tracked cursor-Y.

**Fix:** render the tooltip as an in-container, absolutely-positioned element at the cursor coordinates (no portal / no viewport math), with edge clamping so it stays within the chart. Now it sits at the crosshair point and follows the cursor.

**Test:** adds `TooltipTracksCursor` regression story asserting the tooltip follows cursor-Y and stays within the chart container. Full Storybook suite green (103 tests). No visual-baseline change (tooltip is hover-only; rest-state snapshots unchanged).