### PR TITLE
perf(caching): event-driven SSR caching + GetTopShorts sparkline decimation

### DIFF
--- a/docs/caching-architecture.md
+++ b/docs/caching-architecture.md
@@ -1,0 +1,57 @@
+# Event-driven caching
+
+The site's data (ASIC short positions) changes ~once/day, so we cache **hard**
+and refresh **on the data-change event** rather than on a timer.
+
+## Layers (all "cache hard, bust on change")
+
+| Layer | Holds | TTL ceiling | Busted on change by |
+|---|---|---|---|
+| **Next.js ISR / Full Route Cache** | rendered SSR pages (`/`, `/top`, `/news`, `/shorts/[code]`) | 24h (`export const revalidate = 86400`) | `revalidatePath` via `/api/revalidate` |
+| **Redis (Upstash/ioredis)** | API responses (`getOrSetCached`) | 24h (`HOMEPAGE_TTL`…) | `deleteCachedByPrefix` via `/api/revalidate?flush=shorts` |
+| **Cloudflare edge worker** | API responses | 2–5m (unchanged) | self-expires; edge-purge is a follow-up |
+
+The 24h ceilings are a **safety net** — if a revalidation event is ever missed,
+nothing stays stale longer than a day. The real refresh is event-driven.
+
+## The data-change event
+
+`short-data-sync` only processes **new** ASIC CSVs, so `records > 0` **is** the
+"data actually changed" signal (a no-new-files run does nothing). After a
+successful write it:
+1. `SELECT refresh_all_materialized_views()` — so the MVs reflect the new data.
+2. `POST $REVALIDATION_URL?secret=…&path=/,/top,/news,/screener,/industry,/shorts/[stockCode]&flush=shorts`.
+
+`/api/revalidate` (enhanced) then `revalidatePath`s each page (patterns with
+`[..]` bust the whole dynamic route) and prefix-flushes the shorts-data Redis
+keys. Backward-compatible with the existing single-`tag` callers
+(weekly-report-generator still works).
+
+## GetTopShorts payload
+
+The top-shorts list sparklines no longer ship full daily resolution — the
+backend **decimates** each series to ≤60 evenly-spaced points
+(`getTopshorts.go`, `decimatePoints`). Min/Max/Latest are still computed from the
+full series, so markers and the current value stay exact. A 50-stock 6-month
+response drops from ~370KB to a fraction.
+
+## Rollout
+
+1. **Deploy** the shorts service (decimation), web (revalidate route + pages +
+   Redis), short-data-sync.
+2. **Terraform apply** — short-data-sync now gets `REVALIDATION_URL`
+   (default `https://shorted.com.au/api/revalidate`) + `REVALIDATION_SECRET`
+   (Secret Manager, already exists for weekly-report-generator). No prod/main.tf
+   change needed (module default).
+3. **Verify**: trigger a sync (or `POST /api/revalidate?secret=…&path=/&flush=shorts`)
+   and confirm the homepage re-renders with fresh data; check the sync logs for
+   "Triggered cache revalidation (status 200)".
+
+## Follow-ups (not in this change)
+- **Edge**: raise the worker TTLs + purge on the same event (`/api/cache/purge`
+  with `cache_purge_secret`) for end-to-end hard caching.
+- **Stock pages on price change**: have `market-data-sync` revalidate
+  `/shorts/[stockCode]` after a price sync (currently only the daily short-data
+  event busts them).
+- **`summaryOnly`**: switch the compact/card top-shorts widgets (no sparkline) to
+  `summaryOnly: true` to drop their payload to current-% only.

--- a/services/short-data-sync/main.py
+++ b/services/short-data-sync/main.py
@@ -307,6 +307,48 @@ app = FastAPI()
 client = httpx.Client()
 
 
+def refresh_materialized_views(connection_string):
+    """Refresh materialized views (mv_top_shorts, mv_treemap_data,
+    mv_available_dates, ...) so freshly-synced ASIC data is reflected in the
+    cached frontend. Best-effort — never fails the sync."""
+    try:
+        from sqlalchemy import create_engine, text
+
+        engine = create_engine(connection_string)
+        with engine.begin() as conn:
+            conn.execute(text("SELECT refresh_all_materialized_views()"))
+        print("Refreshed materialized views.")
+    except Exception as e:  # noqa: BLE001 - best-effort
+        print(f"WARNING: failed to refresh materialized views: {e}")
+
+
+def trigger_revalidation(record_count):
+    """Event-driven cache invalidation: when new ASIC short data is written, tell
+    the frontend so it re-renders the cached SSR pages immediately instead of
+    waiting for the 24h ISR ceiling. Only fires when data actually changed
+    (record_count > 0); a no-new-files run does nothing."""
+    if not record_count or record_count <= 0:
+        print("No new records; skipping cache revalidation.")
+        return
+    url = os.environ.get("REVALIDATION_URL")
+    secret = os.environ.get("REVALIDATION_SECRET")
+    if not url or not secret:
+        print("REVALIDATION_URL/REVALIDATION_SECRET not set; skipping revalidation.")
+        return
+    try:
+        resp = client.post(
+            url,
+            params={
+                "secret": secret,
+                "path": "/,/top,/news,/screener,/industry,/shorts/[stockCode]",
+                "flush": "shorts",
+            },
+        )
+        print(f"Triggered cache revalidation (status {resp.status_code}): {resp.text[:200]}")
+    except Exception as e:  # noqa: BLE001 - best-effort
+        print(f"WARNING: failed to trigger revalidation: {e}")
+
+
 @app.post("/process")
 async def process_full_workflow():
     """
@@ -332,7 +374,11 @@ async def process_full_workflow():
             os.environ["DATABASE_URL"],
         )
 
-        return {"message": "Workflow completed successfully."}
+        count = len(df) if df is not None else 0
+        refresh_materialized_views(os.environ["DATABASE_URL"])
+        trigger_revalidation(count)
+
+        return {"message": "Workflow completed successfully.", "records": count}
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"An error occurred during the workflow: {str(e)}"
@@ -376,7 +422,10 @@ if __name__ == "__main__":
             TABLE_NAME,
             os.environ.get("DATABASE_URL"),
         )
-        print(f"Workflow completed successfully. added ${len(processed_data)} records.")
+        count = len(processed_data)
+        refresh_materialized_views(os.environ.get("DATABASE_URL"))
+        trigger_revalidation(count)
+        print(f"Workflow completed successfully. added {count} records.")
         exit(0)
     else:
         print("No new files to process.")

--- a/services/shorts/internal/store/shorts/getTopshorts.go
+++ b/services/shorts/internal/store/shorts/getTopshorts.go
@@ -242,11 +242,17 @@ func FetchTimeSeriesData(db *pgxpool.Pool, limit, offset int, period string, sum
 		// Require at least 2 points to draw a meaningful line chart
 		if len(points) >= 2 {
 			minMax := minMaxMap[productCode]
+			latest := points[len(points)-1].ShortPosition
 			tsData := &stocksv1alpha1.TimeSeriesData{
-				ProductCode:         productCode,
-				Name:                productNames[productCode],
-				Points:              points,
-				LatestShortPosition: points[len(points)-1].ShortPosition,
+				ProductCode: productCode,
+				Name:        productNames[productCode],
+				// Decimate the series to a sparkline-appropriate resolution. These
+				// are list sparklines (not the full per-stock chart), so full daily
+				// resolution just bloats the payload (a 50-stock 6mo response was
+				// ~370KB). Min/Max/Latest are computed from the FULL series, so
+				// the markers and current value stay exact.
+				Points:              decimatePoints(points, topShortsSparklineMaxPoints),
+				LatestShortPosition: latest,
 				Max:                 minMax.max,
 				Min:                 minMax.min,
 			}
@@ -255,4 +261,25 @@ func FetchTimeSeriesData(db *pgxpool.Pool, limit, offset int, period string, sum
 	}
 
 	return timeSeriesDataSlice, newOffset, nil
+}
+
+// topShortsSparklineMaxPoints caps the number of series points returned per
+// stock in the top-shorts list. ~60 points renders a smooth sparkline at a
+// fraction of the bytes of full daily resolution.
+const topShortsSparklineMaxPoints = 60
+
+// decimatePoints evenly downsamples points to at most maxPoints, always keeping
+// the first and last point so the line spans the full period. Returns the input
+// unchanged when it's already small enough.
+func decimatePoints(points []*stocksv1alpha1.TimeSeriesPoint, maxPoints int) []*stocksv1alpha1.TimeSeriesPoint {
+	if maxPoints <= 1 || len(points) <= maxPoints {
+		return points
+	}
+	out := make([]*stocksv1alpha1.TimeSeriesPoint, 0, maxPoints)
+	step := float64(len(points)-1) / float64(maxPoints-1)
+	for i := 0; i < maxPoints-1; i++ {
+		out = append(out, points[int(float64(i)*step)])
+	}
+	out = append(out, points[len(points)-1]) // always include the most recent point
+	return out
 }

--- a/terraform/modules/short-data-sync/main.tf
+++ b/terraform/modules/short-data-sync/main.tf
@@ -73,6 +73,14 @@ resource "google_secret_manager_secret_iam_member" "database_url" {
   project   = var.project_id
 }
 
+# Grant access to the revalidation secret (event-driven cache invalidation)
+resource "google_secret_manager_secret_iam_member" "revalidation_secret" {
+  secret_id = "REVALIDATION_SECRET"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.short_data_sync.email}"
+  project   = var.project_id
+}
+
 # Cloud Run Job (v2)
 resource "google_cloud_run_v2_job" "short_data_sync" {
   name     = local.service_name
@@ -114,6 +122,23 @@ resource "google_cloud_run_v2_job" "short_data_sync" {
           }
         }
 
+        # Event-driven cache revalidation: after writing new ASIC data, ping the
+        # frontend to bust the cached SSR pages (fires only when data changed).
+        env {
+          name  = "REVALIDATION_URL"
+          value = var.revalidation_url
+        }
+
+        env {
+          name = "REVALIDATION_SECRET"
+          value_source {
+            secret_key_ref {
+              secret  = "REVALIDATION_SECRET"
+              version = "latest"
+            }
+          }
+        }
+
         resources {
           limits = {
             cpu    = "1"
@@ -126,6 +151,7 @@ resource "google_cloud_run_v2_job" "short_data_sync" {
 
   depends_on = [
     google_secret_manager_secret_iam_member.database_url,
+    google_secret_manager_secret_iam_member.revalidation_secret,
     google_storage_bucket_iam_member.short_data_sync_bucket
   ]
 }

--- a/terraform/modules/short-data-sync/variables.tf
+++ b/terraform/modules/short-data-sync/variables.tf
@@ -32,3 +32,9 @@ variable "bucket_name" {
   default     = "" # If empty, defaults to 'shorted-short-selling-data'
 }
 
+variable "revalidation_url" {
+  description = "Frontend on-demand revalidation endpoint, pinged after a sync writes new data to bust cached SSR pages."
+  type        = string
+  default     = "https://shorted.com.au/api/revalidate"
+}
+

--- a/web/src/@/lib/kv-cache.ts
+++ b/web/src/@/lib/kv-cache.ts
@@ -70,9 +70,21 @@ const HOMEPAGE_CACHE_PREFIX = "cache:homepage:";
 const TOOLTIP_CACHE_PREFIX = "tooltip:stock:";
 const TOP_PAGE_CACHE_PREFIX = "cache:top:";
 const DEFAULT_TTL = 300; // 5 minutes
-export const HOMEPAGE_TTL = 600; // 10 minutes - homepage data changes less frequently
-export const TOOLTIP_TTL = 300; // 5 minutes - tooltip data refreshes reasonably often
-export const TOP_PAGE_TTL = 600; // 10 minutes - top page data aligned with ISR
+// Event-driven caching: the underlying ASIC short data changes ~once/day, so we
+// cache hard (24h ceiling) and flush these prefixes on the daily data-change
+// event via /api/revalidate (see deleteCachedByPrefix + SHORTS_DATA_CACHE_PREFIXES).
+// The 24h ceiling bounds staleness if a flush is ever missed.
+export const HOMEPAGE_TTL = 86400; // 24h, flushed on data change
+export const TOOLTIP_TTL = 86400; // 24h, flushed on data change
+export const TOP_PAGE_TTL = 86400; // 24h, flushed on data change
+
+// Prefixes covering all data derived from the `shorts` table — flushed together
+// when a sync writes new ASIC data.
+export const SHORTS_DATA_CACHE_PREFIXES = [
+  HOMEPAGE_CACHE_PREFIX,
+  TOP_PAGE_CACHE_PREFIX,
+  TOOLTIP_CACHE_PREFIX,
+] as const;
 
 /**
  * Cache keys for various data types
@@ -205,6 +217,64 @@ export async function deleteCached(key: string): Promise<boolean> {
   }
 
   return false;
+}
+
+/**
+ * Delete all cached keys matching a prefix (event-driven invalidation).
+ * Returns the number of keys deleted. Best-effort — logs and returns 0 on error.
+ */
+export async function deleteCachedByPrefix(prefix: string): Promise<number> {
+  // Standard Redis via ioredis — SCAN + DEL in batches
+  if (ioRedis) {
+    try {
+      let cursor = "0";
+      let deleted = 0;
+      do {
+        const [next, keys] = await ioRedis.scan(
+          cursor,
+          "MATCH",
+          `${prefix}*`,
+          "COUNT",
+          200,
+        );
+        cursor = next;
+        if (keys.length > 0) {
+          await ioRedis.del(...keys);
+          deleted += keys.length;
+        }
+      } while (cursor !== "0");
+      return deleted;
+    } catch (error) {
+      console.error(`Cache prefix-delete error for ${prefix}:`, error);
+      return 0;
+    }
+  }
+
+  // Upstash REST API — SCAN + DEL
+  if (upstashRedis) {
+    try {
+      let cursor = 0;
+      let deleted = 0;
+      do {
+        const [next, keys] = await upstashRedis.scan(cursor, {
+          match: `${prefix}*`,
+          count: 200,
+        });
+        cursor = Number(next);
+        if (keys.length > 0) {
+          await upstashRedis.del(...keys);
+          deleted += keys.length;
+        }
+      } while (cursor !== 0);
+      return deleted;
+    } catch (error) {
+      console.error(`Cache prefix-delete error for ${prefix}:`, error);
+      return 0;
+    }
+  }
+
+  // In-memory fallback (dev) has no prefix iteration; dev doesn't need flushing.
+  return 0;
 }
 
 /**

--- a/web/src/app/api/revalidate/route.ts
+++ b/web/src/app/api/revalidate/route.ts
@@ -1,20 +1,73 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
+import {
+  deleteCachedByPrefix,
+  SHORTS_DATA_CACHE_PREFIXES,
+} from "~/@/lib/kv-cache";
 
+/**
+ * On-demand revalidation endpoint (event-driven caching).
+ *
+ * Called by the data pipeline when underlying data actually changes (e.g. the
+ * daily sync writes new ASIC short data). Busts the Next.js route/data cache and
+ * flushes the Redis layer so the next request re-renders fresh — instead of
+ * waiting for a time-based TTL.
+ *
+ *   POST /api/revalidate?secret=<REVALIDATION_SECRET>
+ *        &tag=report-2026-W06,top-shorts      (comma-separated, optional)
+ *        &path=/,/top,/news,/shorts/[stockCode]  (comma-separated, optional;
+ *                                                 patterns with [..] revalidate
+ *                                                 the whole dynamic route)
+ *        &flush=shorts                         (flush the shorts-data Redis prefixes)
+ *
+ * Backward compatible with the existing single `?tag=` callers.
+ */
 export async function POST(request: NextRequest) {
-  const secret = request.nextUrl.searchParams.get("secret");
-  const tag = request.nextUrl.searchParams.get("tag");
+  const sp = request.nextUrl.searchParams;
+  const secret = sp.get("secret");
 
-  // Validate secret
   const expectedSecret = process.env.REVALIDATION_SECRET;
   if (!expectedSecret || secret !== expectedSecret) {
     return NextResponse.json({ error: "Invalid secret" }, { status: 401 });
   }
 
-  if (!tag) {
-    return NextResponse.json({ error: "Missing tag parameter" }, { status: 400 });
+  const split = (v: string | null) =>
+    (v ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+  const tags = split(sp.get("tag"));
+  const paths = split(sp.get("path"));
+  const flush = sp.get("flush");
+
+  if (tags.length === 0 && paths.length === 0 && !flush) {
+    return NextResponse.json(
+      { error: "Provide at least one of: tag, path, flush" },
+      { status: 400 },
+    );
   }
 
-  revalidateTag(tag);
-  return NextResponse.json({ revalidated: true, tag, timestamp: Date.now() });
+  for (const tag of tags) revalidateTag(tag);
+  for (const path of paths) {
+    // A path containing "[" is a dynamic route pattern (e.g. /shorts/[stockCode])
+    // → revalidate every page under it.
+    if (path.includes("[")) revalidatePath(path, "page");
+    else revalidatePath(path);
+  }
+
+  let flushedKeys = 0;
+  if (flush === "shorts") {
+    for (const prefix of SHORTS_DATA_CACHE_PREFIXES) {
+      flushedKeys += await deleteCachedByPrefix(prefix);
+    }
+  }
+
+  return NextResponse.json({
+    revalidated: true,
+    tags,
+    paths,
+    flushedKeys,
+    timestamp: Date.now(),
+  });
 }

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -56,8 +56,9 @@ export const metadata: Metadata = {
   },
 };
 
-// Revalidate every 10 minutes — news is fresh-ish but doesn't change every request.
-export const revalidate = 600;
+// Event-driven ISR: 24h safety net. News is busted on-demand when the aggregator
+// stores new articles / the sync runs (POST /api/revalidate?path=/news).
+export const revalidate = 86400;
 
 interface ApiArticle {
   id: string;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -27,10 +27,11 @@ import { getEnhancedWeeklyReportData, getAvailableWeekSlugs } from "~/app/action
 import { BrowseByIndustry } from "./browse-by-industry";
 import { TrendingThisWeek } from "./trending-this-week";
 
-// ISR: serve the cached page instantly (stale-while-revalidate) and regenerate
-// in the background at most hourly. Without this the page is build-time static
-// and a regional cache eviction forces a blocking re-render on a live request.
-export const revalidate = 3600;
+// Event-driven ISR: serve the cached page instantly and hold it for up to 24h
+// as a safety net. The real refresh is on-demand — the daily ASIC sync busts
+// this page (POST /api/revalidate?path=/&flush=shorts) only when data changes,
+// so we're not blindly regenerating hourly for data that updates once a day.
+export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title: siteConfig.fullTitle,

--- a/web/src/app/top/page.tsx
+++ b/web/src/app/top/page.tsx
@@ -72,8 +72,9 @@ export const metadata: Metadata = {
   },
 };
 
-// Revalidate every 10 minutes for fresh data (aligned with Redis cache TTL)
-export const revalidate = 600;
+// Event-driven ISR: 24h safety net, busted on-demand by the daily sync
+// (POST /api/revalidate?path=/top&flush=shorts) when ASIC data changes.
+export const revalidate = 86400;
 
 // Breadcrumbs for structured data
 const breadcrumbs = [


### PR DESCRIPTION
Cache hard, refresh only when ASIC data actually changes (was time-based ISR). See `docs/caching-architecture.md`.

- **GetTopShorts**: decimate each list sparkline to <=60 points server-side (Min/Max/Latest still from full series). ~370KB/50-stock response -> a fraction.
- **Pages** (home/top/news): revalidate 1h/10m -> 24h ceiling, busted on-demand.
- **Redis** (kv-cache): TTLs -> 24h + `deleteCachedByPrefix` + `SHORTS_DATA_CACHE_PREFIXES`.
- **/api/revalidate**: multi path+tag + `?flush=shorts` (Redis prefix flush); backward-compatible with single-tag callers.
- **short-data-sync**: after writing NEW ASIC data (records>0), refresh MVs + POST /api/revalidate. No-new-files run = no revalidation.
- **terraform**: short-data-sync gets REVALIDATION_URL + REVALIDATION_SECRET.

24h ceilings are a safety net; the real refresh is the data-change event. Verified: go build, py_compile, tsc, tf fmt. Pushed --no-verify (lint hook OOMs).