### PR TITLE
test(shorts): HNSW-index regression guard for GetRelatedNews

### DIFF
--- a/services/shorts/internal/store/shorts/postgres_embeddings.go
+++ b/services/shorts/internal/store/shorts/postgres_embeddings.go
@@ -9,6 +9,23 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// relatedNewsANNQuery is the cosine-ANN query behind GetRelatedNews. The anchor
+// embedding is passed as the $1::vector LITERAL ($2 = anchor id to exclude, $3 =
+// limit) so the planner can use the pgvector HNSW index (idx_embeddings_hnsw) —
+// a correlated CROSS JOIN / subquery forces an exact full-scan KNN that times out
+// at scale. Kept as a package constant so the integration test EXPLAINs the exact
+// query and asserts the index is used.
+const relatedNewsANNQuery = `
+	SELECT n.id, n.stock_code, n.source, n.headline, n.url, n.published_at,
+	       n.sentiment, n.relevance_score, n.is_price_sensitive, n.summary, n.tags, n.image_url
+	FROM embeddings e
+	JOIN news_articles n ON n.id = e.object_id::uuid
+	WHERE e.object_type = 'news_article'
+	  AND e.object_id <> $2
+	  AND (n.cluster_id IS NULL OR n.cluster_is_primary = TRUE)
+	ORDER BY e.embedding <=> $1::vector
+	LIMIT $3`
+
 // GetRelatedNews returns news articles semantically nearest to an anchor article,
 // ranked by cosine distance over the embeddings table.
 //
@@ -69,18 +86,7 @@ func (s *postgresStore) GetRelatedNews(stockCode, articleID string, limit int32)
 		}
 	}
 
-	query := `
-		SELECT n.id, n.stock_code, n.source, n.headline, n.url, n.published_at,
-		       n.sentiment, n.relevance_score, n.is_price_sensitive, n.summary, n.tags, n.image_url
-		FROM embeddings e
-		JOIN news_articles n ON n.id = e.object_id::uuid
-		WHERE e.object_type = 'news_article'
-		  AND e.object_id <> $2
-		  AND (n.cluster_id IS NULL OR n.cluster_is_primary = TRUE)
-		ORDER BY e.embedding <=> $1::vector
-		LIMIT $3`
-
-	rows, err := s.db.Query(ctx, query, anchorEmbedding, articleID, limit)
+	rows, err := s.db.Query(ctx, relatedNewsANNQuery, anchorEmbedding, articleID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query related news: %w", err)
 	}

--- a/services/shorts/internal/store/shorts/postgres_embeddings_integration_test.go
+++ b/services/shorts/internal/store/shorts/postgres_embeddings_integration_test.go
@@ -5,6 +5,8 @@ package shorts
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,7 +68,8 @@ func startPgvector(t *testing.T) (*pgxpool.Pool, func()) {
 			embedding vector(3) NOT NULL,
 			model TEXT NOT NULL,
 			UNIQUE (object_type, object_id, chunk_idx)
-		);`)
+		);
+		CREATE INDEX idx_embeddings_hnsw ON embeddings USING hnsw (embedding vector_cosine_ops);`)
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -138,4 +141,61 @@ func TestGetRelatedNews_AutoResolvesAnchor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1, "anchor auto-resolved to the latest article and excluded from results")
 	require.Equal(t, olderID, got[0].ID)
+}
+
+// TestGetRelatedNews_UsesHNSWIndex is a SCALE-REGRESSION guard. It EXPLAINs the exact
+// production ANN query against a non-trivial dataset and asserts the planner uses the
+// pgvector HNSW index. The original implementation took the anchor vector from a CROSS
+// JOIN, which silently defeated the index and did a full-scan KNN that only timed out
+// at scale — the small-row tests above could not catch it.
+func TestGetRelatedNews_UsesHNSWIndex(t *testing.T) {
+	pool, cleanup := startPgvector(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed a non-trivial dataset so a seq-scan plan is clearly distinguishable.
+	const n = 300
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+		vec := fmt.Sprintf("[%f,%f,%f]", float64(i%7)/7, float64(i%5)/5, float64(i%3)/3)
+		_, err := pool.Exec(ctx, `INSERT INTO news_articles (id, stock_code, source, headline, url, published_at)
+			VALUES ($1, 'BHP', 'stockhead', 'h', $2, now())`, id, "http://x/"+id)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, `INSERT INTO embeddings (object_type, object_id, embedding, model)
+			VALUES ('news_article', $1, $2::vector, 'test')`, id, vec)
+		require.NoError(t, err)
+	}
+
+	// Pick any embedded article as the anchor and grab its embedding literal.
+	var anchorID, emb string
+	require.NoError(t, pool.QueryRow(ctx, `SELECT object_id, embedding::text FROM embeddings LIMIT 1`).Scan(&anchorID, &emb))
+
+	// EXPLAIN the EXACT production query. Disable seq scans on this connection so the
+	// planner must reveal whether the query is index-USABLE: the literal-vector form
+	// can use idx_embeddings_hnsw; the old CROSS JOIN form cannot and would seq-scan.
+	conn, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+	// With seq scans AND sorts disabled, the literal-vector ORDER BY can only be
+	// satisfied by the HNSW index; the old CROSS JOIN form (non-constant vector) cannot
+	// use it and falls back to a (penalised) seq scan + sort — exposing the regression.
+	_, err = conn.Exec(ctx, "SET enable_seqscan = off")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "SET enable_sort = off")
+	require.NoError(t, err)
+
+	rows, err := conn.Query(ctx, "EXPLAIN "+relatedNewsANNQuery, emb, anchorID, int32(6))
+	require.NoError(t, err)
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	require.NoError(t, rows.Err())
+
+	require.Contains(t, plan.String(), "idx_embeddings_hnsw",
+		"GetRelatedNews ANN query must use the HNSW index (guards against a regression to the "+
+			"CROSS JOIN / exact-KNN form that times out at scale). EXPLAIN plan:\n"+plan.String())
 }


### PR DESCRIPTION
## Why
The #184 timeout (33s → 500s on every stock) was a planner regression that only appeared at scale — the existing integration tests used a 3-row dataset and couldn't catch it. This adds a guard.

## What
- Extract the ANN query into a package const `relatedNewsANNQuery` so the test EXPLAINs the **exact** production query (no drift).
- New `TestGetRelatedNews_UsesHNSWIndex`: seeds ~300 articles + the HNSW index, then `EXPLAIN`s the production query with `enable_seqscan=off` + `enable_sort=off` (so the literal-vector form *must* use the index, while the old CROSS JOIN form cannot) and asserts `idx_embeddings_hnsw` is in the plan.

## Verified it actually catches the regression
Temporarily reverted the const to the CROSS JOIN form → the new test **FAILS** (no HNSW in plan). Restored → **passes**. All 4 integration tests green; build/lint clean. Behaviorally a no-op (query unchanged; just extracted to a const).