### PR TITLE
seo(shorts): make per-stock crawler summary sr-only

### DIFF
--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -385,9 +385,13 @@ const Page = async ({ params }: PageProps) => {
                 __html: JSON.stringify(corporationSchema),
               }}
             />
+            {/* Crawler/LLM summary — kept in the SSR DOM for SEO + AI bots but
+                visually hidden (sr-only, not display:none, so it stays indexed
+                and in the a11y tree). The same facts are shown visibly below in
+                CompanyProfile / CompanyStats / the chart. */}
             <section
               aria-label={`${stockCode} short interest summary`}
-              className="mb-4 rounded-lg border bg-card p-4 md:p-5"
+              className="sr-only"
             >
               <h1 className="text-xl md:text-2xl font-bold tracking-tight">
                 {companyName} ({stockCode}) Short Interest


### PR DESCRIPTION
## What
The per-stock page's `<h1>` + short-interest summary block (`/shorts/[code]`) was added purely for crawler/LLM SEO, but its facts are already shown visibly below (CompanyProfile, CompanyStats, the chart). This hides that `<section>` visually with **`sr-only`**.

## Why this is SEO-safe
- **Server-rendered** → the text stays in the initial HTML for Google/Bing and AI crawlers (GPTBot/ClaudeBot/PerplexityBot); nothing lost for SEO/GEO.
- **`sr-only`, not `display:none`** → `display:none` is discounted by Google and skipped by screen readers; `sr-only` stays indexed and in the a11y tree.
- **Not cloaking** → identical DOM served to everyone; the text is truthful and mirrors the visible data.
- Same pattern already used in this repo (`top-shorts-fallback` sr-only crawler table).

## Note
This is the page's only `<h1>` (now sr-only — allowed, Google reads it). `CompanyProfile` provides the visible title below. If a *visible* H1 is preferred, splitting it (visible H1, sr-only paragraph) is a trivial follow-up.