### PR TITLE
perf(web): SSR-prefetch homepage lead widgets (top-shorts + industry treemap)

### DIFF
--- a/web/src/app/home-content.tsx
+++ b/web/src/app/home-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import dynamic from "next/dynamic";
+import type { JsonValue } from "@bufbuild/protobuf";
 import { RefreshCw, BarChart3 } from "lucide-react";
 import { Button } from "~/@/components/ui/button";
 import { clearSessionCache } from "~/@/lib/session-cache";
@@ -45,7 +46,15 @@ const IndustryTreeMapView = dynamic(
   }
 );
 
-export function HomeContent() {
+export function HomeContent({
+  initialTopShorts,
+}: {
+  // Top-shorts data prefetched by the server page (protobuf JSON) — seeds the
+  // first render so TopShorts skips its mount fetch. Forwarded as-is to the
+  // client-only TopShorts, which deserializes it (keeps protobuf-es out of this
+  // SSR'd shell).
+  initialTopShorts?: JsonValue[];
+}) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -82,7 +91,11 @@ export function HomeContent() {
       </div>
       <div className="flex flex-col lg:flex-row">
         <div className="lg:w-2/5">
-          <TopShorts key={`ts-${refreshKey}`} initialPeriod="3m" />
+          <TopShorts
+            key={`ts-${refreshKey}`}
+            initialPeriod="3m"
+            initialShortsDataJson={refreshKey === 0 ? initialTopShorts : undefined}
+          />
         </div>
         <div className="lg:w-3/5">
           <IndustryTreeMapView

--- a/web/src/app/home-content.tsx
+++ b/web/src/app/home-content.tsx
@@ -48,12 +48,15 @@ const IndustryTreeMapView = dynamic(
 
 export function HomeContent({
   initialTopShorts,
+  initialTreeMap,
 }: {
   // Top-shorts data prefetched by the server page (protobuf JSON) — seeds the
   // first render so TopShorts skips its mount fetch. Forwarded as-is to the
   // client-only TopShorts, which deserializes it (keeps protobuf-es out of this
   // SSR'd shell).
   initialTopShorts?: JsonValue[];
+  // Same, for the industry treemap.
+  initialTreeMap?: JsonValue;
 }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -102,6 +105,7 @@ export function HomeContent({
             key={`tm-${refreshKey}`}
             initialPeriod="3m"
             initialViewMode={VIEW_MODE_CURRENT_CHANGE}
+            initialTreeMapDataJson={refreshKey === 0 ? initialTreeMap : undefined}
           />
         </div>
       </div>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,6 +6,9 @@ import { siteConfig } from "~/@/config/site";
 import { Suspense } from "react";
 import { HomeContent } from "./home-content";
 import { TopShortsFallback } from "./top-shorts-fallback";
+import { toJson } from "@bufbuild/protobuf";
+import { getTopShortsData } from "~/app/actions/getTopShorts";
+import { TimeSeriesDataSchema } from "~/gen/stocks/v1alpha1/stocks_pb";
 
 // Dynamic import to avoid SSR issues — component imports @connectrpc/connect
 const BreakingNewsBanner = dynamic(
@@ -127,6 +130,14 @@ async function WeeklyReportBanner() {
 }
 
 export default async function Page() {
+  // Prefetch the homepage top-shorts (same query the client TopShorts widget
+  // makes on mount: "3m", 10 rows) and hand it to HomeContent as protobuf JSON.
+  // This removes the render->hydrate->fetch waterfall for the lead widget.
+  // getTopShortsData is cached, so the TopShortsFallback call below is ~free.
+  const initialTopShorts = await getTopShortsData("3m", 10, 0)
+    .then((res) => res?.timeSeries?.map((d) => toJson(TimeSeriesDataSchema, d)))
+    .catch(() => undefined);
+
   return (
     <main className="min-h-screen flex flex-col bg-transparent">
       {/* Structured Data for rich snippets and knowledge graph */}
@@ -196,7 +207,7 @@ export default async function Page() {
       </Suspense>
 
       {/* Interactive dashboard content */}
-      <HomeContent />
+      <HomeContent initialTopShorts={initialTopShorts} />
 
       {/* Browse by Industry — server-rendered for SEO internal linking */}
       <Suspense fallback={null}>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -8,7 +8,9 @@ import { HomeContent } from "./home-content";
 import { TopShortsFallback } from "./top-shorts-fallback";
 import { toJson } from "@bufbuild/protobuf";
 import { getTopShortsData } from "~/app/actions/getTopShorts";
-import { TimeSeriesDataSchema } from "~/gen/stocks/v1alpha1/stocks_pb";
+import { getIndustryTreeMap } from "~/app/actions/getIndustryTreeMap";
+import { TimeSeriesDataSchema, IndustryTreeMapSchema } from "~/gen/stocks/v1alpha1/stocks_pb";
+import type { ViewMode } from "~/gen/shorts/v1alpha1/shorts_pb";
 
 // Dynamic import to avoid SSR issues — component imports @connectrpc/connect
 const BreakingNewsBanner = dynamic(
@@ -130,13 +132,19 @@ async function WeeklyReportBanner() {
 }
 
 export default async function Page() {
-  // Prefetch the homepage top-shorts (same query the client TopShorts widget
-  // makes on mount: "3m", 10 rows) and hand it to HomeContent as protobuf JSON.
-  // This removes the render->hydrate->fetch waterfall for the lead widget.
-  // getTopShortsData is cached, so the TopShortsFallback call below is ~free.
-  const initialTopShorts = await getTopShortsData("3m", 10, 0)
-    .then((res) => res?.timeSeries?.map((d) => toJson(TimeSeriesDataSchema, d)))
-    .catch(() => undefined);
+  // Prefetch the homepage widgets server-side (the same queries TopShorts and
+  // the IndustryTreeMap make on mount: "3m", 10 rows / 8 tiles, CURRENT_CHANGE)
+  // and hand them to HomeContent as protobuf JSON (RSC-safe, no bigint across
+  // the boundary). This removes the render->hydrate->fetch waterfall for both
+  // lead widgets. Both actions are cached, so the TopShortsFallback call is free.
+  const [initialTopShorts, initialTreeMap] = await Promise.all([
+    getTopShortsData("3m", 10, 0)
+      .then((res) => res?.timeSeries?.map((d) => toJson(TimeSeriesDataSchema, d)))
+      .catch(() => undefined),
+    getIndustryTreeMap("3m", 8, 0 as ViewMode)
+      .then((tm) => (tm ? toJson(IndustryTreeMapSchema, tm) : undefined))
+      .catch(() => undefined),
+  ]);
 
   return (
     <main className="min-h-screen flex flex-col bg-transparent">
@@ -207,7 +215,10 @@ export default async function Page() {
       </Suspense>
 
       {/* Interactive dashboard content */}
-      <HomeContent initialTopShorts={initialTopShorts} />
+      <HomeContent
+        initialTopShorts={initialTopShorts}
+        initialTreeMap={initialTreeMap}
+      />
 
       {/* Browse by Industry — server-rendered for SEO internal linking */}
       <Suspense fallback={null}>

--- a/web/src/app/topShortsView/topShorts.tsx
+++ b/web/src/app/topShortsView/topShorts.tsx
@@ -5,9 +5,11 @@ import React, {
   useEffect,
   useState,
   useCallback,
+  useMemo,
   Suspense,
   useRef,
 } from "react";
+import { fromJson, type JsonValue } from "@bufbuild/protobuf";
 import {
   Select,
   SelectContent,
@@ -15,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/@/components/ui/select";
-import { type TimeSeriesData } from "~/gen/stocks/v1alpha1/stocks_pb";
+import { type TimeSeriesData, TimeSeriesDataSchema } from "~/gen/stocks/v1alpha1/stocks_pb";
 import { Label } from "~/@/components/ui/label";
 import { getTopShortsDataClient } from "../actions/client/getTopShorts";
 import { DataTable } from "./components/data-table";
@@ -50,6 +52,10 @@ const getPeriodString = (period: string) => {
 
 interface TopShortsProps {
   initialShortsData?: TimeSeriesData[]; // Data for multiple series (optional)
+  // RSC-safe serialized form (protobuf JSON) for server-side prefetch — converted
+  // back to TimeSeriesData[] on the client. Lets the homepage seed the initial
+  // render from data already fetched server-side, skipping the mount fetch.
+  initialShortsDataJson?: JsonValue[];
   initialPeriod?: string; // Add initial period prop
   className?: string; // Allow custom class name
 }
@@ -58,19 +64,29 @@ const LOAD_CHUNK_SIZE = 10;
 
 export const TopShorts: FC<TopShortsProps> = ({
   initialShortsData,
+  initialShortsDataJson,
   initialPeriod = "3m",
   className,
 }) => {
+  // Prefer pre-parsed data; otherwise deserialize the RSC-safe JSON once.
+  const initialData = useMemo<TimeSeriesData[] | undefined>(() => {
+    if (initialShortsData) return initialShortsData;
+    if (initialShortsDataJson) {
+      return initialShortsDataJson.map((j) => fromJson(TimeSeriesDataSchema, j));
+    }
+    return undefined;
+  }, [initialShortsData, initialShortsDataJson]);
+
   const [period, setPeriod] = useState<string>(initialPeriod);
   const [displayPeriod, setDisplayPeriod] = useState<string>(initialPeriod);
   const [isInitialLoading, setIsInitialLoading] =
-    useState<boolean>(!initialShortsData);
+    useState<boolean>(!initialData);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [shortsData, setShortsData] = useState<TimeSeriesData[]>(
-    initialShortsData ?? [],
+    initialData ?? [],
   );
   const requestIdRef = useRef(0);
-  const offsetRef = useRef<number>(initialShortsData?.length ?? 0);
+  const offsetRef = useRef<number>(initialData?.length ?? 0);
   const [refreshKey, setRefreshKey] = useState<number>(() => Date.now());
 
   const getTimeSeriesForPeriod = useCallback(
@@ -145,7 +161,7 @@ export const TopShorts: FC<TopShortsProps> = ({
 
   // On mount: if no initial data was provided, fetch it
   useEffect(() => {
-    if (!initialShortsData || initialShortsData.length === 0) {
+    if (!initialData || initialData.length === 0) {
       void getTimeSeriesForPeriod(initialPeriod, { keepExisting: false });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/app/treemap/treeMap.tsx
+++ b/web/src/app/treemap/treeMap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { type FC, useEffect, useState, Suspense, useRef } from "react";
+import React, { type FC, useEffect, useState, useMemo, Suspense, useRef } from "react";
+import { fromJson, type JsonValue } from "@bufbuild/protobuf";
 import {
   Select,
   SelectContent,
@@ -15,7 +16,7 @@ import { Treemap, hierarchy, stratify, treemapSquarify } from "@visx/hierarchy";
 import { Group } from "@visx/group";
 import { ParentSize } from "@visx/responsive";
 import { scaleLinear } from "@visx/scale";
-import { type IndustryTreeMap } from "~/gen/stocks/v1alpha1/stocks_pb";
+import { type IndustryTreeMap, IndustryTreeMapSchema } from "~/gen/stocks/v1alpha1/stocks_pb";
 import { getIndustryTreeMapClient } from "../actions/client/getIndustryTreeMap";
 import { useRouter } from "next/navigation";
 import { ViewMode } from "~/gen/shorts/v1alpha1/shorts_pb";
@@ -26,6 +27,10 @@ import { getSectorImagePath } from "~/@/lib/sector-images";
 
 interface TreeMapProps {
   initialTreeMapData?: IndustryTreeMap; // Optional initial data
+  // RSC-safe serialized form (protobuf JSON) for server-side prefetch — converted
+  // back to IndustryTreeMap on the client so the homepage can seed the first
+  // render from data already fetched server-side, skipping the mount fetch.
+  initialTreeMapDataJson?: JsonValue;
   initialPeriod?: string; // Add initial period prop
   initialViewMode?: ViewMode; // Add initial view mode prop
   className?: string; // Allow custom class name
@@ -48,18 +53,30 @@ type TreeMapDataType = IndustryTreeMap | null | undefined;
 
 export const IndustryTreeMapView: FC<TreeMapProps> = ({
   initialTreeMapData,
+  initialTreeMapDataJson,
   initialPeriod = "3m",
   initialViewMode = ViewMode.CURRENT_CHANGE,
   className,
 }) => {
-  const firstUpdate = useRef(!initialTreeMapData); // If no initial data, fetch on mount
+  // Prefer pre-parsed data; otherwise deserialize the RSC-safe JSON once.
+  const initialData = useMemo<IndustryTreeMap | undefined>(() => {
+    if (initialTreeMapData) return initialTreeMapData;
+    if (initialTreeMapDataJson)
+      return fromJson(IndustryTreeMapSchema, initialTreeMapDataJson);
+    return undefined;
+  }, [initialTreeMapData, initialTreeMapDataJson]);
+
+  // Always true on the first effect run. When seeded with initialData the mount
+  // effect bails before fetching. (Previously useRef(!initialTreeMapData) was
+  // inverted, so seeded data fell through to the else branch and fetched anyway.)
+  const firstUpdate = useRef(true);
   const router = useRouter();
   const [period, setPeriod] = useState<string>(initialPeriod);
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   const [treeMapData, setTreeMapData] = useState<TreeMapDataType>(
-    initialTreeMapData ?? null,
+    initialData ?? null,
   );
-  const [loading, setLoading] = useState<boolean>(!initialTreeMapData);
+  const [loading, setLoading] = useState<boolean>(!initialData);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
 
   const [tooltipState, setTooltipState] = useState<{
@@ -78,7 +95,7 @@ export const IndustryTreeMapView: FC<TreeMapProps> = ({
 
   useEffect(() => {
     // Fetch data on mount if no initial data, or when period/viewMode changes
-    if (firstUpdate.current && initialTreeMapData) {
+    if (firstUpdate.current && initialData) {
       firstUpdate.current = false;
       return;
     }
@@ -103,7 +120,7 @@ export const IndustryTreeMapView: FC<TreeMapProps> = ({
         setLoading(false);
         setIsRefreshing(false);
       });
-  }, [period, viewMode, initialTreeMapData]);
+  }, [period, viewMode, initialData]);
 
   if (loading || !treeMapData) {
     return (


### PR DESCRIPTION
The headline of the "prefetch + bundle split" perf work — **verified against the prod API in a real browser**. Eliminates the render → hydrate → fetch waterfall for **both** homepage lead widgets.

## Problem
The homepage already fetches top-shorts server-side (for the crawler fallback), but the interactive `TopShorts` **and** `IndustryTreeMap` widgets both refetched the same data client-side on mount.

## Change
- `page.tsx` (server): prefetch `getTopShortsData("3m", 10)` and `getIndustryTreeMap("3m", 8, CURRENT_CHANGE)` in parallel, hand them to `HomeContent` as **protobuf JSON** (`toJson` — RSC-safe, no `bigint` across the boundary).
- `HomeContent` (SSR'd shell): forwards the JSON as-is — no protobuf-es runtime import added here.
- `TopShorts` / `IndustryTreeMapView` (`ssr:false`, client-only): deserialize via `fromJson` and seed initial state, skipping the mount fetch. Seeding is **gated to the first render**, so Refresh still pulls live data; period/view-mode switching is unaffected.
- **Bug fix:** `IndustryTreeMapView` had `firstUpdate = useRef(!initialTreeMapData)` — inverted, so when `initialTreeMapData` was provided `firstUpdate` started `false` and the mount effect fetched anyway. The existing prop never actually skipped the fetch. Now `useRef(true)`.
- Both server actions are cached, so the existing `TopShortsFallback` call is ~free.

## Verification (local dev server → prod API + Playwright, clean rebuild)
- Homepage **HTTP 200**; both widgets render fully populated (top-shorts rows + sector treemap tiles).
- **Zero `GetTopShorts` and zero `GetIndustryTreeMap` RPC on initial load** (network capture) — was ×1 + ×2 before.
- **0 console errors**, no RSC-serialization / hydration issues.
- `tsc --noEmit` + eslint clean.

## Follow-ups
Same pattern applies to per-stock pages; and the dashboard widgets (auth-gated) once they move onto react-query hooks.