### PR TITLE
feat: enrichment ingestion/processing uplift (§6.3 digests, §6.5 people-gate, §6.9 productionise collectors)

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -271,6 +271,12 @@ jobs:
           - name: asx-announcement-crawler
             dockerfile: services/asx-announcement-crawler/Dockerfile
             context: services
+          - name: signals-collector
+            dockerfile: services/signals-collector/Dockerfile
+            context: services/signals-collector
+          - name: report-extractor
+            dockerfile: services/report-extractor/Dockerfile
+            context: services/report-extractor
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -440,6 +446,8 @@ jobs:
             -var="enrichment_processor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/enrichment-processor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="news_aggregator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/news-aggregator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="asx_announcement_crawler_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/asx-announcement-crawler:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="signals_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/signals-collector:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="report_extractor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/report-extractor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="grafana_auth=${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}" \
             -out=tfplan
         # No continue-on-error: a failing plan must fail the PR check. This was
@@ -995,6 +1003,8 @@ jobs:
             -var="enrichment_processor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/enrichment-processor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="news_aggregator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/news-aggregator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="asx_announcement_crawler_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/asx-announcement-crawler:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="signals_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/signals-collector:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="report_extractor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/report-extractor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="grafana_auth=${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}" \
             -var="image_tag=${{ needs.determine-environment.outputs.image-tag }}" \
             -auto-approve

--- a/docs/enrichment-architecture.md
+++ b/docs/enrichment-architecture.md
@@ -148,6 +148,22 @@ ladder and citations. Shorted runs *two* discovery stacks; only one is intellige
 
 ## 9. Research & improvement areas (prioritised)
 
+> **Status (2026-06-20, branch `feat/enrichment-uplift`):** §6.3 ✅, §6.5 ✅, §6.9 ✅
+> shipped (code + IaC only — prod migrations / `terraform apply` / merge still to run).
+> §6.7 **re-scoped & deferred** (the job-monitoring stack was never merged — see §6.7).
+> §6.1/§6.2/§6.10 and §6.4/§6.6/§6.8 untouched.
+> - **§6.3 ✅** title noise-filter (keeps presentations; statutory keep-overrides for
+>   Appendix 4D/4E / "Financial Report" / "Results Announcement") + digest decoupled from
+>   metric extraction + `--backfill-digests` mode to recover the ~4,740 existing
+>   `digest=NULL` rows (prefers stored GCS text). `test_extract.py` added. (c) not done.
+> - **§6.5 ✅** additive `UpdateKeyPeopleIfEmpty` people-only write below the 0.80 gate
+>   (env `WRITE_PEOPLE_BELOW_GATE`; never clobbers an existing list; status left pending).
+>   The historical 178-stock gap still needs a re-run / pending-people backfill to realise.
+> - **§6.9 ✅** signals-collector + report-extractor containerised as scale-to-zero Cloud
+>   Run **jobs** (Python, NOT a Go rewrite — deferred to §6.2); `get_stock_signals` chat
+>   tool; migration 000053 `director_extract_attempts` failure-budget so the daily director
+>   job converges instead of re-burning Gemini on persistent 3Y-PDF failures.
+
 ### 6.1 Adopt stealth's `semantic` extraction across crawlers — HIGH
 Replace brittle CSS-selector scraping (metadata_scraper, report_crawler, 3Y/report parsers)
 with `stealth/brws/semantic.HTMLToSemanticTree` (LLM hierarchical extraction, ~99% token
@@ -183,21 +199,33 @@ shorted v0.4.0 vs brandbrain v0.5.2. Bump shorted to v0.5.x to share evasion-FSM
 waterfall improvements and avoid two engine behaviours. Mind the `go.work` replace + Docker
 bind-mount pattern.
 
-### 6.7 Pipeline observability — MED
-`job_runs` telemetry (migration 000046) is **not applied in prod**, so staleness/coverage gaps
-are invisible (this is why the financial/people gaps lingered). Apply it + wire every
-pipeline + a coverage dashboard (per-source freshness + % coverage). Distinguishes real lag
-from the ASIC **T+4** false-alarm.
+### 6.7 Pipeline observability — MED (re-scoped 2026-06-20)
+**Correction:** `job_runs` telemetry (migration 000046) is not merely "not applied in prod" —
+it is **not in the tree at all**. Migrations jump 000045→000047, and `services/pkg/jobstatus`
+is a 71-line **stub** writing to a `job_runs` table no migration creates (schema incompatible
+with the real design). The full stack lives only on **unmerged branch `feat/job-monitoring`
+(f1b15079)**. So §6.7 is three jobs: (1) land that branch (resolving the stub conflict + ~24-file
+store-layer conflicts vs the knowledge-graph work), (2) apply 000046 to prod manually + wire the
+still-unwired pipelines (enrichment-processor, signals-collector, report-extractor×3, daily-sync)
++ fix the short-data-sync uvicorn-as-job landmine, (3) build the genuinely-new per-source
+freshness + %coverage view that distinguishes real lag from the ASIC **T+4** false alarm.
+Deferred: landing an unmerged branch + manual prod migration + prod TF apply deserves its own
+focused effort, not a side-quest.
 
 ### 6.8 Cost-tiering for all AI calls — MED
 brandbrain's free-index → cheap-search → DeepSeek → Gemini-grounded ladder vs shorted's
 always-LLM enrichment. Adopt a tier-0 cache/heuristic before paid calls across enrichment +
 signals + digests.
 
-### 6.9 Productionise the new collectors — MED
-`signals-collector`, `extract_director_trades`, `extract_reports_concurrent` are run manually.
-Port to Go Cloud Run **jobs** on schedulers (mind brandbrain concurrency limits), incremental
-(skip-fresh) by default. Add a `get_stock_signals` chat tool.
+### 6.9 Productionise the new collectors — MED ✅ (2026-06-20)
+Shipped: `signals-collector` + `report-extractor` (two jobs) containerised as scale-to-zero
+Cloud Run **jobs** (`terraform/modules/{signals-collector,report-extractor}`, wired dev+prod,
+CI build-matrix). Chose **Python containers, not a Go rewrite** — the scripts depend on
+Python-only libs (pymupdf/langextract), don't use stealth, and are already concurrent +
+incremental + idempotent; Go is best deferred to §6.2's brandbrain/stealth unification.
+`get_stock_signals` chat tool added. Failure-budget (migration 000053) lands so the daily
+director job converges. **Prod note:** `gemini_secret_exists=false` in prod — the two report
+jobs deploy but exit early until `GEMINI_API_KEY` is provisioned in prod Secret Manager.
 
 ### 6.10 brandbrain horizontal scale — prerequisite for §6.2
 Single DigitalOcean instance 502s above ~2 concurrent grounded calls. Research: scale-out +
@@ -206,8 +234,10 @@ through it.
 
 ---
 
-**TL;DR for the next session:** the highest-leverage move is **§6.2 + §6.1** — collapse
-shorted's bespoke discovery into brandbrain (over stealth) and adopt stealth's semantic
-extraction — but it's gated on **§6.10** (brandbrain must scale first). Quick wins available
-now: **§6.3** (digest decoupling — recovers the 4,740 no-metric reports) and **§6.5** (people
-write-gate — unlocks the discovered-but-unwritten leadership).
+**TL;DR for the next session:** §6.3 / §6.5 / §6.9 are shipped on `feat/enrichment-uplift`
+(merge + run the prod migrations 000053 / `terraform apply` / provision prod `GEMINI_API_KEY`
+to realise them). The next highest-leverage move is **§6.2 + §6.1** — collapse shorted's
+bespoke discovery into brandbrain (over stealth) + adopt stealth's semantic extraction — gated
+on **§6.10** (brandbrain must scale first). **§6.7** is now a known bigger lift (land the
+unmerged `feat/job-monitoring` branch + prod migration). To *realise* §6.5's coverage gain,
+re-run the enrichment batch with `WRITE_PEOPLE_BELOW_GATE=true` (or a pending-people backfill).

--- a/docs/enrichment-architecture.md
+++ b/docs/enrichment-architecture.md
@@ -1,0 +1,213 @@
+# Enrichment & Intelligent-Crawler Architecture
+
+> How Shorted turns raw ASX data into a per-stock knowledge graph, traced across the
+> three-repo stack **`shorted` → `brandbrain` → `stealth`**, with a prioritised set of
+> research areas. Last reflected: 2026-06-19 (after the director / signals / report /
+> key-people backfills).
+
+## 1. The three-repo stack
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ shorted (this repo) — the product + data pipelines                         │
+│   services/enrichment-processor   bespoke 6-phase company enrichment        │
+│   services/asx-announcement-crawler  ASX announcements → director/dividend  │
+│   services/report-extractor       financial-report PDF → metrics + digest   │
+│   services/signals-collector      NEW: risk/reputation signals              │
+│   services/news-aggregator        RSS/news → match → sentiment → embeddings │
+│   services/pkg/stealthhttp        thin wrapper over the stealth engine      │
+└───────────────┬───────────────────────────────┬───────────────────────────┘
+                │ HTTP (Connect JSON)            │ import (go.mod)
+                ▼                                 ▼
+┌──────────────────────────────────┐   ┌────────────────────────────────────┐
+│ brandbrain (api.brandbrain.dev)  │   │ stealth (github.com/skunkworq/...)  │
+│   AI company/brand discovery     │   │   fetch engine                       │
+│   DiscoverBusiness               │   │   native (uTLS fingerprint, no JS)  │
+│   ResolveBusinessSignals         │──▶│   chromium/firefox/webkit (JS)       │
+│   cost-tiered (free→Gemini-grnd) │   │   waterfall escalation, evasion FSM, │
+│   grounded w/ citations          │   │   RL policy, CF auto-solve,          │
+└──────────────────────────────────┘   │   semantic.HTMLToSemanticTree (LLM) │
+                                        └────────────────────────────────────┘
+```
+
+- **`stealth`** is the shared fetch substrate. Both `shorted` (via `pkg/stealthhttp`) and
+  `brandbrain` import it. `shorted` pins **v0.4.0**, `brandbrain` pins **v0.5.2** (drift —
+  see research §6.6).
+- **`brandbrain`** is a deployed *service* shorted calls over the network. Today only
+  `signals-collector` uses it; the big `enrichment-processor` does **not** (it reimplements
+  discovery — the core duplication this doc flags).
+
+## 2. The fetch layer — `stealth` via `pkg/stealthhttp`
+
+`services/pkg/stealthhttp/client.go` wraps `stealth/brws/engine`:
+- `New()` → **native** engine: uTLS TLS/JA3 fingerprint spoof, HTTP/2, no browser, ~10ms. Default for static HTML / PDFs / APIs.
+- `NewChromium()` → **chromium** engine: JS render + challenge solving. Used for LinkedIn logo discovery only.
+- Options: `WithTimeout`, `WithTLSProfile`, `WithProxy`, `WithMaxRedirects`, `WithExecPath`.
+- OTel-instrumented: `shorted.stealth.fetch_{duration,total,errors,bytes}`.
+
+Consumers in shorted: `news-aggregator` (rss_fetcher, googlenews_resolve, image_backfill),
+`asx-announcement-crawler`, `enrichment-processor`, `pkg/enrichment` (logo_discoverer,
+linkedin_person_client, report_crawler, utils).
+
+**Not yet used by shorted:** the waterfall auto-escalation, evasion FSM / RL policy,
+Cloudflare auto-solve, and — most importantly — `semantic.HTMLToSemanticTree` (LLM
+hierarchical extraction with ~99% token compression). See research §6.1.
+
+## 3. Pipeline A — Company metadata enrichment (`enrichment-processor`)
+
+The bespoke 6-phase pipeline. Entry: `runEnrichmentPhases()` (`main.go:593`). One stock at a time.
+
+| Phase | What | External call | Timeout |
+|---|---|---|---|
+| 0 Website discovery | find official site if missing | `gptClient.DiscoverWebsite` (OpenAI/Gemini) | 60s |
+| 1 Metadata scrape | leadership / about / key links | `metadataScraper.ScrapeMetadata` (stealth native + **Chromium** fallback) | 90s |
+| 2 Report crawl | discover financial-report PDFs on site | `reportCrawler.CrawlFinancialReports` (stealth) | 60s |
+| 3 LLM enrichment | summary/history/risks/people/tags | `gptClient.EnrichCompany` (**OpenAI gpt-5.2** or Gemini) | 4m |
+| 3a Fallback people | only if LLM returned 0 people | **Yahoo Finance officers** + deep crawl + LLM | 2m |
+| 3.5 Person enrichment | photos + LinkedIn for top people | Yahoo, **LinkedIn (Chromium / Exa)**, Wikipedia, GCS upload | 90s |
+| 4 Logo discovery | logo variants + processing | `logoDiscoverer` (**Chromium**) + Python `logo_processor.py` | 2m |
+| 5 Quality eval | score 0–1, warnings | `gptClient.EvaluateQuality` | 60s |
+
+**Write gate (CRITICAL):** `main.go:543` — enrichment is auto-approved (written to the
+served `company-metadata` fields) **only if `quality.OverallScore >= AUTO_APPROVE_THRESHOLD`
+(default 0.80)**. Below that it is staged, not served.
+
+**Run modes:** `RUN_MODE=batch` (one-shot, `BATCH_PRIORITY=short_position|stale|unenriched`,
+`BATCH_SIZE`, `BATCH_CONCURRENCY`); HTTP push (Pub/Sub, single stock); `--backfill-people`
+(images only — **skips zero-people stocks**, `backfill_people.go:74`); `--backfill-images`.
+Needs `APP_STORE_POSTGRES_*` (not `DATABASE_URL`), `OPENAI_API_KEY`. **Not currently deployed**
+in prod (removed after a min-instance cost incident) — run locally against prod.
+
+**Selection landmine:** `GetTopStocksForEnrichment` (`postgres.go:1434`) — `short_position`
+priority has *no* completed-filter (selects all top-shorted) but the processor then *skips*
+already-completed stocks (`"already enriched, use force=true"`); `unenriched`/`stale` filter
+on status/date. There is **no "missing key_people" selector** — targeting that gap requires a
+status reset first.
+
+## 4. Pipeline B — Director trades (`asx-announcement-crawler` + `report-extractor`)
+
+1. **Crawl** (`asx-announcement-crawler`): per-stock ASX announcement pages (stealth native),
+   HTML-parse Appendix 3Y headlines → `director_trades`. Headlines carry **no name in ~59% of
+   cases and never carry $ value** → historically dirty (see [director-data-extraction memory]).
+2. **PDF extraction** (`report-extractor/extract_director_trades.py`, NEW): fetch each 3Y PDF,
+   gemini-2.5-flash structured extract (name, securities, consideration, direction) → write
+   back keyed on `announcement_url`. Concurrent, idempotent.
+
+**Reflection (2026-06-19 backfill):** of 21,291 unique 3Y PDFs — **ok 7,644 / no_extract 13,398**.
+By year: 2026 75% extracted, 2025 31%, **2024 ~0.1%** → older ASX announcement PDF URLs do not
+resolve/download (archived differently or expired). See research §6.4.
+
+## 5. Pipeline C — Risk / reputation signals (`signals-collector` → brandbrain) — NEW
+
+The first true `shorted → brandbrain → stealth` integration.
+`services/signals-collector/collect.py` → POST `brandbrain.v1.DiscoveryService/ResolveBusinessSignals`
+`{business_name, state}` → brandbrain runs Gemini-grounded research (over stealth) → returns
+`adverse[]` (court/sanction/complaint/safety, severity, citations) + `positive[]` (awards/press).
+Upsert `stock_signals` (idempotent via `content_hash`). Served by `GetStockSignals` RPC →
+Overview "Risk & reputation" card.
+
+**Reflection:** 150 top-shorted swept → **2,027 signals / 192 stocks / 205 high-severity**.
+brandbrain **502s above ~2 concurrent** (single instance) — collector retries 5xx w/ backoff.
+This is the model for the rest of enrichment (research §6.2).
+
+## 6. Pipeline D — Financial digests (`report-extractor`)
+
+`extract.py` (+ NEW concurrent `extract_reports_concurrent.py`): select latest-N key financial
+reports per company → fetch PDF (pymupdf) → **langextract** structured metrics → gemini-2.5-flash
+**digest** → `financial_report_extractions` (+ raw text to GCS). Served by
+`GetStockFinancialHighlights` → Financials "Results summary" card.
+
+**Reflection (4,817-report backfill):** **ok 71 / no_metrics 4,740 (98%)**. Metric-hit by type:
+half_year 6.7%, annual_report 3%, annual_results 13%. Root cause: the crawler classifies *any*
+"half year"/"annual" announcement as a report, so the set is dominated by **presentations,
+media releases and CEO letters** (no metric tables), and the digest is **gated on metrics being
+found**. Digests grew 46→115. See research §6.3.
+
+## 7. Pipeline E — News + embeddings (`news-aggregator`)
+
+RSS + Google News (stealth) → stock match → gemini-2.0-flash sentiment → `news_articles` →
+gemini-embedding-001 (MRL-768) embeddings → HNSW related-news + company-summary `similar_to`
+edges. (See stock-intelligence-panel memory; healthy — news fresh daily.)
+
+## 8. Current-state assessment (post-backfill coverage)
+
+| Surface | Coverage | Notes |
+|---|---|---|
+| director_trades clean names | 13,211 / 21,291 | +$value on 5,352; 2024 URLs fail |
+| risk signals | 192 stocks / 2,027 signals | top-shorted swept |
+| financial digests | 115 stocks | low metric-hit; presentation noise |
+| top-shorted w/ key_people | 624 / 802 | **gate-limited** — Yahoo officers score ~0.74 < 0.80 |
+| key_people overall | ~38% | enrichment-processor not deployed |
+| asx_announcements | 0 → fills next crawl | `-all-announcements` enabled |
+
+**The core architectural finding:** `enrichment-processor` Phases 0/1/2/3.5/4 (website, metadata,
+report-discovery, social, logo) **duplicate brandbrain's `DiscoverBusiness`**, but with bespoke
+Chromium scrapers, no cost-tiering, no grounding/citations, and an OpenAI dependency — while
+brandbrain (already deployed, already over stealth) does the same with a free→grounded cost
+ladder and citations. Shorted runs *two* discovery stacks; only one is intelligent.
+
+## 9. Research & improvement areas (prioritised)
+
+### 6.1 Adopt stealth's `semantic` extraction across crawlers — HIGH
+Replace brittle CSS-selector scraping (metadata_scraper, report_crawler, 3Y/report parsers)
+with `stealth/brws/semantic.HTMLToSemanticTree` (LLM hierarchical extraction, ~99% token
+compression). Research: token/cost vs accuracy vs current selectors; one pilot on
+metadata_scraper.
+
+### 6.2 Route discovery through brandbrain (unify the two stacks) — HIGH
+Migrate enrichment Phase 0/1/4 to `brandbrain.DiscoverBusiness` (website, logo, social,
+industry, HQ, contact — grounded, cost-tiered). Keep shorted-specific phases (financial
+reports, people). Removes the Chromium + OpenAI-discovery duplication. Research: field-by-field
+quality parity vs current enrichment; brandbrain throughput (it 502s >2 concurrent — needs
+horizontal scale or a queue first).
+
+### 6.3 Fix the financial-digest hit-rate — HIGH
+(a) Tighten report selection to actual statements (Appendix **4D/4E**, "Financial Report",
+"Results Announcement") and exclude presentations/letters/media releases by title regex.
+(b) **Decouple the digest from metric extraction** — generate the gemini digest from raw PDF
+text even when langextract finds no structured table (a presentation still summarises well).
+(c) Evaluate gemini structured-output (like the 3Y extractor) vs langextract for metric tables.
+
+### 6.4 Recover 2024 director PDFs — MED
+2024 3Y URLs fail ~100%. Research: ASX archive URL format/expiry; re-resolve via
+`displayAnnouncement.do` → `announcements.asx.com.au`; or re-crawl 2024 to refresh URLs.
+
+### 6.5 Decouple key_people writes from the 0.80 quality gate — MED
+Yahoo-officer enrichments score ~0.74 (flagged "generic finance profile") and are therefore
+**not written**, so the people backfill underdelivers. Research: a separate, lower bar for
+*people-only* writes; or score people independently of the whole-company score; or trust
+Yahoo officers as a structured source bypassing the LLM-quality gate.
+
+### 6.6 Align stealth versions — LOW/MED
+shorted v0.4.0 vs brandbrain v0.5.2. Bump shorted to v0.5.x to share evasion-FSM / RL /
+waterfall improvements and avoid two engine behaviours. Mind the `go.work` replace + Docker
+bind-mount pattern.
+
+### 6.7 Pipeline observability — MED
+`job_runs` telemetry (migration 000046) is **not applied in prod**, so staleness/coverage gaps
+are invisible (this is why the financial/people gaps lingered). Apply it + wire every
+pipeline + a coverage dashboard (per-source freshness + % coverage). Distinguishes real lag
+from the ASIC **T+4** false-alarm.
+
+### 6.8 Cost-tiering for all AI calls — MED
+brandbrain's free-index → cheap-search → DeepSeek → Gemini-grounded ladder vs shorted's
+always-LLM enrichment. Adopt a tier-0 cache/heuristic before paid calls across enrichment +
+signals + digests.
+
+### 6.9 Productionise the new collectors — MED
+`signals-collector`, `extract_director_trades`, `extract_reports_concurrent` are run manually.
+Port to Go Cloud Run **jobs** on schedulers (mind brandbrain concurrency limits), incremental
+(skip-fresh) by default. Add a `get_stock_signals` chat tool.
+
+### 6.10 brandbrain horizontal scale — prerequisite for §6.2
+Single DigitalOcean instance 502s above ~2 concurrent grounded calls. Research: scale-out +
+a request queue, or a shorted-side rate-limited client, before routing high-volume enrichment
+through it.
+
+---
+
+**TL;DR for the next session:** the highest-leverage move is **§6.2 + §6.1** — collapse
+shorted's bespoke discovery into brandbrain (over stealth) and adopt stealth's semantic
+extraction — but it's gated on **§6.10** (brandbrain must scale first). Quick wins available
+now: **§6.3** (digest decoupling — recovers the 4,740 no-metric reports) and **§6.5** (people
+write-gate — unlocks the discovered-but-unwritten leadership).

--- a/services/chat-service/system_prompt.go
+++ b/services/chat-service/system_prompt.go
@@ -12,6 +12,7 @@ Key facts about your data:
 - Market data includes stock prices, director trades, dividends, news, and peer comparisons
 - Weekly analysis reports are generated with trend analysis and sector breakdowns
 - You can find semantically related news (cross-outlet, by meaning), map a company's key people and their other ASX board seats, surface narrative-similar peers, and show a merged chronological event timeline of announcements, director trades, and short-position spikes
+- You can surface a company's risk & reputation signals — adverse items (court cases, sanctions, regulatory actions, complaints, safety incidents) and positive items (awards, favourable press), each with severity and source citations — via the get_stock_signals tool
 
 Guidelines:
 - Always cite specific data points when answering (e.g., "BHP is currently 4.2% shorted")

--- a/services/chat-service/tool_executor.go
+++ b/services/chat-service/tool_executor.go
@@ -55,6 +55,8 @@ func (te *ToolExecutor) Execute(ctx context.Context, toolName string, args map[s
 		return te.callRPC(ctx, "GetStockGraph", args)
 	case "get_event_timeline":
 		return te.callRPC(ctx, "GetEventTimeline", args)
+	case "get_stock_signals":
+		return te.callRPC(ctx, "GetStockSignals", args)
 	default:
 		return "", fmt.Errorf("unknown tool: %s", toolName)
 	}
@@ -196,6 +198,15 @@ func mapArgsToRequest(method string, args map[string]interface{}) map[string]int
 			req["limit"] = v
 		} else {
 			req["limit"] = 20
+		}
+	case "GetStockSignals":
+		if v, ok := args["stock_code"]; ok {
+			req["stockCode"] = v
+		}
+		if v, ok := args["limit"]; ok {
+			req["limit"] = v
+		} else {
+			req["limit"] = 10
 		}
 	}
 

--- a/services/chat-service/tools.go
+++ b/services/chat-service/tools.go
@@ -113,5 +113,14 @@ func GetToolDefinitions() []ToolDefinition {
 			},
 			Required: []string{"stock_code"},
 		},
+		{
+			Name:        "get_stock_signals",
+			Description: "Get a stock's risk and reputation signals — adverse items (court cases, sanctions, regulatory actions, complaints, safety incidents) and positive items (awards, favourable press), each with a severity rating and source citations. Use when the user asks about a company's risks, controversies, legal issues, or reputation.",
+			Parameters: map[string]ToolParameter{
+				"stock_code": {Type: "string", Description: "ASX stock code"},
+				"limit":      {Type: "integer", Description: "Max signals per polarity (default 10, max 50)"},
+			},
+			Required: []string{"stock_code"},
+		},
 	}
 }

--- a/services/enrichment-processor/config.go
+++ b/services/enrichment-processor/config.go
@@ -14,6 +14,19 @@ const (
 	// and applied without manual review. Set to 0 to disable auto-approval.
 	DefaultAutoApproveThreshold = 0.8
 
+	// DefaultWritePeopleBelowGate controls §6.5: whether discovered key_people are
+	// written to the served company-metadata even when the whole-company quality score
+	// is below DefaultAutoApproveThreshold. Yahoo-officer leadership scores ~0.74
+	// ("generic finance profile") and would otherwise never be served. The write is
+	// additive (only fills rows that currently have no people) so it can't clobber a
+	// better prior result. Override with env WRITE_PEOPLE_BELOW_GATE.
+	DefaultWritePeopleBelowGate = true
+
+	// DefaultMinPeopleWriteScore is a floor on the overall quality score below which
+	// even the people-only write is suppressed (0 = always write any non-placeholder
+	// people). Override with env MIN_PEOPLE_WRITE_SCORE.
+	DefaultMinPeopleWriteScore = 0.0
+
 	// GCSCacheControl is the Cache-Control header for uploaded logos
 	GCSCacheControl = "public, max-age=86400"
 

--- a/services/enrichment-processor/main.go
+++ b/services/enrichment-processor/main.go
@@ -249,6 +249,28 @@ func main() {
 		logger.Infof("Auto-approve disabled (threshold=0)")
 	}
 
+	// §6.5 People-only write: serve discovered key_people even when the whole-company
+	// quality score is below the auto-approve gate (Yahoo-officer leadership ~0.74).
+	writePeopleBelowGate := DefaultWritePeopleBelowGate
+	if v := os.Getenv("WRITE_PEOPLE_BELOW_GATE"); v != "" {
+		if parsed, parseErr := strconv.ParseBool(v); parseErr == nil {
+			writePeopleBelowGate = parsed
+		} else {
+			logger.Warnf("Invalid WRITE_PEOPLE_BELOW_GATE value: %s (using default %v)", v, DefaultWritePeopleBelowGate)
+		}
+	}
+	minPeopleWriteScore := DefaultMinPeopleWriteScore
+	if v := os.Getenv("MIN_PEOPLE_WRITE_SCORE"); v != "" {
+		if parsed, parseErr := strconv.ParseFloat(v, 64); parseErr == nil && parsed >= 0 && parsed <= 1 {
+			minPeopleWriteScore = parsed
+		} else {
+			logger.Warnf("Invalid MIN_PEOPLE_WRITE_SCORE value: %s (using default %.2f)", v, DefaultMinPeopleWriteScore)
+		}
+	}
+	if writePeopleBelowGate {
+		logger.Infof("People-only write enabled: discovered key_people served below the auto-approve gate (min score %.2f, additive — fills empty rows only)", minPeopleWriteScore)
+	}
+
 	// Read shorts API URL for Algolia sync callbacks
 	shortsAPIURL := strings.TrimSpace(os.Getenv("SHORTS_API_URL"))
 	internalServiceSecret := strings.TrimSpace(os.Getenv("INTERNAL_SERVICE_SECRET"))
@@ -272,6 +294,8 @@ func main() {
 		timeout:               DefaultJobTimeout,
 		qualityThreshold:      DefaultQualityThreshold,
 		autoApproveThreshold:  autoApproveThreshold,
+		writePeopleBelowGate:  writePeopleBelowGate,
+		minPeopleWriteScore:   minPeopleWriteScore,
 		gcsBucket:             gcsBucket,
 		shortsAPIURL:          shortsAPIURL,
 		internalServiceSecret: internalServiceSecret,
@@ -346,9 +370,46 @@ type enrichmentProcessor struct {
 	timeout               time.Duration
 	qualityThreshold      float64
 	autoApproveThreshold  float64
+	writePeopleBelowGate  bool    // §6.5 write discovered key_people even below the auto-approve gate
+	minPeopleWriteScore   float64 // floor below which even the people-only write is suppressed
 	gcsBucket             string
 	shortsAPIURL          string // URL of the shorts API (for Algolia sync callbacks)
 	internalServiceSecret string // Auth secret for internal API calls
+}
+
+// buildPeopleOnlyWriteJSON converts discovered key_people into the served key_people
+// JSON shape (matching backfillPerson / the DB parser), dropping empty and placeholder
+// names. Returns the marshalled JSON and the number of people written; (nil, 0) when there
+// is nothing worth writing. Used by the §6.5 below-gate people-only write.
+func buildPeopleOnlyWriteJSON(people []*stocksv1alpha1.CompanyPerson) ([]byte, int) {
+	out := make([]backfillPerson, 0, len(people))
+	for _, person := range people {
+		if person == nil {
+			continue
+		}
+		name := strings.TrimSpace(person.GetName())
+		if name == "" || enrichment.IsPlaceholderName(name) {
+			continue
+		}
+		out = append(out, backfillPerson{
+			Name:        person.GetName(),
+			Role:        person.GetRole(),
+			Bio:         person.GetBio(),
+			ImageURL:    person.GetImageUrl(),
+			ImageGCSURL: person.GetImageGcsUrl(),
+			LinkedInURL: person.GetLinkedinUrl(),
+			SourceURL:   person.GetSourceUrl(),
+			SourceType:  person.GetSourceType(),
+		})
+	}
+	if len(out) == 0 {
+		return nil, 0
+	}
+	j, err := json.Marshal(out)
+	if err != nil {
+		return nil, 0
+	}
+	return j, len(out)
 }
 
 // notifyAlgoliaSync sends an HTTP POST to the shorts API to sync a stock's enriched data to Algolia.
@@ -560,6 +621,24 @@ func (p *enrichmentProcessor) processJob(ctx context.Context, jobID, stockCode s
 	} else if quality != nil {
 		p.logger.Infof("Enrichment for %s saved as pending review (quality score %.2f < threshold %.2f)",
 			stockCode, quality.OverallScore, p.autoApproveThreshold)
+
+		// §6.5 People-only write: leadership shouldn't be gated behind the whole-company
+		// quality score. Even though the full enrichment stays in pending review, write the
+		// discovered key_people to the served column — but ADDITIVELY (only when the row has
+		// none), so a better prior people list is never clobbered. enrichment_status is left
+		// untouched, so the rest of the enrichment is still gated and can be approved later.
+		if p.writePeopleBelowGate && quality.OverallScore >= p.minPeopleWriteScore {
+			if peopleJSON, count := buildPeopleOnlyWriteJSON(enriched.GetKeyPeople()); count > 0 {
+				if wrote, perr := p.store.UpdateKeyPeopleIfEmpty(stockCode, peopleJSON); perr != nil {
+					p.logger.Warnf("People-only write failed for %s: %v", stockCode, perr)
+				} else if wrote {
+					p.logger.Infof("People-only write for %s: served %d people below gate (score %.2f, status left pending)",
+						stockCode, count, quality.OverallScore)
+				} else {
+					p.logger.Debugf("People-only write skipped for %s: served row already has people", stockCode)
+				}
+			}
+		}
 	}
 
 	// Update job status to completed

--- a/services/enrichment-processor/main.go
+++ b/services/enrichment-processor/main.go
@@ -392,8 +392,8 @@ func buildPeopleOnlyWriteJSON(people []*stocksv1alpha1.CompanyPerson) ([]byte, i
 			continue
 		}
 		out = append(out, backfillPerson{
-			Name:        person.GetName(),
-			Role:        person.GetRole(),
+			Name:        name,
+			Role:        strings.TrimSpace(person.GetRole()),
 			Bio:         person.GetBio(),
 			ImageURL:    person.GetImageUrl(),
 			ImageGCSURL: person.GetImageGcsUrl(),

--- a/services/enrichment-processor/mocks/mocks.go
+++ b/services/enrichment-processor/mocks/mocks.go
@@ -285,6 +285,19 @@ func (mr *MockEnrichmentStoreMockRecorder) UpdateKeyPeopleEnriched(stockCode, ke
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyPeopleEnriched", reflect.TypeOf((*MockEnrichmentStore)(nil).UpdateKeyPeopleEnriched), stockCode, keyPeopleJSON)
 }
 
+func (m *MockEnrichmentStore) UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON []byte) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateKeyPeopleIfEmpty", stockCode, keyPeopleJSON)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockEnrichmentStoreMockRecorder) UpdateKeyPeopleIfEmpty(stockCode, keyPeopleJSON interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyPeopleIfEmpty", reflect.TypeOf((*MockEnrichmentStore)(nil).UpdateKeyPeopleIfEmpty), stockCode, keyPeopleJSON)
+}
+
 // MockGPTClient is a mock of GPTClient interface
 type MockGPTClient struct {
 	ctrl     *gomock.Controller

--- a/services/enrichment-processor/people_write_test.go
+++ b/services/enrichment-processor/people_write_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	shortsv1alpha1 "github.com/castlemilk/shorted.com.au/services/gen/proto/go/shorts/v1alpha1"
+	stocksv1alpha1 "github.com/castlemilk/shorted.com.au/services/gen/proto/go/stocks/v1alpha1"
+	"github.com/castlemilk/shorted.com.au/services/pkg/enrichment"
+	"github.com/castlemilk/shorted.com.au/services/pkg/log"
+	"github.com/castlemilk/shorted.com.au/services/enrichment-processor/mocks"
+)
+
+// §6.5 buildPeopleOnlyWriteJSON: drops empty + placeholder names, keeps real people,
+// and emits the snake_case JSON shape the served key_people parser expects.
+func TestBuildPeopleOnlyWriteJSON(t *testing.T) {
+	people := []*stocksv1alpha1.CompanyPerson{
+		{Name: "Jane Roe", Role: "CEO", LinkedinUrl: "https://linkedin.com/in/janeroe", SourceType: "yahoo_finance"},
+		{Name: "John Doe", Role: "CFO"},      // placeholder name → dropped
+		{Name: "  ", Role: "Director"},        // empty → dropped
+		nil,                                    // nil → skipped
+		{Name: "Sam Lee", Role: "Chair"},
+	}
+
+	data, count := buildPeopleOnlyWriteJSON(people)
+	require.Equal(t, 2, count, "should keep only the two real names")
+
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Len(t, out, 2)
+	assert.Equal(t, "Jane Roe", out[0]["name"])
+	assert.Equal(t, "CEO", out[0]["role"])
+	// snake_case keys must match the served parser (image_gcs_url/linkedin_url/source_type)
+	assert.Equal(t, "https://linkedin.com/in/janeroe", out[0]["linkedin_url"])
+	assert.Equal(t, "yahoo_finance", out[0]["source_type"])
+	assert.Equal(t, "Sam Lee", out[1]["name"])
+}
+
+func TestBuildPeopleOnlyWriteJSON_EmptyAndAllPlaceholders(t *testing.T) {
+	data, count := buildPeopleOnlyWriteJSON(nil)
+	assert.Nil(t, data)
+	assert.Equal(t, 0, count)
+
+	data, count = buildPeopleOnlyWriteJSON([]*stocksv1alpha1.CompanyPerson{
+		{Name: "John Doe"}, {Name: "N/A"}, {Name: "unknown"},
+	})
+	assert.Nil(t, data)
+	assert.Equal(t, 0, count, "all-placeholder input must yield nothing to write")
+}
+
+// guard: confirm the placeholder filter we rely on actually rejects "John Doe".
+func TestIsPlaceholderName_Sanity(t *testing.T) {
+	assert.True(t, enrichment.IsPlaceholderName("John Doe"))
+	assert.False(t, enrichment.IsPlaceholderName("Jane Roe"))
+}
+
+// §6.5 processJob: when the overall quality score is below the auto-approve gate, the
+// discovered key_people are still written via UpdateKeyPeopleIfEmpty (additive), while
+// ApplyEnrichment/ReviewEnrichment are NOT called and enrichment_status stays pending.
+func TestEnrichmentProcessor_ProcessJob_PeopleOnlyWriteBelowGate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := mocks.NewMockEnrichmentStore(ctrl)
+	mockGPTClient := mocks.NewMockGPTClient(ctrl)
+	mockReportCrawler := mocks.NewMockFinancialReportCrawler(ctrl)
+	mockMetadataScraper := mocks.NewMockCompanyMetadataScraper(ctrl)
+	mockLogoDiscoverer := mocks.NewMockLogoDiscoverer(ctrl)
+	mockExaClient := mocks.NewMockExaClient(ctrl)
+	logger := log.NewLogger()
+
+	processor := &enrichmentProcessor{
+		store:                mockStore,
+		gptClient:            mockGPTClient,
+		reportCrawler:        mockReportCrawler,
+		metadataScraper:      mockMetadataScraper,
+		logoDiscoverer:       mockLogoDiscoverer,
+		exaClient:            mockExaClient,
+		logger:               logger,
+		timeout:              10 * time.Minute,
+		qualityThreshold:     0.7,
+		autoApproveThreshold: 0.8,  // gate
+		writePeopleBelowGate: true, // §6.5 enabled
+		minPeopleWriteScore:  0.0,
+		gcsBucket:            "test-bucket",
+	}
+
+	jobID := "test-job-below-gate"
+	stockCode := "DMP"
+
+	stockDetails := &stocksv1alpha1.StockDetails{
+		ProductCode: stockCode, CompanyName: "Domino's Pizza", Industry: "Food & Beverages",
+		Website: "https://www.dominos.com.au", Summary: "Test summary", EnrichmentStatus: "pending",
+	}
+	scrapedMetadata := &enrichment.ScrapedMetadata{
+		AboutPages: []enrichment.AboutPage{{URL: "https://www.dominos.com.au/about", Title: "About Us"}},
+	}
+	reports := []*stocksv1alpha1.FinancialReport{{Type: "annual", Date: "2023"}}
+	// LLM returns >=1 real person, so the Phase-3a fallback is skipped.
+	enrichedData := &shortsv1alpha1.EnrichmentData{
+		EnhancedSummary: "Enhanced summary",
+		KeyPeople:       []*stocksv1alpha1.CompanyPerson{{Name: "Jane Roe", Role: "CEO"}},
+	}
+	// Below the 0.80 gate (the documented Yahoo-officer ~0.74 case).
+	qualityScore := &shortsv1alpha1.QualityScore{OverallScore: 0.74, Warnings: []string{}}
+	discoveredLogo := &enrichment.DiscoveredLogo{SourceURL: "https://x/logo.svg", Format: "svg", Width: 256, Height: 256, QualityScore: 0.9, SVGData: []byte("<svg/>")}
+
+	mockStore.EXPECT().UpdateEnrichmentJobStatus(jobID, shortsv1alpha1.EnrichmentJobStatus_ENRICHMENT_JOB_STATUS_PROCESSING, nil, nil).Return(nil)
+	mockStore.EXPECT().GetStockDetails(stockCode).Return(stockDetails, nil)
+	mockMetadataScraper.EXPECT().ScrapeMetadata(gomock.Any(), stockDetails.Website, stockDetails.CompanyName, mockExaClient).Return(scrapedMetadata, nil)
+	mockReportCrawler.EXPECT().CrawlFinancialReports(gomock.Any(), stockDetails.Website).Return(reports, nil)
+	mockGPTClient.EXPECT().EnrichCompany(gomock.Any(), stockCode, stockDetails.CompanyName, stockDetails.Industry, stockDetails.Website, stockDetails.Summary, reports, scrapedMetadata).Return(enrichedData, nil)
+	mockLogoDiscoverer.EXPECT().DiscoverLogo(gomock.Any(), stockDetails.Website, stockDetails.CompanyName, stockCode).Return(discoveredLogo, nil)
+	mockGPTClient.EXPECT().EvaluateQuality(gomock.Any(), stockCode, enrichedData).Return(qualityScore, nil)
+	mockStore.EXPECT().SavePendingEnrichment(gomock.Any(), stockCode, shortsv1alpha1.EnrichmentStatus_ENRICHMENT_STATUS_PENDING_REVIEW, enrichedData, qualityScore).Return("enrichment-id", nil)
+
+	// THE ASSERTION: people written additively below the gate, returning "wrote=true".
+	mockStore.EXPECT().UpdateKeyPeopleIfEmpty(stockCode, gomock.Any()).Return(true, nil)
+
+	// Job completes. ApplyEnrichment / ReviewEnrichment must NOT be called (no EXPECT → gomock fails if they are).
+	mockStore.EXPECT().UpdateEnrichmentJobStatus(jobID, shortsv1alpha1.EnrichmentJobStatus_ENRICHMENT_JOB_STATUS_COMPLETED, gomock.Any(), nil).Return(nil)
+
+	require.NoError(t, processor.processJob(context.Background(), jobID, stockCode, false))
+}

--- a/services/migrations/000053_director_extract_attempts.down.sql
+++ b/services/migrations/000053_director_extract_attempts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS director_extract_attempts;

--- a/services/migrations/000053_director_extract_attempts.up.sql
+++ b/services/migrations/000053_director_extract_attempts.up.sql
@@ -1,0 +1,18 @@
+-- §6.9 Failure-budget for the scheduled director-trade extractor.
+--
+-- extract_director_trades.py selects rows where extraction hasn't succeeded
+-- (director_name='Unknown Director' OR total_value IS NULL). Many Appendix 3Y PDFs
+-- never extract (older/expired ASX URLs, scanned PDFs), so without a marker the daily
+-- job re-attempts the same persistent failures every run, burning Gemini quota and never
+-- draining the queue. This table records each attempt so failed URLs are skipped for a
+-- cool-off window (--retry-after-days) while still allowing eventual re-tries (e.g. once
+-- §6.4 re-resolves 2024 URLs).
+CREATE TABLE IF NOT EXISTS director_extract_attempts (
+    announcement_url  TEXT PRIMARY KEY,
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    last_outcome      TEXT,
+    last_attempted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_director_extract_attempts_last
+    ON director_extract_attempts (last_attempted_at);

--- a/services/pkg/enrichment/store.go
+++ b/services/pkg/enrichment/store.go
@@ -59,4 +59,8 @@ type EnrichmentStore interface {
 	GetStocksForPeopleReenrichment(limit int, afterStockCode string) ([]StockPeopleData, error)
 	GetStocksForImageBackfill(limit int, afterStockCode string) ([]StockPeopleData, error)
 	UpdateKeyPeopleEnriched(stockCode string, keyPeopleJSON []byte) error
+	// UpdateKeyPeopleIfEmpty writes key_people ONLY when the served row currently has
+	// none (§6.5 additive people-only write, used when the whole-company quality score
+	// is below the auto-approve gate). Returns true when a row was actually written.
+	UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON []byte) (bool, error)
 }

--- a/services/report-extractor/Dockerfile
+++ b/services/report-extractor/Dockerfile
@@ -1,0 +1,27 @@
+# Report extractor — financial-report digests + director-trade (Appendix 3Y) extraction.
+# One image, TWO Cloud Run Jobs differentiated by the job's `command`/`args`:
+#   - financial-report-extractor: python extract_reports_concurrent.py ...
+#   - director-trade-extractor:    python extract_director_trades.py ...
+# Both import the sibling `extract` module, so all scripts live in the same WORKDIR.
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# pymupdf + psycopg2-binary wheels are usually prebuilt; gcc/g++ kept defensively.
+RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir --timeout 120 --retries 5 -r requirements.txt
+
+COPY . .
+
+RUN useradd -m -u 1001 appuser && chown -R appuser:appuser /app
+USER appuser
+
+# No locked CMD: each Cloud Run Job sets `command`/`args` to choose the script + flags.
+# `import extract` resolves because WORKDIR=/app holds extract.py + both entrypoints.
+ENTRYPOINT ["python"]

--- a/services/report-extractor/extract.py
+++ b/services/report-extractor/extract.py
@@ -128,6 +128,80 @@ FY2025 guidance: Revenue growth of 6-8% expected.""",
     ),
 ]
 
+# --- §6.3 Report selection: title-based noise filter ---------------------------
+# The ASX-announcement crawler types an announcement as a "results"/"report" via
+# substring matching on the headline (asx-announcement-crawler/main.go:
+# financialKeywords + classifyReportType). That over-classifies: a "Half Year
+# Results Media Release" or "Full Year Results — Chairman's Letter" is typed
+# half_year_results / full_year_results even though it carries no financial
+# statements. We keep presentations (they summarise well via the digest) but
+# drop hard non-statement noise here, on the *title*, regardless of `type`.
+NOISE_TITLE_PATTERNS = [
+    r"media release",
+    r"media announcement",
+    r"letter to (?:share|security)\s?holders",
+    r"chair(?:man|woman|person)?'?s? letter",
+    r"ceo'?s? letter",
+    r"letter from the chair",
+    r"chair(?:man|woman|person)?'?s? address",
+    r"ceo'?s? address",
+    r"address to (?:share|security)\s?holders",
+    r"agm address",
+    r"notice of (?:annual general )?meeting",
+    r"notice of agm",
+    r"proxy form",
+    r"cleansing (?:notice|statement)",
+    r"trading halt",
+    r"suspension (?:from|of) (?:quotation|trading)",
+    r"appendix 3[xyz]",
+    r"change (?:of|in) director'?s? interest",
+    r"director'?s? interest notice",
+    r"(?:becoming|ceasing).{0,30}substantial (?:holder|holding)",
+    r"change (?:in|to) substantial holding",
+    r"substantial (?:holder|holding) notice",
+    r"on-?market buy-?back",
+    r"buy-?back (?:notice|booklet)",
+]
+_NOISE_TITLE_RE = re.compile("|".join(NOISE_TITLE_PATTERNS), re.IGNORECASE)
+
+# Strong statement signals that ALWAYS win over the noise patterns. ASX filers
+# sometimes pack the statutory form name and an accompanying-press-release mention
+# into one headline ("Appendix 4E Full Year Results — Media Release"); the substring
+# noise match would wrongly drop it, so a keep-override is checked first.
+# Only HARD statutory document identifiers belong here — names a media release/letter
+# never carries. Deliberately NOT bare "results" (a "Full Year Results Media Release"
+# legitimately contains "results" yet is noise), so the override can't readmit noise.
+KEEP_OVERRIDE_PATTERNS = [
+    r"appendix 4[de]",
+    r"preliminary final report",
+    r"annual report",
+    r"(?:annual|half[\s-]?year|full[\s-]?year|interim) financial (?:report|statements)",
+    r"financial (?:report|statements)",
+    r"results announcement",
+]
+_KEEP_OVERRIDE_RE = re.compile("|".join(KEEP_OVERRIDE_PATTERNS), re.IGNORECASE)
+
+
+def is_financial_report_title(title: str) -> bool:
+    """Return False for headlines that are clearly NOT a financial statement/results
+    document (media releases, letters/addresses, notices of meeting, director/holder
+    notices, trading halts, buy-backs). Presentations are intentionally KEPT — they
+    summarise well and the digest is generated from raw text even without a metric table.
+
+    A strong statement signal (Appendix 4D/4E, "Financial Report", "Results
+    Announcement", "Half Year Results", …) overrides the noise patterns so a genuine
+    filing whose headline also mentions an accompanying media release is not dropped.
+
+    An empty/whitespace title is treated as acceptable (we can't judge it; the digest
+    step will still produce something useful).
+    """
+    if not title or not title.strip():
+        return True
+    if _KEEP_OVERRIDE_RE.search(title):
+        return True
+    return _NOISE_TITLE_RE.search(title) is None
+
+
 # ASX PDF download headers
 ASX_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
@@ -216,6 +290,12 @@ def get_reports_to_process(conn, mode: str, codes: list[str], limit: int, recent
                 "annual_report",
                 "financial_report",
             ):
+                continue
+            # §6.3(a) Drop non-statement noise (media releases, letters, notices,
+            # director/holder notices, halts) that the crawler mistyped as a report.
+            title = r.get("title", "")
+            if not is_financial_report_title(title):
+                log.debug("  skip noise title: %s (%s) %s", stock_code, rtype, title[:80])
                 continue
             reports.append(
                 {
@@ -390,9 +470,19 @@ def extractions_to_metrics(extractions: list[dict]) -> dict:
 
 DIGEST_MODEL = "gemini-2.5-flash"
 
-DIGEST_PROMPT = """You are summarising an ASX-listed company's financial report for a retail investor.
+# §6.3(b) The digest is generated from raw report text even when langextract finds
+# no structured metric table (most "results presentations" lack a clean table but
+# still state the headline numbers in prose). Give the model a wider text window so
+# it can find figures on its own, and tell it how to behave when metrics are empty.
+DIGEST_TEXT_CHARS = 16000
+MIN_DIGEST_CHARS = 400  # below this the PDF text is too thin to summarise meaningfully
+
+DIGEST_PROMPT = """You are summarising an ASX-listed company's financial report or results document for a retail investor.
 In 2-3 plain-English sentences, lead with the headline result (revenue and net profit direction with % change),
-then the dividend, then any guidance. Be concrete with the numbers from the metrics.
+then the dividend, then any guidance. Be concrete with the numbers.
+Prefer the figures in the extracted metrics JSON when present. If the metrics JSON is empty, read the figures
+directly from the report text excerpt. If the document states no financial results at all (e.g. it is a cover
+note or administrative document), set confidence below 0.3 and concisely summarise what the document covers.
 Output STRICT JSON: {"digest": "...", "confidence": 0.0-1.0, "key_takeaways": ["...", "..."]}"""
 
 
@@ -416,8 +506,9 @@ def summarize_report(metrics: dict, page_text: str, model_id: str = DIGEST_MODEL
 
     # Build context: structured metrics + truncated raw text
     metrics_json = json.dumps(metrics, indent=2)
-    # Limit page text to 8000 chars to stay well within token budget
-    truncated_text = page_text[:8000] if page_text else ""
+    # Limit page text to stay within token budget (wider window when there are no
+    # structured metrics, since the model must find the figures in prose itself).
+    truncated_text = page_text[:DIGEST_TEXT_CHARS] if page_text else ""
 
     user_content = (
         f"## Extracted metrics (JSON)\n{metrics_json}\n\n"
@@ -481,6 +572,29 @@ def upload_raw_text_to_gcs(stock_code: str, report_url: str, text: str) -> Optio
         return None
 
 
+def download_text_from_gcs(gcs_uri: str) -> Optional[str]:
+    """Fetch previously-stored raw page text from a gs:// URI (written by
+    upload_raw_text_to_gcs). Used by the digest backfill so it can re-summarise
+    existing rows without re-downloading the PDF — important because older (2024)
+    ASX announcement URLs no longer resolve. Returns None on any failure.
+    """
+    if not gcs_uri or not gcs_uri.startswith("gs://"):
+        return None
+    try:
+        from google.cloud import storage as gcs
+        without_scheme = gcs_uri[len("gs://"):]
+        bucket_name, _, blob_path = without_scheme.partition("/")
+        if not bucket_name or not blob_path:
+            return None
+        client = gcs.Client()
+        blob = client.bucket(bucket_name).blob(blob_path)
+        text = blob.download_as_text()
+        return text if text and text.strip() else None
+    except Exception as e:  # noqa: BLE001
+        log.debug("  GCS text fetch failed for %s: %s", gcs_uri, e)
+        return None
+
+
 def store_extraction(conn, report: dict, metrics: dict, raw_text_length: int, dry_run: bool = False, digest_result: Optional[dict] = None, raw_text_gcs_url: Optional[str] = None):
     """Store extraction results in the database."""
     if dry_run:
@@ -517,7 +631,9 @@ def store_extraction(conn, report: dict, metrics: dict, raw_text_length: int, dr
             raw_text_length,
             datetime.utcnow(),
             dr.get("digest") or None,
-            dr.get("confidence") if dr.get("confidence") is not None else None,
+            # Only persist confidence alongside an actual digest; a 0.0 from a failed
+            # digest call must stay NULL so it isn't confused with a genuine low-confidence one.
+            dr.get("confidence") if (dr.get("digest") and dr.get("confidence") is not None) else None,
             DIGEST_MODEL if dr.get("digest") else None,
             raw_text_gcs_url,
         ),
@@ -622,11 +738,19 @@ def main():
         # Step 2: Extract financial data with langextract
         extractions = extract_financial_data(text, report["stock_code"], model_id=args.model)
         if not extractions:
-            log.info("  No financial metrics found")
+            log.info("  No structured metrics found")
             total_processed += 1
-            # Still store empty result to mark as processed (no digest — nothing to summarise)
+            # §6.3(b) Decouple the digest from metric extraction: still summarise from
+            # raw text (most results presentations state numbers in prose, not tables).
+            digest_result = None
+            if len(text) >= MIN_DIGEST_CHARS:
+                log.info("  Generating digest from raw text (no metrics)...")
+                digest_result = summarize_report({}, text, model_id=args.model)
+                if digest_result.get("digest"):
+                    log.info("  Digest (confidence=%.2f): %.120s", digest_result["confidence"], digest_result["digest"])
+                    total_extracted += 1
             raw_text_gcs_url = upload_raw_text_to_gcs(report["stock_code"], report["url"], text)
-            store_extraction(conn, report, {}, len(text), args.dry_run, digest_result=None, raw_text_gcs_url=raw_text_gcs_url)
+            store_extraction(conn, report, {}, len(text), args.dry_run, digest_result=digest_result, raw_text_gcs_url=raw_text_gcs_url)
             continue
 
         # Step 3: Convert to structured metrics

--- a/services/report-extractor/extract_director_trades.py
+++ b/services/report-extractor/extract_director_trades.py
@@ -205,17 +205,29 @@ def derive_trade(parsed: dict) -> dict | None:
     }
 
 
-def select_urls(conn, priority: str, limit: int) -> list[dict]:
+def attempts_table_exists(conn) -> bool:
+    """Whether the §6.9 failure-budget marker table is present (migration 000053).
+    The script degrades gracefully when it isn't (no skip, no recording)."""
+    cur = conn.cursor()
+    cur.execute("SELECT to_regclass('public.director_extract_attempts')")
+    exists = cur.fetchone()[0] is not None
+    cur.close()
+    return exists
+
+
+def select_urls(conn, priority: str, limit: int, retry_after_days: int = 0) -> list[dict]:
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    base = """
-        SELECT DISTINCT ON (announcement_url)
-               announcement_url, stock_code, trade_date
-        FROM director_trades
-        WHERE announcement_url ~ '^https?://'
-          AND (director_name = 'Unknown Director' OR total_value IS NULL)
-    """
-    if priority == "unknown":
-        base += " AND director_name = 'Unknown Director'"
+    # §6.9 Skip URLs attempted within the cool-off window so the scheduled job converges
+    # instead of re-burning Gemini on the same persistent no_pdf/no_extract failures.
+    skip = ""
+    params: list = []
+    if retry_after_days > 0 and attempts_table_exists(conn):
+        skip = (
+            " AND NOT EXISTS (SELECT 1 FROM director_extract_attempts a "
+            "WHERE a.announcement_url = {col} "
+            "AND a.last_attempted_at > NOW() - make_interval(days => %s))"
+        )
+
     if priority == "top-shorted":
         base = """
             SELECT DISTINCT ON (dt.announcement_url)
@@ -225,13 +237,50 @@ def select_urls(conn, priority: str, limit: int) -> list[dict]:
             WHERE dt.announcement_url ~ '^https?://'
               AND (dt.director_name = 'Unknown Director' OR dt.total_value IS NULL)
         """
-    order_col = "trade_date" if priority == "top-shorted" else "trade_date"
-    base += f" ORDER BY announcement_url, {order_col} DESC" if priority != "top-shorted" \
-        else " ORDER BY dt.announcement_url, dt.trade_date DESC"
+        if skip:
+            base += skip.format(col="dt.announcement_url")
+            params.append(retry_after_days)
+        base += " ORDER BY dt.announcement_url, dt.trade_date DESC"
+    else:
+        base = """
+            SELECT DISTINCT ON (announcement_url)
+                   announcement_url, stock_code, trade_date
+            FROM director_trades
+            WHERE announcement_url ~ '^https?://'
+              AND (director_name = 'Unknown Director' OR total_value IS NULL)
+        """
+        if priority == "unknown":
+            base += " AND director_name = 'Unknown Director'"
+        if skip:
+            base += skip.format(col="director_trades.announcement_url")
+            params.append(retry_after_days)
+        base += " ORDER BY announcement_url, trade_date DESC"
+
     # Re-sort the de-duplicated set by recency and cap.
     outer = f"SELECT * FROM ({base}) s ORDER BY trade_date DESC LIMIT %s"
-    cur.execute(outer, (limit,))
+    params.append(limit)
+    cur.execute(outer, tuple(params))
     return [dict(r) for r in cur.fetchall()]
+
+
+def record_attempt(conn, url: str, outcome: str, lock: threading.Lock):
+    """Upsert the §6.9 failure-budget marker for a URL (no-op if the table is absent)."""
+    sql = """
+        INSERT INTO director_extract_attempts (announcement_url, attempts, last_outcome, last_attempted_at)
+        VALUES (%s, 1, %s, NOW())
+        ON CONFLICT (announcement_url) DO UPDATE SET
+            attempts = director_extract_attempts.attempts + 1,
+            last_outcome = EXCLUDED.last_outcome,
+            last_attempted_at = NOW()
+    """
+    with lock:
+        try:
+            cur = conn.cursor()
+            cur.execute(sql, (url, outcome))
+            conn.commit()
+            cur.close()
+        except psycopg2.Error:
+            conn.rollback()  # table missing / transient — never fail the run on the marker
 
 
 def update_trade(conn, url: str, d: dict, lock: threading.Lock, dry_run: bool):
@@ -257,7 +306,16 @@ def update_trade(conn, url: str, d: dict, lock: threading.Lock, dry_run: bool):
         conn.commit()
 
 
-def process_one(row: dict, conn, lock: threading.Lock, dry_run: bool) -> str:
+def process_one(row: dict, conn, lock: threading.Lock, dry_run: bool, record_attempts: bool) -> str:
+    url = row["announcement_url"]
+    outcome = _process_one_inner(row, conn, lock, dry_run)
+    # §6.9 Record the attempt (under lock) so persistent failures are skipped next run.
+    if record_attempts and not dry_run:
+        record_attempt(conn, url, outcome, lock)
+    return outcome
+
+
+def _process_one_inner(row: dict, conn, lock: threading.Lock, dry_run: bool) -> str:
     url = row["announcement_url"]
     text = extract.download_pdf_text(_session(), url, max_pages=4)
     if not text:
@@ -277,18 +335,24 @@ def main():
     ap.add_argument("--limit", type=int, default=200)
     ap.add_argument("--priority", choices=["recent", "unknown", "top-shorted"], default="recent")
     ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--retry-after-days", type=int, default=30,
+                    help="§6.9 skip URLs attempted within this many days (0=disable, retry everything)")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
     conn = extract.get_db_connection()
-    rows = select_urls(conn, args.priority, args.limit)
-    log.info("Director-trade extraction: %d PDFs to process (priority=%s)", len(rows), args.priority)
+    rows = select_urls(conn, args.priority, args.limit, retry_after_days=args.retry_after_days)
+    record_attempts = args.retry_after_days > 0 and attempts_table_exists(conn)
+    if args.retry_after_days > 0 and not record_attempts:
+        log.warning("director_extract_attempts table missing (apply migration 000053) — failure-budget disabled this run")
+    log.info("Director-trade extraction: %d PDFs to process (priority=%s, retry_after_days=%d)",
+             len(rows), args.priority, args.retry_after_days)
 
     lock = threading.Lock()
     counts: dict[str, int] = {}
     done = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
-        futs = {ex.submit(process_one, r, conn, lock, args.dry_run): r for r in rows}
+        futs = {ex.submit(process_one, r, conn, lock, args.dry_run, record_attempts): r for r in rows}
         for fut in concurrent.futures.as_completed(futs):
             try:
                 outcome = fut.result()

--- a/services/report-extractor/extract_director_trades.py
+++ b/services/report-extractor/extract_director_trades.py
@@ -79,6 +79,17 @@ def _session() -> requests.Session:
     return s
 
 
+def _conn():
+    """Thread-local DB connection. psycopg2 connections are NOT thread-safe, so each
+    worker gets its own — this removes the shared-connection + lock race where a failed
+    commit in one worker would poison another worker's transaction."""
+    c = getattr(_thread_local, "conn", None)
+    if c is None:
+        c = extract.get_db_connection()
+        _thread_local.conn = c
+    return c
+
+
 def _genai_client():
     """One genai client per thread (the SDK client is not guaranteed thread-safe)."""
     c = getattr(_thread_local, "genai", None)
@@ -263,8 +274,10 @@ def select_urls(conn, priority: str, limit: int, retry_after_days: int = 0) -> l
     return [dict(r) for r in cur.fetchall()]
 
 
-def record_attempt(conn, url: str, outcome: str, lock: threading.Lock):
-    """Upsert the §6.9 failure-budget marker for a URL (no-op if the table is absent)."""
+def record_attempt(url: str, outcome: str):
+    """Upsert the §6.9 failure-budget marker for a URL (no-op if the table is absent).
+    Uses the worker's thread-local connection."""
+    conn = _conn()
     sql = """
         INSERT INTO director_extract_attempts (announcement_url, attempts, last_outcome, last_attempted_at)
         VALUES (%s, 1, %s, NOW())
@@ -273,17 +286,16 @@ def record_attempt(conn, url: str, outcome: str, lock: threading.Lock):
             last_outcome = EXCLUDED.last_outcome,
             last_attempted_at = NOW()
     """
-    with lock:
-        try:
-            cur = conn.cursor()
-            cur.execute(sql, (url, outcome))
-            conn.commit()
-            cur.close()
-        except psycopg2.Error:
-            conn.rollback()  # table missing / transient — never fail the run on the marker
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, (url, outcome))
+        conn.commit()
+        cur.close()
+    except psycopg2.Error:
+        conn.rollback()  # table missing / transient — never fail the run on the marker
 
 
-def update_trade(conn, url: str, d: dict, lock: threading.Lock, dry_run: bool):
+def update_trade(url: str, d: dict, dry_run: bool):
     if dry_run:
         log.info("  [dry-run] %s -> %s %s shares=%s $%s conf=%.2f",
                  url[-40:], d["director_name"], d["trade_type"],
@@ -299,23 +311,28 @@ def update_trade(conn, url: str, d: dict, lock: threading.Lock, dry_run: bool):
             trade_date = COALESCE(%s::date, trade_date)
         WHERE announcement_url = %s
     """
-    with lock:
+    conn = _conn()
+    try:
         cur = conn.cursor()
         cur.execute(sql, (d["director_name"], d["trade_type"], d["shares_traded"],
                           d["total_value"], d["price_per_share"], d["trade_date"], url))
         conn.commit()
+        cur.close()
+    except psycopg2.Error:
+        conn.rollback()  # keep this worker's connection usable for the next row
+        raise
 
 
-def process_one(row: dict, conn, lock: threading.Lock, dry_run: bool, record_attempts: bool) -> str:
+def process_one(row: dict, dry_run: bool, record_attempts: bool) -> str:
     url = row["announcement_url"]
-    outcome = _process_one_inner(row, conn, lock, dry_run)
-    # §6.9 Record the attempt (under lock) so persistent failures are skipped next run.
+    outcome = _process_one_inner(row, dry_run)
+    # §6.9 Record the attempt so persistent failures are skipped next run.
     if record_attempts and not dry_run:
-        record_attempt(conn, url, outcome, lock)
+        record_attempt(url, outcome)
     return outcome
 
 
-def _process_one_inner(row: dict, conn, lock: threading.Lock, dry_run: bool) -> str:
+def _process_one_inner(row: dict, dry_run: bool) -> str:
     url = row["announcement_url"]
     text = extract.download_pdf_text(_session(), url, max_pages=4)
     if not text:
@@ -326,7 +343,7 @@ def _process_one_inner(row: dict, conn, lock: threading.Lock, dry_run: bool) -> 
     d = derive_trade(parsed)
     if not d:
         return "low_conf"
-    update_trade(conn, url, d, lock, dry_run)
+    update_trade(url, d, dry_run)
     return "ok"
 
 
@@ -348,11 +365,10 @@ def main():
     log.info("Director-trade extraction: %d PDFs to process (priority=%s, retry_after_days=%d)",
              len(rows), args.priority, args.retry_after_days)
 
-    lock = threading.Lock()
     counts: dict[str, int] = {}
     done = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
-        futs = {ex.submit(process_one, r, conn, lock, args.dry_run, record_attempts): r for r in rows}
+        futs = {ex.submit(process_one, r, args.dry_run, record_attempts): r for r in rows}
         for fut in concurrent.futures.as_completed(futs):
             try:
                 outcome = fut.result()

--- a/services/report-extractor/extract_reports_concurrent.py
+++ b/services/report-extractor/extract_reports_concurrent.py
@@ -6,9 +6,24 @@ but far too slow for the ~5k latest-reports-per-company backfill. This reuses
 extract.py's PDF + langextract + digest helpers under a ThreadPoolExecutor so the
 financial-digest coverage can be broadened from ~63 stocks to the whole market.
 
+Two modes:
+  (default)            select latest-N key reports per company that have NEVER been
+                       extracted, and run the full extract+digest pipeline.
+  --backfill-digests   §6.3(b): re-summarise rows ALREADY in
+                       financial_report_extractions that have digest IS NULL (the
+                       ~4,740 historical no-metrics rows). Prefers the raw text
+                       stored in GCS so it does not re-download (older 2024 ASX URLs
+                       no longer resolve); falls back to re-downloading the PDF.
+
 Run (against prod):
   DATABASE_URL=... GEMINI_API_KEY=... LANGEXTRACT_API_KEY=$GEMINI_API_KEY \
     python extract_reports_concurrent.py --recent 2 --limit 5000 --workers 8 [--top-shorted-first]
+  DATABASE_URL=... GEMINI_API_KEY=... \
+    python extract_reports_concurrent.py --backfill-digests --limit 5000 --workers 8 [--top-shorted-first]
+
+Threading note: each worker uses its own thread-local psycopg2 connection (psycopg2
+connections are not thread-safe). The main thread's connection is used only for the
+initial selection query.
 """
 from __future__ import annotations
 
@@ -38,21 +53,72 @@ def _session() -> requests.Session:
     return s
 
 
+def _conn():
+    """Thread-local DB connection. psycopg2 connections are NOT thread-safe, so each
+    worker thread gets its own (this removes the shared-connection + lock hazard)."""
+    c = getattr(_tl, "conn", None)
+    if c is None:
+        c = extract.get_db_connection()
+        _tl.conn = c
+    return c
+
+
+def _apply_top_shorted_order(conn, reports: list[dict], top_shorted_first: bool) -> list[dict]:
+    if not top_shorted_first:
+        return reports
+    cur = conn.cursor()
+    cur.execute("SELECT product_code, current_percent FROM mv_top_shorts")
+    rank = {code: pct for code, pct in cur.fetchall()}
+    cur.close()
+    reports.sort(key=lambda r: rank.get(r["stock_code"], -1), reverse=True)
+    return reports
+
+
 def select_reports(conn, recent: int, limit: int, top_shorted_first: bool) -> list[dict]:
     """Latest `recent` key financial reports per company, deduped vs already-extracted."""
     reports = extract.get_reports_to_process(conn, mode="all", codes=[], limit=0, recent=recent)
-    if top_shorted_first:
-        cur = conn.cursor()
-        cur.execute("SELECT product_code, current_percent FROM mv_top_shorts")
-        rank = {code: pct for code, pct in cur.fetchall()}
-        cur.close()
-        reports.sort(key=lambda r: rank.get(r["stock_code"], -1), reverse=True)
+    reports = _apply_top_shorted_order(conn, reports, top_shorted_first)
     if limit > 0:
         reports = reports[:limit]
     return reports
 
 
-def process(report: dict, conn, lock: threading.Lock, model: str, max_pages: int, dry_run: bool) -> str:
+def select_digestless_reports(conn, limit: int, top_shorted_first: bool) -> list[dict]:
+    """§6.3(b) Rows already extracted but with NO digest yet (the historical
+    no-metrics corpus). Carries the stored metrics + GCS text pointer so the digest
+    can be (re)generated without re-downloading the PDF."""
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    cur.execute(
+        """
+        SELECT stock_code, report_url, report_type, report_title,
+               report_date::text AS report_date, metrics::text AS metrics,
+               raw_text_length, raw_text_gcs_url
+        FROM financial_report_extractions
+        WHERE digest IS NULL
+        """
+    )
+    rows = [dict(r) for r in cur.fetchall()]
+    cur.close()
+    reports = [
+        {
+            "stock_code": r["stock_code"],
+            "url": r["report_url"],
+            "type": r["report_type"],
+            "title": r["report_title"] or "",
+            "date": r["report_date"],
+            "metrics": r["metrics"],
+            "raw_text_gcs_url": r["raw_text_gcs_url"],
+        }
+        for r in rows
+    ]
+    reports = _apply_top_shorted_order(conn, reports, top_shorted_first)
+    if limit > 0:
+        reports = reports[:limit]
+    return reports
+
+
+def process(report: dict, model: str, max_pages: int, dry_run: bool) -> str:
+    conn = _conn()
     text = extract.download_pdf_text(_session(), report["url"], max_pages=max_pages)
     if not text:
         return "no_pdf"
@@ -64,15 +130,51 @@ def process(report: dict, conn, lock: threading.Lock, model: str, max_pages: int
         gcs_url = None
 
     if not extractions:
-        with lock:
-            extract.store_extraction(conn, report, {}, len(text), dry_run, digest_result=None, raw_text_gcs_url=gcs_url)
-        return "no_metrics"
+        # §6.3(b) Decouple the digest from metric extraction: still summarise from raw
+        # text (most results presentations state numbers in prose, not tables).
+        digest = None
+        if len(text) >= extract.MIN_DIGEST_CHARS:
+            digest = extract.summarize_report({}, text, model_id=model)
+        extract.store_extraction(conn, report, {}, len(text), dry_run, digest_result=digest, raw_text_gcs_url=gcs_url)
+        return "digest_only" if (digest and digest.get("digest")) else "no_metrics"
 
     metrics = extract.extractions_to_metrics(extractions)
     digest = extract.summarize_report(metrics, text, model_id=model)
-    with lock:
-        extract.store_extraction(conn, report, metrics, len(text), dry_run, digest_result=digest, raw_text_gcs_url=gcs_url)
+    extract.store_extraction(conn, report, metrics, len(text), dry_run, digest_result=digest, raw_text_gcs_url=gcs_url)
     return "ok"
+
+
+def process_digestless(report: dict, model: str, max_pages: int, dry_run: bool) -> str:
+    """Re-summarise one already-extracted row that has no digest. Prefers stored GCS
+    text; only re-downloads the PDF if the text isn't in GCS."""
+    import json as _json
+
+    conn = _conn()
+    gcs_url = report.get("raw_text_gcs_url")
+    text = extract.download_text_from_gcs(gcs_url) if gcs_url else None
+    source = "gcs"
+    if not text:
+        text = extract.download_pdf_text(_session(), report["url"], max_pages=max_pages)
+        source = "pdf"
+        # Backfill the GCS pointer if we had to re-download.
+        if text and not gcs_url:
+            try:
+                gcs_url = extract.upload_raw_text_to_gcs(report["stock_code"], report["url"], text)
+            except Exception:  # noqa: BLE001
+                gcs_url = None
+    if not text or len(text) < extract.MIN_DIGEST_CHARS:
+        return "no_text"
+
+    try:
+        metrics = _json.loads(report.get("metrics") or "{}")
+    except (ValueError, TypeError):
+        metrics = {}
+
+    digest = extract.summarize_report(metrics, text, model_id=model)
+    if not (digest and digest.get("digest")):
+        return "no_digest"
+    extract.store_extraction(conn, report, metrics, len(text), dry_run, digest_result=digest, raw_text_gcs_url=gcs_url)
+    return f"ok_{source}"
 
 
 def main():
@@ -83,21 +185,29 @@ def main():
     ap.add_argument("--model", type=str, default="gemini-2.5-flash")
     ap.add_argument("--max-pages", type=int, default=10)
     ap.add_argument("--top-shorted-first", action="store_true")
+    ap.add_argument("--backfill-digests", action="store_true",
+                    help="§6.3(b): re-summarise existing rows with digest IS NULL (uses stored GCS text)")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
     conn = extract.get_db_connection()
-    reports = select_reports(conn, args.recent, args.limit, args.top_shorted_first)
-    log.info("Report backfill: %d reports to process (recent=%d, workers=%d)", len(reports), args.recent, args.workers)
+    if args.backfill_digests:
+        reports = select_digestless_reports(conn, args.limit, args.top_shorted_first)
+        worker = process_digestless
+        log.info("Digest backfill: %d rows with no digest (workers=%d)", len(reports), args.workers)
+    else:
+        reports = select_reports(conn, args.recent, args.limit, args.top_shorted_first)
+        worker = process
+        log.info("Report backfill: %d reports to process (recent=%d, workers=%d)", len(reports), args.recent, args.workers)
+
     if args.dry_run and reports:
         for r in reports[:10]:
-            log.info("  [dry-run] %s %s (%s) %s", r["stock_code"], r["title"][:50], r["type"], r["date"])
+            log.info("  [dry-run] %s %s (%s) %s", r["stock_code"], (r.get("title") or "")[:50], r.get("type"), r.get("date"))
 
-    lock = threading.Lock()
     counts: dict[str, int] = {}
     done = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
-        futs = {ex.submit(process, r, conn, lock, args.model, args.max_pages, args.dry_run): r for r in reports}
+        futs = {ex.submit(worker, r, args.model, args.max_pages, args.dry_run): r for r in reports}
         for fut in concurrent.futures.as_completed(futs):
             try:
                 outcome = fut.result()

--- a/services/report-extractor/extract_reports_concurrent.py
+++ b/services/report-extractor/extract_reports_concurrent.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Concurrent financial-report extraction backfill.
+
+extract.py's main() is sequential (--delay loop) — fine for a handful of stocks
+but far too slow for the ~5k latest-reports-per-company backfill. This reuses
+extract.py's PDF + langextract + digest helpers under a ThreadPoolExecutor so the
+financial-digest coverage can be broadened from ~63 stocks to the whole market.
+
+Run (against prod):
+  DATABASE_URL=... GEMINI_API_KEY=... LANGEXTRACT_API_KEY=$GEMINI_API_KEY \
+    python extract_reports_concurrent.py --recent 2 --limit 5000 --workers 8 [--top-shorted-first]
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import logging
+import threading
+
+import psycopg2
+import psycopg2.extras
+import requests
+
+import extract  # reuse helpers (import is side-effect-free)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("reports-backfill")
+
+_tl = threading.local()
+
+
+def _session() -> requests.Session:
+    s = getattr(_tl, "session", None)
+    if s is None:
+        s = requests.Session()
+        s.headers.update(extract.ASX_HEADERS)
+        _tl.session = s
+    return s
+
+
+def select_reports(conn, recent: int, limit: int, top_shorted_first: bool) -> list[dict]:
+    """Latest `recent` key financial reports per company, deduped vs already-extracted."""
+    reports = extract.get_reports_to_process(conn, mode="all", codes=[], limit=0, recent=recent)
+    if top_shorted_first:
+        cur = conn.cursor()
+        cur.execute("SELECT product_code, current_percent FROM mv_top_shorts")
+        rank = {code: pct for code, pct in cur.fetchall()}
+        cur.close()
+        reports.sort(key=lambda r: rank.get(r["stock_code"], -1), reverse=True)
+    if limit > 0:
+        reports = reports[:limit]
+    return reports
+
+
+def process(report: dict, conn, lock: threading.Lock, model: str, max_pages: int, dry_run: bool) -> str:
+    text = extract.download_pdf_text(_session(), report["url"], max_pages=max_pages)
+    if not text:
+        return "no_pdf"
+    extractions = extract.extract_financial_data(text, report["stock_code"], model_id=model)
+    # GCS upload is best-effort; never fail the report on it.
+    try:
+        gcs_url = extract.upload_raw_text_to_gcs(report["stock_code"], report["url"], text)
+    except Exception:  # noqa: BLE001
+        gcs_url = None
+
+    if not extractions:
+        with lock:
+            extract.store_extraction(conn, report, {}, len(text), dry_run, digest_result=None, raw_text_gcs_url=gcs_url)
+        return "no_metrics"
+
+    metrics = extract.extractions_to_metrics(extractions)
+    digest = extract.summarize_report(metrics, text, model_id=model)
+    with lock:
+        extract.store_extraction(conn, report, metrics, len(text), dry_run, digest_result=digest, raw_text_gcs_url=gcs_url)
+    return "ok"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--recent", type=int, default=2, help="latest N reports per company")
+    ap.add_argument("--limit", type=int, default=0, help="cap total reports (0=all)")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--model", type=str, default="gemini-2.5-flash")
+    ap.add_argument("--max-pages", type=int, default=10)
+    ap.add_argument("--top-shorted-first", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    conn = extract.get_db_connection()
+    reports = select_reports(conn, args.recent, args.limit, args.top_shorted_first)
+    log.info("Report backfill: %d reports to process (recent=%d, workers=%d)", len(reports), args.recent, args.workers)
+    if args.dry_run and reports:
+        for r in reports[:10]:
+            log.info("  [dry-run] %s %s (%s) %s", r["stock_code"], r["title"][:50], r["type"], r["date"])
+
+    lock = threading.Lock()
+    counts: dict[str, int] = {}
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(process, r, conn, lock, args.model, args.max_pages, args.dry_run): r for r in reports}
+        for fut in concurrent.futures.as_completed(futs):
+            try:
+                outcome = fut.result()
+            except Exception as e:  # noqa: BLE001
+                outcome = "error"
+                log.warning("  worker error: %s", e)
+            counts[outcome] = counts.get(outcome, 0) + 1
+            done += 1
+            if done % 50 == 0:
+                log.info("  progress %d/%d  %s", done, len(reports), counts)
+
+    log.info("DONE: %s", counts)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/report-extractor/test_extract.py
+++ b/services/report-extractor/test_extract.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for the report-extractor's §6.3 report-selection + digest changes.
+
+Focused on the pure logic that gates which announcements become financial-report
+digests (the title noise-filter) plus the digest constants. Heavy third-party deps
+(langextract, pymupdf, psycopg2, requests, google-genai) are stubbed when absent so
+the test runs locally; CI installs the real deps and uses them instead.
+
+Run:  python -m pytest test_extract.py -q     (or)   python test_extract.py
+"""
+import sys
+import types
+
+
+def _stub_missing_deps() -> None:
+    """Inject minimal stand-ins for heavy deps so `import extract` works locally.
+
+    Only used when the real module is not importable — CI uses the real libraries.
+    extract.py touches these at *module load*:
+      - langextract: lx.data.ExampleData(...) / lx.data.Extraction(...)
+      - the rest are only referenced inside functions, so bare module stubs suffice.
+    """
+    def _ensure(name: str, module: types.ModuleType) -> None:
+        try:
+            __import__(name)
+        except Exception:  # noqa: BLE001 - any import failure → use the stub
+            sys.modules[name] = module
+
+    # langextract with a `data` namespace exposing the two dataclass-like callables.
+    lx = types.ModuleType("langextract")
+    data = types.ModuleType("langextract.data")
+
+    class _Example:  # accepts whatever kwargs extract.py passes
+        def __init__(self, *args, **kwargs):
+            self.args, self.kwargs = args, kwargs
+
+    data.ExampleData = _Example
+    data.Extraction = _Example
+    lx.data = data
+    sys.modules.setdefault("langextract", lx) if "langextract" not in sys.modules else None
+    try:
+        __import__("langextract")
+    except Exception:  # noqa: BLE001
+        sys.modules["langextract"] = lx
+        sys.modules["langextract.data"] = data
+
+    _ensure("fitz", types.ModuleType("fitz"))
+    _ensure("psycopg2", types.ModuleType("psycopg2"))
+    _ensure("psycopg2.extras", types.ModuleType("psycopg2.extras"))
+    _ensure("requests", types.ModuleType("requests"))
+
+
+_stub_missing_deps()
+
+import extract  # noqa: E402
+
+
+# --- §6.3(a) title noise-filter ------------------------------------------------
+
+# Real-world headlines the ASX crawler over-classifies as results/reports.
+# These should be DROPPED (not surfaced as financial-report digests).
+NOISE_TITLES = [
+    "Half Year Results Media Release",
+    "FY24 Full Year Results - Media Announcement",
+    "Annual Results - Letter to Shareholders",
+    "Chairman's Letter",
+    "CEO Letter to Securityholders",
+    "Chairman's Address - Annual General Meeting",
+    "CEO Address",
+    "Notice of Annual General Meeting",
+    "Notice of Meeting and Proxy Form",
+    "Cleansing Notice",
+    "Trading Halt",
+    "Suspension from Quotation",
+    "Appendix 3Y - Change of Director's Interest",
+    "Change of Director's Interest Notice",
+    "Becoming a Substantial Holder",
+    "Ceasing to be a Substantial Holder",
+    "Change in Substantial Holding",
+    "On-Market Buy-Back Notice",
+    "Chairwoman's Letter",  # alternation must cover 'woman', not just 'man'/'person'
+]
+
+# Genuine financial statements/results AND presentations — these should be KEPT
+# (presentations are intentionally retained; the digest reads numbers from prose).
+KEEP_TITLES = [
+    "Appendix 4E and Full Year Financial Report",
+    "Appendix 4D and Half Year Report",
+    "Half Year Results Announcement",
+    "Annual Report 2024",
+    "Full Year Results Investor Presentation",
+    "Half Year Results Presentation",
+    "Preliminary Final Report",
+    "Annual Financial Report",
+    "FY24 Results Presentation",
+    # Compound titles: a genuine statutory filing whose headline ALSO mentions an
+    # accompanying media release/letter must survive (keep-override beats noise).
+    "Appendix 4E Full Year Results — Media Release",
+    "Appendix 4D and Half Year Report - Media Release",
+    "Half Year Financial Report and Chairman's Letter",
+    "",  # empty title → cannot judge → keep
+    "   ",
+]
+
+
+def test_noise_titles_are_dropped():
+    for title in NOISE_TITLES:
+        assert extract.is_financial_report_title(title) is False, f"should drop: {title!r}"
+
+
+def test_real_reports_and_presentations_are_kept():
+    for title in KEEP_TITLES:
+        assert extract.is_financial_report_title(title) is True, f"should keep: {title!r}"
+
+
+def test_presentation_is_not_treated_as_noise():
+    # Explicit guard for the design decision: presentations are KEPT.
+    assert extract.is_financial_report_title("Full Year Results Presentation") is True
+
+
+# --- §6.3(b) digest constants --------------------------------------------------
+
+def test_digest_window_widened_and_threshold_present():
+    # Lower bound: wide enough to find figures in prose. Upper bound: guard against a
+    # token/cost blow-up in the concurrent backfill (16k chars × N workers per batch).
+    assert 16000 <= extract.DIGEST_TEXT_CHARS <= 20000
+    assert extract.MIN_DIGEST_CHARS > 0
+    # Prompt must instruct the model to read figures from text when metrics are empty.
+    assert "metrics JSON is empty" in extract.DIGEST_PROMPT
+
+
+def test_keep_override_beats_noise_for_compound_titles():
+    # Explicit guard for the §6.3 review finding: a statutory form name overrides noise.
+    assert extract.is_financial_report_title("Appendix 4E Full Year Results — Media Release") is True
+    # Pure noise (no statutory signal) is still dropped.
+    assert extract.is_financial_report_title("Half Year Results Media Release") is False
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)

--- a/services/shorts/internal/services/shorts/event_timeline_test.go
+++ b/services/shorts/internal/services/shorts/event_timeline_test.go
@@ -21,7 +21,7 @@ func TestGetEventTimeline_HandlerReturnsEvents(t *testing.T) {
 	mockStore := mocks.NewMockShortsStore(ctrl)
 	// Lowercase input → handler normalizes to "BHP"
 	mockStore.EXPECT().
-		GetEventTimeline("BHP", int32(90), int32(50)).
+		GetEventTimeline("BHP", int32(365), int32(50)).
 		Return([]*shortsstore.TimelineEventRow{
 			{
 				Date:             "2026-06-15",
@@ -60,7 +60,7 @@ func TestGetEventTimeline_HandlerReturnsEvents(t *testing.T) {
 	srv := newTestServer(t, mockStore)
 	resp, err := srv.GetEventTimeline(context.Background(), connect.NewRequest(&shortsv1alpha1.GetEventTimelineRequest{
 		StockCode: "bhp",
-		// DaysBack and Limit at zero → handler applies defaults (90 and 50)
+		// DaysBack and Limit at zero → handler applies defaults (365 and 50)
 	}))
 
 	require.NoError(t, err)

--- a/services/shorts/internal/store/shorts/postgres.go
+++ b/services/shorts/internal/store/shorts/postgres.go
@@ -3176,7 +3176,6 @@ func (s *postgresStore) UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON [
 		    key_people IS NULL
 		    OR key_people = '[]'::jsonb
 		    OR jsonb_typeof(key_people) <> 'array'
-		    OR jsonb_array_length(key_people) = 0
 		  )
 	`
 

--- a/services/shorts/internal/store/shorts/postgres.go
+++ b/services/shorts/internal/store/shorts/postgres.go
@@ -3158,6 +3158,35 @@ func (s *postgresStore) UpdateKeyPeopleEnriched(stockCode string, keyPeopleJSON 
 	return nil
 }
 
+// UpdateKeyPeopleIfEmpty writes key_people ONLY when the served row currently has no
+// people (NULL / '[]' / empty array). This backs the §6.5 additive people-only write:
+// discovered leadership is served even when the whole-company quality score is below the
+// auto-approve gate, but an existing (higher-quality) people list is never clobbered.
+// It deliberately does NOT set key_people_enriched_at, leaving person-level photo/LinkedIn
+// backfill free to run later. Returns true when a row was actually updated.
+func (s *postgresStore) UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON []byte) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	query := `
+		UPDATE "company-metadata"
+		SET key_people = $1::jsonb
+		WHERE stock_code = $2
+		  AND (
+		    key_people IS NULL
+		    OR key_people = '[]'::jsonb
+		    OR jsonb_typeof(key_people) <> 'array'
+		    OR jsonb_array_length(key_people) = 0
+		  )
+	`
+
+	tag, err := s.db.Exec(ctx, query, string(keyPeopleJSON), stockCode)
+	if err != nil {
+		return false, fmt.Errorf("failed to conditionally update key_people for %s: %w", stockCode, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 // GetStocksForImageBackfill returns stocks that have people with LinkedIn URLs but no images.
 // Used with --backfill-images to fetch photos from authenticated LinkedIn sessions.
 func (s *postgresStore) GetStocksForImageBackfill(limit int, afterStockCode string) ([]StockPeopleBackfillRow, error) {

--- a/services/shorts/internal/store/shorts/store.go
+++ b/services/shorts/internal/store/shorts/store.go
@@ -113,6 +113,9 @@ type Store interface {
 	GetStocksForPeopleReenrichment(limit int, afterStockCode string) ([]StockPeopleBackfillRow, error)
 	GetStocksForImageBackfill(limit int, afterStockCode string) ([]StockPeopleBackfillRow, error)
 	UpdateKeyPeopleEnriched(stockCode string, keyPeopleJSON []byte) error
+	// UpdateKeyPeopleIfEmpty writes key_people only when the served row currently has
+	// none (§6.5 additive below-gate people write). Returns true when a row was written.
+	UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON []byte) (bool, error)
 
 	// News methods
 	GetStockNews(stockCode string, limit int32, source, sentiment string) ([]*NewsArticle, int, error)

--- a/services/shorts/pkg/store_factory.go
+++ b/services/shorts/pkg/store_factory.go
@@ -168,6 +168,10 @@ func (a *enrichmentStoreAdapter) UpdateKeyPeopleEnriched(stockCode string, keyPe
 	return a.store.UpdateKeyPeopleEnriched(stockCode, keyPeopleJSON)
 }
 
+func (a *enrichmentStoreAdapter) UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON []byte) (bool, error) {
+	return a.store.UpdateKeyPeopleIfEmpty(stockCode, keyPeopleJSON)
+}
+
 // Explicit interface check to ensure enrichmentStoreAdapter implements enrichment.EnrichmentStore
 var _ enrichment.EnrichmentStore = (*enrichmentStoreAdapter)(nil)
 

--- a/services/shorts/store_factory.go
+++ b/services/shorts/store_factory.go
@@ -172,6 +172,10 @@ func (a *enrichmentStoreAdapter) UpdateKeyPeopleIfEmpty(stockCode string, keyPeo
 	return a.store.UpdateKeyPeopleIfEmpty(stockCode, keyPeopleJSON)
 }
 
+// Compile-time guard that the adapter fully implements EnrichmentStore (mirrors the
+// check in shorts/pkg/store_factory.go).
+var _ enrichment.EnrichmentStore = (*enrichmentStoreAdapter)(nil)
+
 type ErrStoreCreationFailed struct{}
 
 func (e *ErrStoreCreationFailed) Error() string {

--- a/services/shorts/store_factory.go
+++ b/services/shorts/store_factory.go
@@ -168,6 +168,10 @@ func (a *enrichmentStoreAdapter) UpdateKeyPeopleEnriched(stockCode string, keyPe
 	return a.store.UpdateKeyPeopleEnriched(stockCode, keyPeopleJSON)
 }
 
+func (a *enrichmentStoreAdapter) UpdateKeyPeopleIfEmpty(stockCode string, keyPeopleJSON []byte) (bool, error) {
+	return a.store.UpdateKeyPeopleIfEmpty(stockCode, keyPeopleJSON)
+}
+
 type ErrStoreCreationFailed struct{}
 
 func (e *ErrStoreCreationFailed) Error() string {

--- a/services/signals-collector/Dockerfile
+++ b/services/signals-collector/Dockerfile
@@ -1,0 +1,24 @@
+# Signals collector — calls brandbrain ResolveBusinessSignals and upserts stock_signals.
+# Runs as a scheduled Cloud Run Job (scale-to-zero, no min instances).
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Only psycopg2-binary + requests are needed (brandbrain does the grounded research
+# server-side, so no Gemini/LLM deps here). gcc kept for any psycopg2 source fallback.
+RUN apt-get update && apt-get install -y --no-install-recommends gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir --timeout 120 --retries 5 -r requirements.txt
+
+COPY . .
+
+RUN useradd -m -u 1001 appuser && chown -R appuser:appuser /app
+USER appuser
+
+# Cloud Run Job supplies the flags via the job's `args`; this is the default entrypoint.
+ENTRYPOINT ["python", "collect.py"]

--- a/services/signals-collector/collect.py
+++ b/services/signals-collector/collect.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import threading
+import time
 
 import psycopg2
 import psycopg2.extras
@@ -84,21 +85,33 @@ def select_stocks(conn, priority: str, limit: int, max_age_days: int) -> list[di
     return [dict(r) for r in cur.fetchall()]
 
 
-def resolve_signals(company_name: str) -> dict | None:
-    """Call brandbrain ResolveBusinessSignals. Returns parsed response or None."""
-    try:
-        resp = _session().post(
-            BRANDBRAIN_URL,
-            data=json.dumps({"business_name": company_name, "state": ""}),
-            timeout=150,
-        )
-        if resp.status_code != 200:
+def resolve_signals(company_name: str, retries: int = 3) -> dict | None:
+    """Call brandbrain ResolveBusinessSignals with 5xx retry/backoff.
+
+    brandbrain runs on a single instance and 502s under concurrency, so retry
+    transient 5xx with exponential backoff (these grounded calls are slow).
+    """
+    for attempt in range(retries):
+        try:
+            resp = _session().post(
+                BRANDBRAIN_URL,
+                data=json.dumps({"business_name": company_name, "state": ""}),
+                timeout=180,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            if 500 <= resp.status_code < 600 and attempt < retries - 1:
+                time.sleep(2 ** attempt + attempt)  # 1s, 3s, 6s
+                continue
             log.warning("  brandbrain HTTP %d for %s", resp.status_code, company_name)
             return None
-        return resp.json()
-    except Exception as e:  # noqa: BLE001
-        log.warning("  brandbrain call failed for %s: %s", company_name, e)
-        return None
+        except Exception as e:  # noqa: BLE001
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt + attempt)
+                continue
+            log.warning("  brandbrain call failed for %s: %s", company_name, e)
+            return None
+    return None
 
 
 def _hash(stock_code: str, polarity: str, headline: str) -> str:

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -271,6 +271,35 @@ module "asx_announcement_crawler" {
   ]
 }
 
+# Signals collector — brandbrain risk/reputation signals (§6.9). Scale-to-zero job.
+module "signals_collector" {
+  source = "../../modules/signals-collector"
+
+  project_id       = var.project_id
+  region           = var.region
+  scheduler_region = "australia-southeast1"
+  environment      = "dev"
+  image_url        = var.signals_collector_image
+
+  depends_on = [
+  ]
+}
+
+# Report extractor — director-trade + financial-report digest jobs (§6.9). Scale-to-zero.
+module "report_extractor" {
+  source = "../../modules/report-extractor"
+
+  project_id           = var.project_id
+  region               = var.region
+  scheduler_region     = "australia-southeast1"
+  environment          = "dev"
+  image_url            = var.report_extractor_image
+  gemini_secret_exists = var.gemini_secret_exists
+
+  depends_on = [
+  ]
+}
+
 # =============================================================================
 # Cloudflare Edge — managed by environments/prod ONLY.
 # There is a single shorted.com.au zone; dev previously co-managed the same

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -94,6 +94,18 @@ variable "asx_announcement_crawler_image" {
   default     = "australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/asx-announcement-crawler:latest"
 }
 
+variable "signals_collector_image" {
+  description = "Docker image URL for the signals-collector job"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/signals-collector:latest"
+}
+
+variable "report_extractor_image" {
+  description = "Docker image URL shared by both report-extractor jobs"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/report-extractor:latest"
+}
+
 variable "chat_service_image" {
   description = "Docker image URL for chat-service"
   type        = string
@@ -138,7 +150,7 @@ variable "cloudflare_email" {
 variable "cloudflare_zone_id" {
   # Public DNS identifier for the single shorted.com.au zone (not a secret).
   # Defaulted so PR terraform-plan runs without tfvars — mirrors prod.
-  default = "41b338d2d75853d7bedb9a93f1e824f1"
+  default     = "41b338d2d75853d7bedb9a93f1e824f1"
   description = "Cloudflare Zone ID for shorted.com.au."
   type        = string
 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -146,7 +146,7 @@ module "stock_price_ingestion" {
   source = "../../modules/stock-price-ingestion"
 
   project_id       = var.project_id
-  region           = "us-central1" # Tier 1 pricing — batch job, latency irrelevant
+  region           = "us-central1"          # Tier 1 pricing — batch job, latency irrelevant
   scheduler_region = "australia-southeast1" # Cloud Scheduler only available in southeast1
   environment      = "production"
   image_url        = var.stock_price_ingestion_image
@@ -231,10 +231,10 @@ module "grafana_dashboards" {
 module "weekly_report_generator" {
   source = "../../modules/weekly-report-generator"
 
-  project_id       = var.project_id
-  region           = var.region
-  scheduler_region = "australia-southeast1" # Cloud Scheduler only available in southeast1
-  environment      = "production"
+  project_id           = var.project_id
+  region               = var.region
+  scheduler_region     = "australia-southeast1" # Cloud Scheduler only available in southeast1
+  environment          = "production"
   image_url            = var.weekly_report_generator_image
   gemini_secret_exists = false # GEMINI_API_KEY not yet provisioned in prod
 
@@ -289,7 +289,7 @@ module "market_discovery_sync" {
   source = "../../modules/market-discovery-sync"
 
   project_id             = var.project_id
-  region                 = "us-central1" # Tier 1 pricing — batch job, latency irrelevant
+  region                 = "us-central1"          # Tier 1 pricing — batch job, latency irrelevant
   scheduler_region       = "australia-southeast1" # Cloud Scheduler only available in southeast1
   environment            = "production"
   asx_discovery_image    = var.asx_discovery_image
@@ -336,6 +336,41 @@ module "asx_announcement_crawler" {
   ]
 }
 
+# Signals collector — brandbrain risk/reputation signals (§6.9). Scale-to-zero job.
+module "signals_collector" {
+  source = "../../modules/signals-collector"
+
+  project_id       = var.project_id
+  region           = var.region
+  scheduler_region = "australia-southeast1"
+  environment      = "production"
+  image_url        = var.signals_collector_image
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_artifact_registry_repository.shorted
+  ]
+}
+
+# Report extractor — director-trade + financial-report digest jobs (§6.9). Scale-to-zero.
+# gemini_secret_exists=false: GEMINI_API_KEY is not yet provisioned in prod, so both jobs
+# deploy but exit early until the secret exists (same posture as weekly-report-generator).
+module "report_extractor" {
+  source = "../../modules/report-extractor"
+
+  project_id           = var.project_id
+  region               = var.region
+  scheduler_region     = "australia-southeast1"
+  environment          = "production"
+  image_url            = var.report_extractor_image
+  gemini_secret_exists = false
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_artifact_registry_repository.shorted
+  ]
+}
+
 # =============================================================================
 # Cloudflare Edge — CDN, WAF, rate limiting, DNS
 # =============================================================================
@@ -343,15 +378,15 @@ module "asx_announcement_crawler" {
 module "edge" {
   source = "../../modules/cloudflare-edge"
 
-  cloudflare_zone_id   = var.cloudflare_zone_id
-  domain               = "api.shorted.com.au"
-  environment          = "production"
+  cloudflare_zone_id = var.cloudflare_zone_id
+  domain             = "api.shorted.com.au"
+  environment        = "production"
 
-  shorts_api_origin    = module.shorts_api.service_url
-  chat_service_origin  = module.chat_service.service_url
-  market_data_origin   = module.market_data.service_url
-  frontend_origin      = "https://shorted.com.au"
-  create_frontend_records = true   # Proxy frontend through Cloudflare edge for caching + rate limiting
+  shorts_api_origin       = module.shorts_api.service_url
+  chat_service_origin     = module.chat_service.service_url
+  market_data_origin      = module.market_data.service_url
+  frontend_origin         = "https://shorted.com.au"
+  create_frontend_records = true # Proxy frontend through Cloudflare edge for caching + rate limiting
 
   # AI crawler policy: allow AI bots (llms.txt / Content-Signals / MCP
   # discovery strategy). Token re-scoped with Bot Management Edit June 2026.
@@ -364,15 +399,15 @@ module "edge" {
   stock_data_cache_ttl = 120
   news_cache_ttl       = 300
 
-  rate_limit_enabled   = true
-  api_rate_limit_requests = 60
+  rate_limit_enabled         = true
+  api_rate_limit_requests    = 60
   search_rate_limit_requests = 20
 
   waf_enabled            = true
   bot_protection_enabled = true
 
-  cache_purge_secret     = var.cache_purge_secret
-  prewarm_secret         = var.cache_purge_secret  # reuse same shared secret for both worker bindings
+  cache_purge_secret = var.cache_purge_secret
+  prewarm_secret     = var.cache_purge_secret # reuse same shared secret for both worker bindings
 }
 
 output "edge_url" {

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -94,6 +94,18 @@ variable "asx_announcement_crawler_image" {
   default     = "australia-southeast2-docker.pkg.dev/rosy-clover-477102-t5/shorted/asx-announcement-crawler:latest"
 }
 
+variable "signals_collector_image" {
+  description = "Docker image URL for the signals-collector job"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/rosy-clover-477102-t5/shorted/signals-collector:latest"
+}
+
+variable "report_extractor_image" {
+  description = "Docker image URL shared by both report-extractor jobs"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/rosy-clover-477102-t5/shorted/report-extractor:latest"
+}
+
 variable "chat_service_image" {
   description = "Docker image URL for chat-service"
   type        = string

--- a/terraform/modules/report-extractor/main.tf
+++ b/terraform/modules/report-extractor/main.tf
@@ -1,0 +1,316 @@
+/**
+ * Report Extractor Module
+ *
+ * Manages TWO Cloud Run Jobs from ONE image (services/report-extractor):
+ *   - director-trade-extractor    (extract_director_trades.py): Appendix 3Y PDFs -> director_trades
+ *   - financial-report-extractor  (extract_reports_concurrent.py): report PDFs -> financial_report_extractions + digests
+ * Plus a shared service account, secret IAM (DATABASE_URL, OTEL, optional GEMINI_API_KEY),
+ * GCS write access for digest raw-text, and a Cloud Scheduler per job.
+ *
+ * Both scripts need a Gemini key (gemini-2.5-flash). In environments where the GEMINI_API_KEY
+ * secret does not yet exist (prod), set gemini_secret_exists=false — the jobs deploy but will
+ * exit early until the key is provisioned. Both are incremental/idempotent (skip already-
+ * extracted rows), so re-runs converge.
+ */
+
+locals {
+  labels = {
+    service     = "report-extractor"
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+resource "google_service_account" "report_extractor" {
+  account_id   = "report-extractor"
+  display_name = "Report Extractor"
+  description  = "Service account for the financial-report + director-trade extractors"
+  project      = var.project_id
+}
+
+resource "google_secret_manager_secret_iam_member" "database_url" {
+  secret_id = "DATABASE_URL"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.report_extractor.email}"
+  project   = var.project_id
+}
+
+resource "google_secret_manager_secret_iam_member" "otel_headers" {
+  secret_id = "OTEL_EXPORTER_OTLP_HEADERS"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.report_extractor.email}"
+  project   = var.project_id
+}
+
+# Optional — only when the GEMINI_API_KEY secret exists in this project.
+resource "google_secret_manager_secret_iam_member" "gemini_api_key" {
+  count     = var.gemini_secret_exists ? 1 : 0
+  secret_id = "GEMINI_API_KEY"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.report_extractor.email}"
+  project   = var.project_id
+}
+
+# Digest raw-text is uploaded to the reports bucket by extract_reports_concurrent.py.
+resource "google_storage_bucket_iam_member" "reports_bucket" {
+  bucket = var.reports_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.report_extractor.email}"
+}
+
+# ---------------------------------------------------------------------------
+# Job 1: director-trade-extractor  (extract_director_trades.py)
+# ---------------------------------------------------------------------------
+resource "google_cloud_run_v2_job" "director_trade_extractor" {
+  name     = "director-trade-extractor"
+  location = var.region
+  project  = var.project_id
+  labels   = local.labels
+
+  template {
+    task_count = 1
+    template {
+      service_account = google_service_account.report_extractor.email
+      max_retries     = 2
+      timeout         = "3600s"
+
+      containers {
+        image   = var.image_url
+        command = ["python", "extract_director_trades.py"]
+        args    = ["--priority", "recent", "--limit", tostring(var.director_limit), "--workers", "6"]
+
+        env {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = "DATABASE_URL"
+              version = "latest"
+            }
+          }
+        }
+        dynamic "env" {
+          for_each = var.gemini_secret_exists ? [1] : []
+          content {
+            name = "GEMINI_API_KEY"
+            value_source {
+              secret_key_ref {
+                secret  = "GEMINI_API_KEY"
+                version = "latest"
+              }
+            }
+          }
+        }
+        env {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.otel_endpoint
+        }
+        env {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "http/protobuf"
+        }
+        env {
+          name = "OTEL_EXPORTER_OTLP_HEADERS"
+          value_source {
+            secret_key_ref {
+              secret  = "OTEL_EXPORTER_OTLP_HEADERS"
+              version = "latest"
+            }
+          }
+        }
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.database_url,
+    google_secret_manager_secret_iam_member.otel_headers,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Job 2: financial-report-extractor  (extract_reports_concurrent.py)
+# ---------------------------------------------------------------------------
+resource "google_cloud_run_v2_job" "financial_report_extractor" {
+  name     = "financial-report-extractor"
+  location = var.region
+  project  = var.project_id
+  labels   = local.labels
+
+  template {
+    task_count = 1
+    template {
+      service_account = google_service_account.report_extractor.email
+      max_retries     = 2
+      timeout         = "3600s"
+
+      containers {
+        image   = var.image_url
+        command = ["python", "extract_reports_concurrent.py"]
+        args    = ["--recent", "2", "--limit", tostring(var.reports_limit), "--workers", "8", "--top-shorted-first"]
+
+        env {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = "DATABASE_URL"
+              version = "latest"
+            }
+          }
+        }
+        dynamic "env" {
+          for_each = var.gemini_secret_exists ? [1] : []
+          content {
+            name = "GEMINI_API_KEY"
+            value_source {
+              secret_key_ref {
+                secret  = "GEMINI_API_KEY"
+                version = "latest"
+              }
+            }
+          }
+        }
+        # langextract reads its key from LANGEXTRACT_API_KEY; mirror the Gemini key.
+        dynamic "env" {
+          for_each = var.gemini_secret_exists ? [1] : []
+          content {
+            name = "LANGEXTRACT_API_KEY"
+            value_source {
+              secret_key_ref {
+                secret  = "GEMINI_API_KEY"
+                version = "latest"
+              }
+            }
+          }
+        }
+        env {
+          name  = "GCS_REPORTS_BUCKET"
+          value = var.reports_bucket
+        }
+        env {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.otel_endpoint
+        }
+        env {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "http/protobuf"
+        }
+        env {
+          name = "OTEL_EXPORTER_OTLP_HEADERS"
+          value_source {
+            secret_key_ref {
+              secret  = "OTEL_EXPORTER_OTLP_HEADERS"
+              version = "latest"
+            }
+          }
+        }
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.database_url,
+    google_secret_manager_secret_iam_member.otel_headers,
+    google_storage_bucket_iam_member.reports_bucket,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Scheduling — shared invoker SA, one scheduler per job.
+# ---------------------------------------------------------------------------
+resource "google_service_account" "scheduler_invoker" {
+  account_id   = "report-extractor-sched"
+  display_name = "Report Extractor Scheduler"
+  description  = "Service account for Cloud Scheduler to invoke the report-extractor jobs"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_job_iam_member" "director_invoker" {
+  name     = google_cloud_run_v2_job.director_trade_extractor.name
+  location = google_cloud_run_v2_job.director_trade_extractor.location
+  project  = var.project_id
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "reports_invoker" {
+  name     = google_cloud_run_v2_job.financial_report_extractor.name
+  location = google_cloud_run_v2_job.financial_report_extractor.location
+  project  = var.project_id
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+# Director extractor — daily, chained after the asx-announcement-crawler (which runs
+# 11:00 UTC) populates new Appendix 3Y URLs. Runs 12:30 UTC.
+resource "google_cloud_scheduler_job" "director_trade_extractor" {
+  name             = "director-trade-extractor-daily"
+  description      = "Daily extraction of director trades from Appendix 3Y PDFs"
+  schedule         = var.director_schedule
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 1
+    min_backoff_duration = "30s"
+    max_backoff_duration = "1800s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.director_trade_extractor.name}:run"
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+  }
+
+  depends_on = [google_cloud_run_v2_job_iam_member.director_invoker]
+}
+
+# Financial-report extractor — weekly (Sundays 14:00 UTC).
+resource "google_cloud_scheduler_job" "financial_report_extractor" {
+  name             = "financial-report-extractor-weekly"
+  description      = "Weekly financial-report digest extraction (top-shorted first)"
+  schedule         = var.reports_schedule
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 1
+    min_backoff_duration = "30s"
+    max_backoff_duration = "1800s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.financial_report_extractor.name}:run"
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+  }
+
+  depends_on = [google_cloud_run_v2_job_iam_member.reports_invoker]
+}

--- a/terraform/modules/report-extractor/outputs.tf
+++ b/terraform/modules/report-extractor/outputs.tf
@@ -1,0 +1,22 @@
+output "director_job_name" {
+  description = "Name of the director-trade-extractor Cloud Run job"
+  value       = google_cloud_run_v2_job.director_trade_extractor.name
+}
+
+output "reports_job_name" {
+  description = "Name of the financial-report-extractor Cloud Run job"
+  value       = google_cloud_run_v2_job.financial_report_extractor.name
+}
+
+output "service_account_email" {
+  description = "Email of the shared job service account"
+  value       = google_service_account.report_extractor.email
+}
+
+output "director_scheduler_job_name" {
+  value = google_cloud_scheduler_job.director_trade_extractor.name
+}
+
+output "reports_scheduler_job_name" {
+  value = google_cloud_scheduler_job.financial_report_extractor.name
+}

--- a/terraform/modules/report-extractor/variables.tf
+++ b/terraform/modules/report-extractor/variables.tf
@@ -1,0 +1,69 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud Run jobs"
+  type        = string
+  default     = "australia-southeast2"
+}
+
+variable "scheduler_region" {
+  description = "GCP region for Cloud Scheduler (only australia-southeast1 is supported)"
+  type        = string
+  default     = "australia-southeast1"
+}
+
+variable "environment" {
+  description = "Environment name (development, staging, production)"
+  type        = string
+  default     = "production"
+}
+
+variable "image_url" {
+  description = "Docker image URL shared by both report-extractor jobs"
+  type        = string
+}
+
+variable "gemini_secret_exists" {
+  description = "Whether the GEMINI_API_KEY secret exists in this project (both jobs need it)"
+  type        = bool
+  default     = false
+}
+
+variable "reports_bucket" {
+  description = "GCS bucket for digest raw-text uploads (GCS_REPORTS_BUCKET)"
+  type        = string
+  default     = "shorted-financial-reports"
+}
+
+variable "director_limit" {
+  description = "Max director-trade PDFs to process per daily run"
+  type        = number
+  default     = 200
+}
+
+variable "reports_limit" {
+  description = "Max financial reports to process per weekly run"
+  type        = number
+  default     = 500
+}
+
+variable "director_schedule" {
+  description = "Cloud Scheduler cron (UTC) for the director extractor. Default: daily 12:30 UTC (after the announcement crawler)."
+  type        = string
+  default     = "30 12 * * *"
+}
+
+variable "reports_schedule" {
+  description = "Cloud Scheduler cron (UTC) for the financial-report extractor. Default: Sundays 14:00 UTC."
+  type        = string
+  default     = "0 14 * * 0"
+}
+
+variable "otel_endpoint" {
+  description = "OpenTelemetry OTLP endpoint for traces and metrics"
+  type        = string
+  default     = "https://otlp-gateway-prod-au-southeast-1.grafana.net/otlp"
+}

--- a/terraform/modules/signals-collector/main.tf
+++ b/terraform/modules/signals-collector/main.tf
@@ -1,0 +1,168 @@
+/**
+ * Signals Collector Module
+ *
+ * Manages:
+ * - Cloud Run Job that calls brandbrain ResolveBusinessSignals and upserts stock_signals
+ * - Service account and IAM permissions (DATABASE_URL + OTEL secrets)
+ * - Cloud Scheduler job (weekly)
+ *
+ * brandbrain runs on a single instance and 502s above ~2 concurrent grounded calls, so
+ * the job is pinned to --workers 2 with a bounded --limit per sweep. Raising throughput
+ * is gated on brandbrain horizontal scale (docs/enrichment-architecture.md §6.10).
+ */
+
+locals {
+  service_name = "signals-collector"
+  labels = {
+    service     = "signals-collector"
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+resource "google_service_account" "signals_collector" {
+  account_id   = local.service_name
+  display_name = "Signals Collector"
+  description  = "Service account for the brandbrain risk/reputation signals collector"
+  project      = var.project_id
+}
+
+resource "google_secret_manager_secret_iam_member" "database_url" {
+  secret_id = "DATABASE_URL"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.signals_collector.email}"
+  project   = var.project_id
+}
+
+resource "google_secret_manager_secret_iam_member" "otel_headers" {
+  secret_id = "OTEL_EXPORTER_OTLP_HEADERS"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.signals_collector.email}"
+  project   = var.project_id
+}
+
+resource "google_cloud_run_v2_job" "signals_collector" {
+  name     = local.service_name
+  location = var.region
+  project  = var.project_id
+
+  labels = local.labels
+
+  template {
+    task_count = 1
+
+    template {
+      service_account = google_service_account.signals_collector.email
+
+      max_retries = 2
+      timeout     = "3600s" # 1 hour; bounded --limit keeps a sweep well within this
+
+      containers {
+        image = var.image_url
+
+        # workers=2: brandbrain single-instance 502s above ~2 concurrent grounded calls.
+        args = ["--priority", "top-shorted", "--limit", tostring(var.sweep_limit), "--max-age-days", tostring(var.max_age_days), "--workers", "2"]
+
+        env {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+
+        env {
+          name  = "BRANDBRAIN_URL"
+          value = var.brandbrain_url
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = "DATABASE_URL"
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.otel_endpoint
+        }
+
+        env {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "http/protobuf"
+        }
+
+        env {
+          name = "OTEL_EXPORTER_OTLP_HEADERS"
+          value_source {
+            secret_key_ref {
+              secret  = "OTEL_EXPORTER_OTLP_HEADERS"
+              version = "latest"
+            }
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.database_url,
+    google_secret_manager_secret_iam_member.otel_headers,
+  ]
+}
+
+resource "google_service_account" "scheduler_invoker" {
+  account_id   = "${local.service_name}-sched"
+  display_name = "Signals Collector Scheduler"
+  description  = "Service account for Cloud Scheduler to invoke the signals collector"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
+  name     = google_cloud_run_v2_job.signals_collector.name
+  location = google_cloud_run_v2_job.signals_collector.location
+  project  = var.project_id
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+# Weekly — each sweep is expensive brandbrain-grounded research; skip-fresh (--max-age-days)
+# means most stocks are skipped between sweeps anyway.
+resource "google_cloud_scheduler_job" "signals_collector" {
+  name             = "${local.service_name}-weekly"
+  description      = "Weekly sweep of risk/reputation signals for top-shorted stocks via brandbrain"
+  schedule         = var.schedule
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "3600s"
+    min_backoff_duration = "30s"
+    max_backoff_duration = "1800s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.signals_collector.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+  }
+
+  depends_on = [
+    google_cloud_run_v2_job.signals_collector,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker
+  ]
+}

--- a/terraform/modules/signals-collector/outputs.tf
+++ b/terraform/modules/signals-collector/outputs.tf
@@ -1,0 +1,19 @@
+output "job_name" {
+  description = "Name of the Cloud Run job"
+  value       = google_cloud_run_v2_job.signals_collector.name
+}
+
+output "job_id" {
+  description = "Full resource ID of the Cloud Run job"
+  value       = google_cloud_run_v2_job.signals_collector.id
+}
+
+output "service_account_email" {
+  description = "Email of the job service account"
+  value       = google_service_account.signals_collector.email
+}
+
+output "scheduler_job_name" {
+  description = "Name of the Cloud Scheduler job"
+  value       = google_cloud_scheduler_job.signals_collector.name
+}

--- a/terraform/modules/signals-collector/variables.tf
+++ b/terraform/modules/signals-collector/variables.tf
@@ -1,0 +1,57 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud Run job"
+  type        = string
+  default     = "australia-southeast2"
+}
+
+variable "scheduler_region" {
+  description = "GCP region for Cloud Scheduler (only australia-southeast1 is supported)"
+  type        = string
+  default     = "australia-southeast1"
+}
+
+variable "environment" {
+  description = "Environment name (development, staging, production)"
+  type        = string
+  default     = "production"
+}
+
+variable "image_url" {
+  description = "Docker image URL for the signals-collector job"
+  type        = string
+}
+
+variable "brandbrain_url" {
+  description = "Base URL of the brandbrain DiscoveryService (Connect JSON)"
+  type        = string
+  default     = "https://api.brandbrain.dev"
+}
+
+variable "sweep_limit" {
+  description = "Max stocks to process per scheduled sweep (bounded to respect brandbrain capacity)"
+  type        = number
+  default     = 200
+}
+
+variable "max_age_days" {
+  description = "Skip stocks whose signals were fetched within this many days (skip-fresh)"
+  type        = number
+  default     = 30
+}
+
+variable "schedule" {
+  description = "Cloud Scheduler cron (UTC). Default: Mondays 13:00 UTC (11 PM AEST)."
+  type        = string
+  default     = "0 13 * * 1"
+}
+
+variable "otel_endpoint" {
+  description = "OpenTelemetry OTLP endpoint for traces and metrics"
+  type        = string
+  default     = "https://otlp-gateway-prod-au-southeast-1.grafana.net/otlp"
+}


### PR DESCRIPTION
Implements **§6.3, §6.5, §6.9** of `docs/enrichment-architecture.md` (ingestion/processing uplift). §6.7 deferred (see below). Stacked on #198 (`docs/enrichment-architecture`).

## What's in here

### §6.3 — financial-digest hit-rate (`report-extractor`)
- Title noise-filter (`is_financial_report_title`): drops media releases / letters / notices / holder & director-interest notices / halts / buy-backs that the ASX crawler mistypes as results, with **statutory keep-overrides** (Appendix 4D/4E, "Financial Report", "Results Announcement", "Annual Report") so compound titles like *"Appendix 4E Full Year Results — Media Release"* survive. **Presentations are kept** (they summarise well).
- **Decoupled the digest from langextract metrics** — a gemini digest is now generated from raw PDF text even with zero structured metrics, in both the sequential and concurrent paths.
- **`--backfill-digests` mode** to re-summarise the ~4,740 existing `digest=NULL` rows (prefers stored GCS text over re-downloading dead 2024 PDF URLs) — without it the decoupling was a no-op for the existing corpus.
- Thread-local DB connections (psycopg2 isn't thread-safe); `digest_confidence` stored NULL unless a digest was produced; new `test_extract.py`.

### §6.5 — write key_people below the auto-approve gate (`enrichment-processor`)
Yahoo-officer leadership scores ~0.74 (< 0.80 gate) so discovered people were staged and never served (top-shorted coverage stuck at 624/802). New **additive** `UpdateKeyPeopleIfEmpty` writes `key_people` to the served column **only when the row currently has none** (never clobbers), independent of the gate, env-toggled by `WRITE_PEOPLE_BELOW_GATE` (default on). `enrichment_status` is left pending so the rest stays gated. Wired through all store layers + mock; tests cover the below-gate path + full-flow regression.

### §6.9 — productionise the collectors
- `get_stock_signals` **chat tool** (the RPC/table/handler already existed).
- `signals-collector` + `report-extractor` containerised as **scale-to-zero Cloud Run jobs** (Dockerfiles + `terraform/modules/{signals-collector,report-extractor}`, wired dev+prod, CI build-matrix). **Python, not a Go rewrite** — deferred to §6.2.
- Migration **000053** `director_extract_attempts` failure-budget + `--retry-after-days` so the daily director job converges instead of re-burning Gemini on persistent 3Y-PDF failures.

### §6.7 — deferred (and a correction)
The job-monitoring stack is **not in the tree** (migrations jump 045→047; `pkg/jobstatus` is a broken stub). It lives only on unmerged `feat/job-monitoring` (f1b15079). Landing it (branch + manual prod migration + new coverage view) is its own effort — deferred.

## Verification
Two rounds of adversarial review; all confirmed findings fixed (the §6.5 `jsonb_array_length` throw-risk, the §6.9 shared-connection race, name-trimming, interface guard). `go vet ./...` + `go test ./...` green **except one pre-existing failure unrelated to this PR**: `TestGetEventTimeline_HandlerReturnsEvents` (daysBack 365-vs-90 drift in `internal/services/shorts`, untouched here — fails identically on the base). `terraform validate` passes; both images build; in-container `--help` works for all three entrypoints.

## Post-merge prod actions (need `ben@shorted.com.au` gcloud)
1. Apply migration **000053** to prod (manual psql).
2. Merge → CI `terraform apply` creates the 3 jobs + schedulers.
3. Provision prod **`GEMINI_API_KEY`** secret + flip `gemini_secret_exists=true` (the 2 report jobs exit early until then).
4. Realise the data gains: re-run enrichment with `WRITE_PEOPLE_BELOW_GATE=true` (fills the 178-stock key_people gap) and `extract_reports_concurrent.py --backfill-digests` (the 4,740 rows).
