### PR TITLE
feat(reports): concurrent financial-report extraction backfill

### DIFF
--- a/services/report-extractor/extract_reports_concurrent.py
+++ b/services/report-extractor/extract_reports_concurrent.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Concurrent financial-report extraction backfill.
+
+extract.py's main() is sequential (--delay loop) — fine for a handful of stocks
+but far too slow for the ~5k latest-reports-per-company backfill. This reuses
+extract.py's PDF + langextract + digest helpers under a ThreadPoolExecutor so the
+financial-digest coverage can be broadened from ~63 stocks to the whole market.
+
+Run (against prod):
+  DATABASE_URL=... GEMINI_API_KEY=... LANGEXTRACT_API_KEY=$GEMINI_API_KEY \
+    python extract_reports_concurrent.py --recent 2 --limit 5000 --workers 8 [--top-shorted-first]
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import logging
+import threading
+
+import psycopg2
+import psycopg2.extras
+import requests
+
+import extract  # reuse helpers (import is side-effect-free)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("reports-backfill")
+
+_tl = threading.local()
+
+
+def _session() -> requests.Session:
+    s = getattr(_tl, "session", None)
+    if s is None:
+        s = requests.Session()
+        s.headers.update(extract.ASX_HEADERS)
+        _tl.session = s
+    return s
+
+
+def select_reports(conn, recent: int, limit: int, top_shorted_first: bool) -> list[dict]:
+    """Latest `recent` key financial reports per company, deduped vs already-extracted."""
+    reports = extract.get_reports_to_process(conn, mode="all", codes=[], limit=0, recent=recent)
+    if top_shorted_first:
+        cur = conn.cursor()
+        cur.execute("SELECT product_code, current_percent FROM mv_top_shorts")
+        rank = {code: pct for code, pct in cur.fetchall()}
+        cur.close()
+        reports.sort(key=lambda r: rank.get(r["stock_code"], -1), reverse=True)
+    if limit > 0:
+        reports = reports[:limit]
+    return reports
+
+
+def process(report: dict, conn, lock: threading.Lock, model: str, max_pages: int, dry_run: bool) -> str:
+    text = extract.download_pdf_text(_session(), report["url"], max_pages=max_pages)
+    if not text:
+        return "no_pdf"
+    extractions = extract.extract_financial_data(text, report["stock_code"], model_id=model)
+    # GCS upload is best-effort; never fail the report on it.
+    try:
+        gcs_url = extract.upload_raw_text_to_gcs(report["stock_code"], report["url"], text)
+    except Exception:  # noqa: BLE001
+        gcs_url = None
+
+    if not extractions:
+        with lock:
+            extract.store_extraction(conn, report, {}, len(text), dry_run, digest_result=None, raw_text_gcs_url=gcs_url)
+        return "no_metrics"
+
+    metrics = extract.extractions_to_metrics(extractions)
+    digest = extract.summarize_report(metrics, text, model_id=model)
+    with lock:
+        extract.store_extraction(conn, report, metrics, len(text), dry_run, digest_result=digest, raw_text_gcs_url=gcs_url)
+    return "ok"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--recent", type=int, default=2, help="latest N reports per company")
+    ap.add_argument("--limit", type=int, default=0, help="cap total reports (0=all)")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--model", type=str, default="gemini-2.5-flash")
+    ap.add_argument("--max-pages", type=int, default=10)
+    ap.add_argument("--top-shorted-first", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    conn = extract.get_db_connection()
+    reports = select_reports(conn, args.recent, args.limit, args.top_shorted_first)
+    log.info("Report backfill: %d reports to process (recent=%d, workers=%d)", len(reports), args.recent, args.workers)
+    if args.dry_run and reports:
+        for r in reports[:10]:
+            log.info("  [dry-run] %s %s (%s) %s", r["stock_code"], r["title"][:50], r["type"], r["date"])
+
+    lock = threading.Lock()
+    counts: dict[str, int] = {}
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(process, r, conn, lock, args.model, args.max_pages, args.dry_run): r for r in reports}
+        for fut in concurrent.futures.as_completed(futs):
+            try:
+                outcome = fut.result()
+            except Exception as e:  # noqa: BLE001
+                outcome = "error"
+                log.warning("  worker error: %s", e)
+            counts[outcome] = counts.get(outcome, 0) + 1
+            done += 1
+            if done % 50 == 0:
+                log.info("  progress %d/%d  %s", done, len(reports), counts)
+
+    log.info("DONE: %s", counts)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/signals-collector/collect.py
+++ b/services/signals-collector/collect.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import threading
+import time
 
 import psycopg2
 import psycopg2.extras
@@ -84,21 +85,33 @@ def select_stocks(conn, priority: str, limit: int, max_age_days: int) -> list[di
     return [dict(r) for r in cur.fetchall()]
 
 
-def resolve_signals(company_name: str) -> dict | None:
-    """Call brandbrain ResolveBusinessSignals. Returns parsed response or None."""
-    try:
-        resp = _session().post(
-            BRANDBRAIN_URL,
-            data=json.dumps({"business_name": company_name, "state": ""}),
-            timeout=150,
-        )
-        if resp.status_code != 200:
+def resolve_signals(company_name: str, retries: int = 3) -> dict | None:
+    """Call brandbrain ResolveBusinessSignals with 5xx retry/backoff.
+
+    brandbrain runs on a single instance and 502s under concurrency, so retry
+    transient 5xx with exponential backoff (these grounded calls are slow).
+    """
+    for attempt in range(retries):
+        try:
+            resp = _session().post(
+                BRANDBRAIN_URL,
+                data=json.dumps({"business_name": company_name, "state": ""}),
+                timeout=180,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            if 500 <= resp.status_code < 600 and attempt < retries - 1:
+                time.sleep(2 ** attempt + attempt)  # 1s, 3s, 6s
+                continue
             log.warning("  brandbrain HTTP %d for %s", resp.status_code, company_name)
             return None
-        return resp.json()
-    except Exception as e:  # noqa: BLE001
-        log.warning("  brandbrain call failed for %s: %s", company_name, e)
-        return None
+        except Exception as e:  # noqa: BLE001
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt + attempt)
+                continue
+            log.warning("  brandbrain call failed for %s: %s", company_name, e)
+            return None
+    return None
 
 
 def _hash(stock_code: str, polarity: str, headline: str) -> str:


### PR DESCRIPTION
Crawler-improvement finding: only **63 stocks (1.4%)** had financial-report extractions despite **2,669 stocks having reports (91,879 URLs)** — the report-extractor wasn't being run broadly and extract.py's main() is sequential.

This adds a concurrent driver (reuses extract.py's PDF + langextract + gemini-digest helpers under a ThreadPoolExecutor), processing the latest 2 key financial reports per company (~4,822 reports), top-shorted-first, deduped. Broadens the Financials 'Results summary' digest card from 63 stocks toward the whole market. Backfill running now.