### PR TITLE
feat(charts): short-vs-price divergence shading (Shorted-only chart overlay)

### DIFF
--- a/web/src/@/components/charts/StockChart.stories.tsx
+++ b/web/src/@/components/charts/StockChart.stories.tsx
@@ -98,6 +98,35 @@ export const DualAxis: Story = {
   },
 };
 
+// Short-vs-price divergence shading: bearish (red) where shorts build into a
+// rally, bullish (green) where shorts cover into a slide. Explicit regions here
+// for a deterministic visual; the computation is unit-tested in divergence.test.
+export const WithDivergenceRegions: Story = {
+  tags: ["no-visual"], // interaction-only until a visual baseline is generated
+  args: {
+    series: [priceSeries("PLS", "1y"), shortSeries("PLS", "1y")],
+    leftAxis: { side: "left", format: priceFmt },
+    rightAxis: { side: "right", format: shortFmt },
+    regions: (() => {
+      const price = priceParts("PLS", "1y").price;
+      const t0 = price[0]?.t ?? 0;
+      const t1 = price[price.length - 1]?.t ?? 0;
+      const span = t1 - t0;
+      return [
+        { start: t0 + span * 0.08, end: t0 + span * 0.34, tone: "bearish" as const, label: "Shorts building into price strength" },
+        { start: t0 + span * 0.55, end: t0 + span * 0.82, tone: "bullish" as const, label: "Shorts covering into price weakness" },
+      ];
+    })(),
+    height: 400,
+  },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(capture(canvasElement)).toBeTruthy());
+    // One bearish (red) + one bullish (green) band rendered under the series.
+    expect(canvasElement.querySelector('rect[fill="#ef4444"]')).toBeTruthy();
+    expect(canvasElement.querySelector('rect[fill="#22c55e"]')).toBeTruthy();
+  },
+};
+
 // Regression: the tooltip must follow the cursor vertically (not sit at a fixed
 // top anchor). A fixed anchor detaches the tooltip from the hovered point and,
 // on scrolled/sticky-header pages, floats it above the chart entirely.

--- a/web/src/@/components/charts/StockChart.tsx
+++ b/web/src/@/components/charts/StockChart.tsx
@@ -70,6 +70,7 @@ function StockChartInner({
   volume,
   indicators = [],
   oscillators = [],
+  regions = [],
   leftAxis,
   rightAxis,
   viewMode = "absolute",
@@ -433,6 +434,28 @@ function StockChartInner({
       <svg width={width} height={height} data-points={renderSeries[0]?.points.length ?? 0}>
         <Group left={margin.left} top={margin.top}>
           <Grid yScale={leftScale} width={innerW} />
+          {/* Divergence bands sit UNDER the data: short-vs-price regimes. */}
+          {regions.map((r, i) => {
+            const xa = dateScale(r.start);
+            const xb = dateScale(r.end);
+            const x = Math.max(0, Math.min(xa, xb));
+            const cw = Math.min(Math.max(xa, xb), innerW) - x;
+            if (cw <= 0) return null;
+            return (
+              <rect
+                key={`region-${i}`}
+                x={x}
+                y={0}
+                width={cw}
+                height={mainH}
+                fill={r.tone === "bearish" ? "#ef4444" : "#22c55e"}
+                fillOpacity={0.1}
+                pointerEvents="none"
+              >
+                {r.label ? <title>{r.label}</title> : null}
+              </rect>
+            );
+          })}
           {showVolume && (
             <VolumePath data={decVolume} xScale={dateScale} yScale={volumeScale} />
           )}

--- a/web/src/@/components/charts/StockChartPanel.tsx
+++ b/web/src/@/components/charts/StockChartPanel.tsx
@@ -6,6 +6,7 @@ import { StockChart } from "./StockChart";
 import { seriesColor } from "./chart-theme";
 import { calculateSMA } from "./indicators";
 import { useStockChartData } from "./use-stock-chart-data";
+import { computeDivergenceRegions } from "./divergence";
 import type { AxisSpec, ChartSeriesSpec, SeriesIndicator } from "./types";
 
 const PERIODS = ["1m", "3m", "6m", "1y", "2y", "max"] as const;
@@ -68,9 +69,21 @@ export function StockChartPanel({
   const [period, setPeriod] = useState<Period>(defaultPeriod);
   const [view, setView] = useState<ViewId>(defaultView);
   const [showMA, setShowMA] = useState(false);
+  const [showDivergence, setShowDivergence] = useState(false);
 
   const { short, price, volume, correlation, anyLoading, isError } =
     useStockChartData(stockCode, period);
+
+  // Shorted-only overlay (combined view): shade spans where short interest and
+  // price trend the SAME way — shorts building into a rally (bearish) or
+  // covering into a slide (bullish). Only computed when toggled on.
+  const regions = useMemo(
+    () =>
+      showDivergence && view === "combined" && short.length && price.length
+        ? computeDivergenceRegions(price, short)
+        : [],
+    [showDivergence, view, short, price],
+  );
 
   const priceSeries = useMemo<ChartSeriesSpec>(
     () => ({
@@ -192,6 +205,31 @@ export function StockChartPanel({
               SMA 20
             </button>
           )}
+          {view === "combined" && (
+            <button
+              type="button"
+              onClick={() => setShowDivergence((v) => !v)}
+              aria-pressed={showDivergence}
+              title="Shade spans where short interest and price trend the same way — shorts building into a rally, or covering into a slide"
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                showDivergence
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
+              )}
+            >
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{
+                  background: showDivergence
+                    ? "linear-gradient(90deg,#ef4444 50%,#22c55e 50%)"
+                    : "transparent",
+                  border: "1px solid #94a3b8",
+                }}
+              />
+              Divergence
+            </button>
+          )}
           <div
             className="flex items-center gap-0.5 rounded-md border p-0.5"
             role="group"
@@ -206,6 +244,26 @@ export function StockChartPanel({
         </div>
       </div>
 
+      {/* Divergence legend (only when on and regions were found) */}
+      {showDivergence && view === "combined" && regions.length > 0 && (
+        <div className="-mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="h-2.5 w-2.5 rounded-sm"
+              style={{ background: "#ef444433", border: "1px solid #ef4444" }}
+            />
+            Shorts building into price strength
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="h-2.5 w-2.5 rounded-sm"
+              style={{ background: "#22c55e33", border: "1px solid #22c55e" }}
+            />
+            Shorts covering into price weakness
+          </span>
+        </div>
+      )}
+
       {/* Chart */}
       {isError ? (
         <div
@@ -219,6 +277,7 @@ export function StockChartPanel({
           series={series}
           volume={vol}
           indicators={indicators}
+          regions={regions}
           leftAxis={leftAxis}
           rightAxis={rightAxis}
           height={height}

--- a/web/src/@/components/charts/StockPriceShortChart.tsx
+++ b/web/src/@/components/charts/StockPriceShortChart.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { StockChart } from "./StockChart";
 import { seriesColor } from "./chart-theme";
 import { calculateSMA } from "./indicators";
+import { computeDivergenceRegions } from "./divergence";
 import { useStockChartData } from "./use-stock-chart-data";
 import type { ChartSeriesSpec, SeriesIndicator } from "./types";
 
@@ -69,9 +70,21 @@ export function StockPriceShortChart({
   const [showShort, setShowShort] = useState(true);
   const [showVolume, setShowVolume] = useState(true);
   const [showMA, setShowMA] = useState(false);
+  const [showDivergence, setShowDivergence] = useState(false);
 
   const { short, price, volume, correlation, anyLoading, isError } =
     useStockChartData(stockCode, period);
+
+  // Shorted-only overlay: shade spans where short interest and price trend the
+  // SAME way — shorts building into a rally (bearish) or covering into a slide
+  // (bullish). Needs both legs; only computed when toggled on.
+  const regions = useMemo(
+    () =>
+      showDivergence && short.length && price.length
+        ? computeDivergenceRegions(price, short)
+        : [],
+    [showDivergence, short, price],
+  );
 
   const series = useMemo(() => {
     const arr: ChartSeriesSpec[] = [];
@@ -134,6 +147,9 @@ export function StockPriceShortChart({
           <Toggle active={showMA} onClick={() => setShowMA((v) => !v)} color="#f59e0b">
             SMA 20
           </Toggle>
+          <Toggle active={showDivergence} onClick={() => setShowDivergence((v) => !v)}>
+            Divergence
+          </Toggle>
         </div>
         <div className="flex items-center gap-2">
           {correlation != null && showPrice && showShort && (
@@ -166,6 +182,26 @@ export function StockPriceShortChart({
         </div>
       </div>
 
+      {/* Divergence legend (only when the overlay is on and found something) */}
+      {showDivergence && regions.length > 0 && (
+        <div className="-mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="h-2.5 w-2.5 rounded-sm"
+              style={{ background: "#ef444433", border: "1px solid #ef4444" }}
+            />
+            Shorts building into price strength
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="h-2.5 w-2.5 rounded-sm"
+              style={{ background: "#22c55e33", border: "1px solid #22c55e" }}
+            />
+            Shorts covering into price weakness
+          </span>
+        </div>
+      )}
+
       {/* Chart */}
       {isError ? (
         <div
@@ -179,6 +215,7 @@ export function StockPriceShortChart({
           series={series}
           volume={showVolume ? volume : undefined}
           indicators={indicators}
+          regions={regions}
           leftAxis={{ side: "left", format: priceFmt }}
           rightAxis={{ side: "right", format: shortFmt }}
           height={height}

--- a/web/src/@/components/charts/__tests__/divergence.test.ts
+++ b/web/src/@/components/charts/__tests__/divergence.test.ts
@@ -1,0 +1,45 @@
+import { computeDivergenceRegions } from "../divergence";
+
+const DAY = 86_400_000;
+const ramp = (n: number, step: number) =>
+  Array.from({ length: n }, (_, i) => ({ t: i * DAY, v: 10 + i * step }));
+
+describe("computeDivergenceRegions", () => {
+  it("flags a bearish span when short and price both rise", () => {
+    const regions = computeDivergenceRegions(ramp(40, 1), ramp(40, 0.1));
+    expect(regions.length).toBeGreaterThan(0);
+    expect(regions.every((r) => r.tone === "bearish")).toBe(true);
+  });
+
+  it("flags a bullish span when short and price both fall", () => {
+    const regions = computeDivergenceRegions(ramp(40, -1), ramp(40, -0.1));
+    expect(regions.length).toBeGreaterThan(0);
+    expect(regions.every((r) => r.tone === "bullish")).toBe(true);
+  });
+
+  it("flags nothing for the normal inverse relationship (short up, price down)", () => {
+    // price falling, short rising — the expected anti-correlation, not divergence
+    expect(computeDivergenceRegions(ramp(40, -1), ramp(40, 0.1))).toEqual([]);
+  });
+
+  it("returns [] for too-few points", () => {
+    expect(computeDivergenceRegions([], [])).toEqual([]);
+    expect(computeDivergenceRegions(ramp(2, 1), ramp(2, 0.1))).toEqual([]);
+  });
+
+  it("keeps region times within the short-series range", () => {
+    const short = ramp(40, 0.1);
+    const [r] = computeDivergenceRegions(ramp(40, 1), short);
+    expect(r!.start).toBeGreaterThanOrEqual(short[0]!.t);
+    expect(r!.end).toBeLessThanOrEqual(short[short.length - 1]!.t);
+  });
+
+  it("drops runs shorter than minRun", () => {
+    // 40 points, but force a tiny window + large minRun so no run qualifies
+    const regions = computeDivergenceRegions(ramp(40, 1), ramp(40, 0.1), {
+      window: 3,
+      minRun: 1000,
+    });
+    expect(regions).toEqual([]);
+  });
+});

--- a/web/src/@/components/charts/divergence.ts
+++ b/web/src/@/components/charts/divergence.ts
@@ -1,0 +1,103 @@
+import type { ChartPoint, ChartRegion } from "./types";
+
+/** Nearest value in a t-ascending series (binary search). */
+function valueAt(points: ChartPoint[], t: number): number | null {
+  const n = points.length;
+  if (!n) return null;
+  if (t <= points[0]!.t) return points[0]!.v;
+  if (t >= points[n - 1]!.t) return points[n - 1]!.v;
+  let lo = 0;
+  let hi = n - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const mt = points[mid]!.t;
+    if (mt === t) return points[mid]!.v;
+    if (mt < t) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  // lo = first point after t, hi = last point before t — pick the nearer.
+  const a = points[hi]!;
+  const b = points[lo]!;
+  return t - a.t <= b.t - t ? a.v : b.v;
+}
+
+export interface DivergenceOptions {
+  /** Trend window in short-series points (default: adaptive, ~length/12, 5..15). */
+  window?: number;
+  /** Drop regions spanning fewer than this many short points (default 3). */
+  minRun?: number;
+}
+
+type Tone = "bearish" | "bullish" | null;
+
+/**
+ * Shade spans where short interest and price trend in the SAME direction — the
+ * counterintuitive, Shorted-specific regimes a generic charting library can't
+ * draw because it doesn't co-locate daily short interest with price:
+ *  - "bearish": short ↑ while price ↑  (bears pressing into a rally).
+ *  - "bullish": short ↓ while price ↓  (bears covering into a decline).
+ * Spans where they move inversely (the normal relationship) or either leg is
+ * flat are left unshaded. Slopes are sign-of-delta over a trailing window.
+ */
+export function computeDivergenceRegions(
+  price: ChartPoint[],
+  short: ChartPoint[],
+  opts: DivergenceOptions = {},
+): ChartRegion[] {
+  const w = Math.max(
+    3,
+    opts.window ?? Math.min(15, Math.max(5, Math.round(short.length / 12))),
+  );
+  const minRun = Math.max(1, opts.minRun ?? 3);
+  if (short.length < w + 1 || price.length < 2) return [];
+
+  const toneAt: { t: number; tone: Tone }[] = [];
+  for (let i = w; i < short.length; i++) {
+    const s0 = short[i - w]!;
+    const s1 = short[i]!;
+    const dShort = s1.v - s0.v;
+    const p0 = valueAt(price, s0.t);
+    const p1 = valueAt(price, s1.t);
+    if (p0 == null || p1 == null) {
+      toneAt.push({ t: s1.t, tone: null });
+      continue;
+    }
+    const dPrice = p1 - p0;
+    let tone: Tone = null;
+    if (dShort > 0 && dPrice > 0) tone = "bearish";
+    else if (dShort < 0 && dPrice < 0) tone = "bullish";
+    toneAt.push({ t: s1.t, tone });
+  }
+
+  const regions: ChartRegion[] = [];
+  let run: { tone: "bearish" | "bullish"; start: number; end: number; n: number } | null = null;
+  const flush = () => {
+    if (run && run.n >= minRun) {
+      regions.push({
+        start: run.start,
+        end: run.end,
+        tone: run.tone,
+        label:
+          run.tone === "bearish"
+            ? "Shorts building into price strength"
+            : "Shorts covering into price weakness",
+      });
+    }
+    run = null;
+  };
+  for (const { t, tone } of toneAt) {
+    if (tone == null) {
+      flush();
+      continue;
+    }
+    if (run && run.tone === tone) {
+      run.end = t;
+      run.n += 1;
+    } else {
+      flush();
+      run = { tone, start: t, end: t, n: 1 };
+    }
+  }
+  flush();
+  return regions;
+}

--- a/web/src/@/components/charts/types.ts
+++ b/web/src/@/components/charts/types.ts
@@ -33,6 +33,18 @@ export interface ChartSeriesSpec {
   measureUnit?: string;
 }
 
+/**
+ * A shaded time-span drawn UNDER the series (full plot height). Generic on
+ * purpose — the caller decides what a region means (e.g. short-vs-price
+ * divergence) and the core just paints it by `tone`.
+ */
+export interface ChartRegion {
+  start: number; // epoch ms (inclusive)
+  end: number; // epoch ms (inclusive)
+  tone: "bearish" | "bullish";
+  label?: string;
+}
+
 export interface AxisSpec {
   side: "left" | "right";
   label?: string;
@@ -75,6 +87,8 @@ export interface StockChartProps {
   volume?: ChartPoint[]; // single-path; hidden in compact / on mobile
   indicators?: SeriesIndicator[];
   oscillators?: OscillatorSpec[];
+  /** Shaded time-spans drawn under the series (e.g. short-vs-price divergence). */
+  regions?: ChartRegion[];
   leftAxis?: AxisSpec;
   rightAxis?: AxisSpec;
   viewMode?: "absolute" | "normalized"; // default "absolute"


### PR DESCRIPTION
First of the "cool finance features" — a chart overlay no generic charting library can draw, because Shorted is the only one that co-locates **daily short interest with price**.

## What
Shades date spans where short interest and price trend the **same** way (the counterintuitive regimes — normally they're anti-correlated):
- 🔴 **bearish**: shorts ↑ into a rally (bears pressing into strength)
- 🟢 **bullish**: shorts ↓ into a slide (bears covering into weakness)

![divergence](https://github.com/castlemilk/shorted.com.au/assets/divergence-demo) <!-- screenshot in PR thread -->

## How
- **StockChart core** gains a generic, opt-in `regions` prop (`ChartRegion[]`) that paints toned bands under the series — the core stays generic, the *meaning* lives in the caller.
- **`divergence.ts`** computes the regimes: sign-of-delta over an adaptive trailing window, runs coalesced, short runs dropped.
- Wired into **`StockChartPanel`** (the per-stock `/shorts/[code]` chart) and **`StockPriceShortChart`** as a **"Divergence"** toggle (combined view) with a red/green legend.

## Verification
- **6 unit tests** (`divergence.test.ts`) — bearish/bullish/inverse/edge cases.
- **Storybook interaction test** asserts both band rects (`#ef4444` + `#22c55e`) render in the live SVG.
- **Visual confirmed** via screenshot on a real PLS chart (red band over a rally, green band over a slide).
- `tsc --noEmit` + eslint clean. New story tagged `no-visual` (no baseline yet).

## Follow-ups (same Shorted-feature track)
Days-to-cover squeeze overlay, director-trade markers on the price line, candlesticks (OHLC already parsed), log price axis.