### PR TITLE
perf(web): code-split react-grid-layout out of the eager /dashboards bundle

### DIFF
--- a/web/src/app/dashboards/page.tsx
+++ b/web/src/app/dashboards/page.tsx
@@ -1,9 +1,28 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
+import dynamic from "next/dynamic";
 import { useSession } from "next-auth/react";
 import { DashboardLayout } from "~/@/components/layouts/dashboard-layout";
-import { DashboardGrid } from "~/@/components/dashboard/dashboard-grid";
+// react-grid-layout + react-resizable (~764KB) live inside DashboardGrid and are
+// useless until the user's dashboards load from the network. Code-split the grid
+// into its own chunk so it never blocks first paint / hydration of the page shell.
+const DashboardGrid = dynamic(
+  () => import("~/@/components/dashboard/dashboard-grid").then((m) => m.DashboardGrid),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="grid grid-cols-12 gap-4">
+        <div className="col-span-12 lg:col-span-5">
+          <Skeleton className="h-[400px] w-full rounded-lg" />
+        </div>
+        <div className="col-span-12 lg:col-span-7">
+          <Skeleton className="h-[400px] w-full rounded-lg" />
+        </div>
+      </div>
+    ),
+  },
+);
 import { WidgetConfigDialog } from "~/@/components/dashboard/widget-config-dialog";
 import { WidgetPicker } from "~/@/components/dashboard/widget-picker";
 import { DashboardSwitcher } from "~/@/components/dashboard/dashboard-switcher";


### PR DESCRIPTION
Second item from the dashboard/charts performance investigation — the single biggest `/dashboards` bundle win.

## Problem
`dashboard-grid.tsx` statically imports `react-grid-layout` + `react-resizable` + 3 CSS files (**~764KB**) at module scope, and the fully-`"use client"` `/dashboards` page statically imports `DashboardGrid`. So the whole grid library is in the eager client bundle and blocks hydration / first interaction — even though the grid is unusable until the user's saved dashboards load from the network.

## Change
Load `DashboardGrid` via `next/dynamic({ ssr: false })` with a skeleton fallback, so the grid and its heavy deps split into a separate async chunk fetched on demand. The page already shows a skeleton while dashboards load, so there's no UX regression.

## Verification
`npx tsc --noEmit` clean. `DashboardGrid` is only used on this page.

## Next (same investigation)
SSR data-prefetch for the homepage top-shorts (needs a running app to verify RSC serialization of protobuf `bigint` fields — `TopShorts` already accepts `initialShortsData`, the homepage just never passes the data it already fetches for the crawler fallback), IntersectionObserver-gating of widget JS-chunk imports, and wiring the existing `perf-benchmark.mjs` into CI.