### PR TITLE
fix(timeline-ui): default 365d window to match backend

### DIFF
--- a/web/src/@/components/company/event-timeline.tsx
+++ b/web/src/@/components/company/event-timeline.tsx
@@ -84,7 +84,7 @@ function getEventConfig(type: string) {
 
 export function EventTimeline({
   stockCode,
-  daysBack = 90,
+  daysBack = 365,
   limit = 40,
 }: EventTimelineProps) {
   const { data, isLoading } = useQuery({
@@ -135,7 +135,7 @@ export function EventTimeline({
           Event timeline
         </CardTitle>
         <CardDescription>
-          Key events over the last {daysBack} days
+          Key events over the last {daysBack >= 365 ? "year" : `${daysBack} days`}
         </CardDescription>
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
Backend now serves a 365-day event timeline (director trades & announcements are routinely months old), but the `EventTimeline` component still hardcoded `daysBack=90`, leaving most stocks' timelines sparse. Aligns the frontend default to 365d and shows a 'last year' label.

Verified live: BHP Connections (cross-board leadership + narrative peers), Timeline, and CBA Financials 'Results summary' digest all render in prod.