### PR TITLE
perf(web): align react-query cache to daily (T+4) data cadence

### DIFF
--- a/web/src/@/components/ui/brushChart.tsx
+++ b/web/src/@/components/ui/brushChart.tsx
@@ -398,7 +398,10 @@ const BrushChart = forwardRef<HandleBrushClearAndReset, BrushProps>(
         {tooltipData && (
           <>
             <TooltipWithBounds
-              key={Math.random()}
+              // Stable position-derived key: lets TooltipWithBounds recompute its
+              // bounds when the anchor moves, without unmount/remounting the DOM
+              // node on every render (the old key={Math.random()} did the latter).
+              key={`${Math.round(tooltipLeft)}_${Math.round(tooltipTop)}`}
               top={tooltipTop}
               left={tooltipLeft}
               style={{

--- a/web/src/@/hooks/use-stock-queries.ts
+++ b/web/src/@/hooks/use-stock-queries.ts
@@ -14,6 +14,12 @@ import { getTopShortsData } from "~/app/actions/getTopShorts";
 import { getStock } from "~/app/actions/getStock";
 import type { TimeSeriesData } from "~/gen/stocks/v1alpha1/stocks_pb";
 
+// Short positions (ASIC T+4, refreshed by the daily sync), end-of-day prices,
+// top-shorts MV, and company details all change at most once per trading day.
+// Keep them fresh for 30 minutes so revisiting a stock/widget doesn't refetch
+// data that is identical all day. Intraday quotes keep their own short window.
+const DAILY_STALE = 30 * 60 * 1000;
+
 /**
  * Hook for fetching multiple stock quotes with automatic deduplication
  * Uses sorted, comma-joined codes as cache key for deduplication
@@ -47,7 +53,7 @@ export function useHistoricalData(code: string, period: string) {
     queryKey: queryKeys.market.historical(code, period),
     queryFn: () => getHistoricalData(code, period),
     enabled: !!code && !!period,
-    staleTime: 5 * 60 * 1000, // 5 minutes for historical data
+    staleTime: DAILY_STALE, // daily end-of-day prices
   });
 }
 
@@ -61,7 +67,7 @@ export function useMultipleHistoricalData(codes: string[], period: string) {
       queryKey: queryKeys.market.historical(code, period),
       queryFn: () => getHistoricalData(code, period),
       enabled: !!code && !!period,
-      staleTime: 5 * 60 * 1000,
+      staleTime: DAILY_STALE,
     })),
     combine: (results) => ({
       data: new Map(
@@ -84,7 +90,7 @@ export function useShortTimeSeries(code: string, period: string) {
     queryKey: queryKeys.stock.timeSeries(code, period),
     queryFn: () => fetchStockDataClient(code, period),
     enabled: !!code && !!period,
-    staleTime: 60 * 1000, // 1 minute
+    staleTime: DAILY_STALE, // daily (ASIC T+4)
   });
 }
 
@@ -97,7 +103,7 @@ export function useMultipleShortTimeSeries(codes: string[], period: string) {
       queryKey: queryKeys.stock.timeSeries(code, period),
       queryFn: () => fetchStockDataClient(code, period),
       enabled: !!code && !!period,
-      staleTime: 60 * 1000,
+      staleTime: DAILY_STALE,
     })),
     combine: (results) => ({
       data: new Map(
@@ -120,7 +126,7 @@ export function useStockDetails(code: string) {
     queryKey: queryKeys.stock.details(code),
     queryFn: () => fetchStockDetailsClient(code),
     enabled: !!code,
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: DAILY_STALE, // company details change rarely
   });
 }
 
@@ -134,7 +140,7 @@ export function useTopShorts(period: string, limit: number) {
       const result = await getTopShortsData(period, limit, 0);
       return result?.timeSeries ?? [];
     },
-    staleTime: 60 * 1000, // 1 minute
+    staleTime: DAILY_STALE, // daily (ASIC T+4)
   });
 }
 
@@ -146,7 +152,7 @@ export function useStockShortPosition(code: string) {
     queryKey: queryKeys.shorts.stock(code),
     queryFn: () => getStock(code),
     enabled: !!code,
-    staleTime: 60 * 1000,
+    staleTime: DAILY_STALE,
   });
 }
 
@@ -159,7 +165,7 @@ export function useMultipleStockShortPositions(codes: string[]) {
       queryKey: queryKeys.shorts.stock(code),
       queryFn: () => getStock(code),
       enabled: !!code,
-      staleTime: 60 * 1000,
+      staleTime: DAILY_STALE,
     })),
     combine: (results) => ({
       data: new Map(

--- a/web/src/@/lib/query-client.ts
+++ b/web/src/@/lib/query-client.ts
@@ -63,9 +63,12 @@ function makeQueryClient() {
     defaultOptions: {
       queries: {
         // Stale time of 5 minutes - short position data changes at most once per day
+        // (per-hook overrides in use-stock-queries.ts lengthen this for daily data).
         staleTime: 5 * 60 * 1000,
-        // Garbage collection time of 5 minutes
-        gcTime: 5 * 60 * 1000,
+        // Retention is decoupled from freshness: keep inactive query data for 30
+        // minutes so back/forward navigation and tab switches are instant instead
+        // of refetching from scratch. gcTime is memory retention, NOT freshness.
+        gcTime: 30 * 60 * 1000,
         // Smart retry logic with rate limit awareness
         retry: shouldRetryQuery,
         retryDelay: calculateRetryDelay,


### PR DESCRIPTION
First quick-win from the dashboard/charts performance investigation (the #1 sequenced item — pure config, biggest bang, zero visual risk).

## Problem
The frontend caches data far more aggressively than its real update cadence:
- `gcTime === staleTime === 5min` globally — inactive query data is evicted exactly when it could be reused, so back/forward nav and tab switches refetch from scratch.
- Short-position data is **daily** (ASIC T+4, refreshed by the ~2am sync) yet the hooks marked it stale after **30–60s**, so the rate-limited Cloud Run backend gets hammered for data that's identical all day.

## Change
- **`query-client.ts`**: `gcTime` 5min → **30min** (retention is decoupled from freshness; `staleTime` unchanged).
- **`use-stock-queries.ts`**: short-positions, top-shorts, EOD prices, and company details → **`DAILY_STALE` (30min)** (was 30–60s). Intraday quotes keep their 30s window.
- **`brushChart.tsx`** (legacy `/embed/chart`): `key={Math.random()}` → stable position-derived key (was unmount/remounting the tooltip DOM node every render).

## Impact
Fewer redundant client → Next proxy → Cloud Run RPCs for daily data; instant back/forward navigation; no more tooltip thrash on the embed chart. No visual/behavioural change to fresh-load output.

## Verification
`npx tsc --noEmit` clean; eslint clean (2 pre-existing unrelated warnings).

## Follow-ups (from the same investigation, not in this PR)
HydrationBoundary server-prefetch, batched multi-stock endpoints, edge cache-control on the in-app RPC proxy, splitting the ~764KB react-grid-layout out of the eager dashboard bundle, chart pointer rAF-coalescing + decimation, and the Shorted-specific chart features (short-vs-price divergence shading, days-to-cover squeeze band, director-trade markers).