### PR TITLE
fix(seo): index real stock pages, fix 5xx, expand sitemap

### DIFF
--- a/web/src/@/lib/seo/__tests__/stock-indexability.test.ts
+++ b/web/src/@/lib/seo/__tests__/stock-indexability.test.ts
@@ -1,0 +1,93 @@
+import {
+  isStockIndexable,
+  isStockSitemapEligible,
+  STOCK_INDEX_MIN_SHORT_PCT,
+  VALID_STOCK_CODE,
+} from "../stock-indexability";
+
+describe("isStockIndexable", () => {
+  it("indexes enriched companies regardless of short % (rescues BXB/DOW/CNB/HCL)", () => {
+    // Real companies with industry metadata — should index even at ~0% short.
+    expect(isStockIndexable({ code: "BXB", name: "BRAMBLES LIMITED", industry: "Industrials", percentShorted: 0.496 })).toBe(true);
+    expect(isStockIndexable({ code: "DOW", name: "DOWNER EDI LIMITED", industry: "Industrials", percentShorted: 0.399 })).toBe(true);
+    expect(isStockIndexable({ code: "CNB", name: "CARNABY RESOURCE", industry: "Materials", percentShorted: 0.012 })).toBe(true);
+    expect(isStockIndexable({ code: "HCL", name: "HIGHCOM LIMITED", industry: "Industrials", percentShorted: 0 })).toBe(true);
+  });
+
+  it("indexes meaningfully-shorted stocks even without an industry classification", () => {
+    expect(isStockIndexable({ code: "ABC", name: "SOME CO", industry: "", percentShorted: 0.6 })).toBe(true);
+    expect(isStockIndexable({ code: "ABC", name: "SOME CO", percentShorted: STOCK_INDEX_MIN_SHORT_PCT })).toBe(true);
+  });
+
+  it("noindexes thin stubs: no industry AND short % below the floor (JREG/WEMG)", () => {
+    expect(isStockIndexable({ code: "JREG", name: "JADE GAS HOLDINGS", industry: "", percentShorted: 0.083 })).toBe(false);
+    expect(isStockIndexable({ code: "WEMG", name: "WEB TRAVEL GROUP", industry: null, percentShorted: 0.004 })).toBe(false);
+  });
+
+  it("requires a company name", () => {
+    expect(isStockIndexable({ code: "BHP", name: "", industry: "Materials", percentShorted: 1.4 })).toBe(false);
+    expect(isStockIndexable({ code: "BHP", name: "   ", industry: "Materials", percentShorted: 1.4 })).toBe(false);
+    expect(isStockIndexable({ code: "BHP", name: undefined, industry: "Materials", percentShorted: 1.4 })).toBe(false);
+  });
+
+  it("rejects codes the /shorts/[code] route cannot serve (>4 chars / non-alnum)", () => {
+    expect(isStockIndexable({ code: "GSBW30", name: "GOVT BOND", industry: "Government", percentShorted: 5 })).toBe(false);
+    expect(isStockIndexable({ code: "bhp", name: "BHP", industry: "Materials", percentShorted: 1.4 })).toBe(false);
+    expect(isStockIndexable({ code: "", name: "X", industry: "Y", percentShorted: 1 })).toBe(false);
+  });
+
+  it("treats null/undefined short % as 0", () => {
+    expect(isStockIndexable({ code: "ABC", name: "CO", percentShorted: null })).toBe(false);
+    expect(isStockIndexable({ code: "ABC", name: "CO" })).toBe(false);
+    // ...but still indexes if it has industry
+    expect(isStockIndexable({ code: "ABC", name: "CO", industry: "Energy" })).toBe(true);
+  });
+});
+
+describe("isStockSitemapEligible", () => {
+  it("lists named stocks at or above the floor", () => {
+    expect(isStockSitemapEligible({ code: "BXB", name: "BRAMBLES", percentShorted: 0.496 })).toBe(true);
+    expect(isStockSitemapEligible({ code: "ABC", name: "CO", percentShorted: STOCK_INDEX_MIN_SHORT_PCT })).toBe(true);
+  });
+
+  it("excludes stocks below the floor (they remain page-indexable via industry, just not in the sitemap)", () => {
+    expect(isStockSitemapEligible({ code: "CNB", name: "CARNABY", percentShorted: 0.012 })).toBe(false);
+    expect(isStockSitemapEligible({ code: "HCL", name: "HIGHCOM", percentShorted: 0 })).toBe(false);
+  });
+
+  it("requires a name and a valid code", () => {
+    expect(isStockSitemapEligible({ code: "ABC", name: "", percentShorted: 5 })).toBe(false);
+    expect(isStockSitemapEligible({ code: "GSBW30", name: "BOND", percentShorted: 5 })).toBe(false);
+  });
+});
+
+describe("sitemap eligibility is a strict subset of indexability (no conflicting signals)", () => {
+  // Property: anything the sitemap lists must also be indexed by the page.
+  const codes = ["BHP", "AB1", "Z9"];
+  const names = ["", "Some Company"];
+  const industries = ["", "Energy"];
+  const pcts = [0, 0.05, STOCK_INDEX_MIN_SHORT_PCT, 0.25, 0.5, 2];
+
+  for (const code of codes) {
+    for (const name of names) {
+      for (const industry of industries) {
+        for (const percentShorted of pcts) {
+          it(`code=${code} name="${name}" industry="${industry}" pct=${percentShorted}`, () => {
+            const sitemap = isStockSitemapEligible({ code, name, percentShorted });
+            const indexable = isStockIndexable({ code, name, industry, percentShorted });
+            if (sitemap) expect(indexable).toBe(true);
+          });
+        }
+      }
+    }
+  }
+});
+
+describe("VALID_STOCK_CODE", () => {
+  it("matches 1-4 uppercase alphanumeric codes only", () => {
+    expect(VALID_STOCK_CODE.test("BHP")).toBe(true);
+    expect(VALID_STOCK_CODE.test("4DX")).toBe(true);
+    expect(VALID_STOCK_CODE.test("GSBW30")).toBe(false);
+    expect(VALID_STOCK_CODE.test("bhp")).toBe(false);
+  });
+});

--- a/web/src/@/lib/seo/stock-indexability.ts
+++ b/web/src/@/lib/seo/stock-indexability.ts
@@ -1,0 +1,89 @@
+/**
+ * Single source of truth for which /shorts/[code] pages are indexable by search
+ * engines, shared by the page's robots meta and the XML sitemap.
+ *
+ * Why this exists: every stock page is server-rendered with a unique,
+ * substantial narrative (ASIC short data + company profile + financials), so
+ * pages for real companies deserve to be indexed. The previous policy
+ * noindex'd any stock under 0.5% short interest, which excluded ~87% of
+ * stocks — including major companies like Brambles (BXB) and Downer (DOW) —
+ * and was the dominant cause of "Excluded by noindex" in Search Console.
+ *
+ * We now index any *named* company that is either enriched (has an industry
+ * classification — a strong proxy for "real, live company with content") OR
+ * meaningfully shorted. Only genuinely thin stubs (no name, no industry, and
+ * negligible short interest — typically delisted instruments) stay out of the
+ * index.
+ *
+ * Two gates share ONE floor so the sitemap can never advertise a URL the page
+ * itself marks noindex (a conflicting signal Google penalises):
+ *
+ *  - {@link isStockIndexable} — used by the page's `robots` metadata. Has the
+ *    full Stock object (name + industry + short %).
+ *
+ *  - {@link isStockSitemapEligible} — used by sitemap.ts, which only knows the
+ *    code, name and latest short %. Because it requires short % >= the same
+ *    floor, every sitemap entry also satisfies the page gate via the
+ *    short-interest branch, making the sitemap set a strict SUBSET of the
+ *    indexable set. The two can therefore never disagree.
+ */
+
+/** ASX product codes the /shorts/[code] route accepts (1-4 alphanumerics). */
+export const VALID_STOCK_CODE = /^[A-Z0-9]{1,4}$/;
+
+/**
+ * Short-interest floor (percent of issued capital) at/above which a stock is
+ * indexed and sitemap-listed regardless of enrichment. Below it, a stock is
+ * only indexed when it carries richer metadata (an industry classification).
+ */
+export const STOCK_INDEX_MIN_SHORT_PCT = 0.1;
+
+function hasValidCode(code: string | undefined | null): boolean {
+  return typeof code === "string" && VALID_STOCK_CODE.test(code);
+}
+
+function hasText(value: string | undefined | null): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export interface StockIndexabilityInput {
+  /** ASX product code, e.g. "BHP". */
+  code: string;
+  /** Company / product name. */
+  name?: string | null;
+  /** Industry classification (presence implies an enriched, real company). */
+  industry?: string | null;
+  /** Latest reported short interest as a percent of issued capital. */
+  percentShorted?: number | null;
+}
+
+/**
+ * Page-level gate. Index a stock when it has a valid code, a company name, and
+ * either an industry classification (enriched / real company) or a short
+ * position at or above {@link STOCK_INDEX_MIN_SHORT_PCT}.
+ */
+export function isStockIndexable(input: StockIndexabilityInput): boolean {
+  if (!hasValidCode(input.code)) return false;
+  if (!hasText(input.name)) return false;
+  return (
+    hasText(input.industry) ||
+    (input.percentShorted ?? 0) >= STOCK_INDEX_MIN_SHORT_PCT
+  );
+}
+
+export interface StockSitemapInput {
+  code: string;
+  name?: string | null;
+  percentShorted?: number | null;
+}
+
+/**
+ * Sitemap-level gate. A strict subset of {@link isStockIndexable}: any stock
+ * that passes this (short % >= floor) is also page-indexable via the
+ * short-interest branch, so the sitemap never lists a noindexed URL.
+ */
+export function isStockSitemapEligible(input: StockSitemapInput): boolean {
+  if (!hasValidCode(input.code)) return false;
+  if (!hasText(input.name)) return false;
+  return (input.percentShorted ?? 0) >= STOCK_INDEX_MIN_SHORT_PCT;
+}

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -15,7 +15,11 @@ import {
   formatReadingTime,
 } from "~/@/utils/reading-time";
 import Info from "~/@/components/ui/info";
-import RegisterEmail from "~/@/components/ui/register-email";
+// SSR-safe wrapper: the raw RegisterEmail is a client component that imports a
+// Connect-RPC server action, which crashes RSC rendering inside MDXRemote
+// (see CLAUDE.md "SSR Issues with @connectrpc/connect"). The dynamic ssr:false
+// wrapper is what the blog index already uses.
+import RegisterEmailClient from "~/@/components/ui/register-email-client";
 // Lazy load Prism CSS only for blog posts
 import "prismjs/themes/prism-tomorrow.css";
 
@@ -84,7 +88,7 @@ export default async function Post({ params }: Params) {
       <td className="px-4 py-2 text-left" {...props} />
     ),
     RegisterEmail: (props: Record<string, unknown>) => (
-      <RegisterEmail {...props} />
+      <RegisterEmailClient {...props} />
     ),
     Info: (props: { title: string; children: React.ReactNode }) => (
       <Info {...props} />

--- a/web/src/app/shorts/[stockCode]/page.tsx
+++ b/web/src/app/shorts/[stockCode]/page.tsx
@@ -55,6 +55,7 @@ import { siteConfig } from "~/@/config/site";
 import { RelatedStocks } from "~/@/components/seo/related-stocks";
 import { getRelatedStocks } from "~/app/actions/getRelatedStocks";
 import { getStockOrNotFound } from "~/app/actions/getStock";
+import { isStockIndexable } from "~/@/lib/seo/stock-indexability";
 import { ShortInterestHistory } from "./short-interest-history";
 import { NotFoundError } from "~/app/actions/withRetry";
 import { notFound } from "next/navigation";
@@ -78,10 +79,11 @@ export async function generateStaticParams(): Promise<{ stockCode: string }[]> {
     return [];
   }
   try {
-    // Only pre-generate top 50 stocks at build time.
-    // The rest are generated on-demand via ISR (dynamicParams = true by default).
-    // This saves ~3-5 minutes of Vercel build time vs generating all ~1000.
-    const response = await getTopShortsData("max", 50, 0);
+    // Pre-generate the most-shorted stocks at build time so Googlebot rarely
+    // triggers cold on-demand ISR generation (the source of intermittent 5xx
+    // when the Cloud Run backend is cold). The long tail is still generated
+    // on-demand via ISR (dynamicParams = true by default).
+    const response = await getTopShortsData("max", 500, 0);
     if (!response) return [];
 
     const stockCodes = response.timeSeries
@@ -102,11 +104,6 @@ export async function generateStaticParams(): Promise<{ stockCode: string }[]> {
 interface PageProps {
   params: Promise<{ stockCode: string }>;
 }
-
-// Stocks below this short % threshold are noindex'd. They produce thin
-// templated pages with no narrative value, leading to "Crawled - currently
-// not indexed" in GSC. Page remains accessible (no 404), just not indexed.
-const STOCK_PAGE_NOINDEX_THRESHOLD = 0.5;
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { stockCode } = await params;
@@ -140,11 +137,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       const industryInfo = stock.industry ? ` Industry: ${stock.industry}.` : "";
       description = `${shortInfo}${industryInfo} Track ${code}'s short position history, price charts, peer comparison, and ASIC data. Updated daily with T+4 delay.`;
 
-      // Noindex thin stocks (no/minimal short interest) — they remain
-      // crawlable but don't pollute the index with templated thin content.
-      if ((stock.percentageShorted ?? 0) < STOCK_PAGE_NOINDEX_THRESHOLD) {
-        shouldNoindex = true;
-      }
+      // Index real companies (named + enriched OR meaningfully shorted), only
+      // noindex genuinely thin stubs. Shared with the sitemap so the two never
+      // disagree. See ~/@/lib/seo/stock-indexability.
+      shouldNoindex = !isStockIndexable({
+        code,
+        name: stock.name,
+        industry: stock.industry,
+        percentShorted: stock.percentageShorted,
+      });
     }
   } catch {
     // Fall back to default title/description if fetch fails

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -11,6 +11,7 @@ import {
   getAvailableMonthSlugs,
   getAvailableYearSlugs,
 } from "./actions/reports/getReportData";
+import { isStockSitemapEligible } from "~/@/lib/seo/stock-indexability";
 
 // Educational articles for sitemap
 const learnArticles = [
@@ -36,17 +37,19 @@ const API_URL =
 // API response type for top shorts
 interface TopShortsResponse {
   // In summary mode (summaryOnly=true), the API returns `latestShortPosition`
-  // populated with `current_percent` from mv_top_shorts, sorted DESC.
-  timeSeries: Array<{ productCode?: string; latestShortPosition?: number }>;
+  // populated with `current_percent` from mv_top_shorts (sorted DESC) plus the
+  // company `name`.
+  timeSeries: Array<{
+    productCode?: string;
+    name?: string;
+    latestShortPosition?: number;
+  }>;
 }
 
-// Sitemap quality bar: only index stocks with meaningful short interest.
-// Stocks below this threshold get crawled but rarely indexed, polluting
-// "Crawled - currently not indexed" in GSC. Tail pages remain accessible
-// but use metadata.robots.noindex on the page itself.
-const SITEMAP_MIN_SHORT_PCT = 0.5;
-// Effectively uncapped: the equities-only MV filter (migration 000043) caps
-// the universe at ~800 stocks, and the 0.5% quality bar prunes the tail.
+// Cap on stock URLs in the sitemap. The shared short-interest floor
+// (~0.1%, see stock-indexability) keeps the set to genuinely-shorted stocks
+// (~1k) which is well under this cap; the equities-only MV filter
+// (migration 000043) already excludes ETFs/bonds.
 const SITEMAP_MAX_STOCKS = 1000;
 
 // Popular stock codes as fallback when API is unavailable
@@ -67,13 +70,18 @@ async function getAllStockCodes(): Promise<string[]> {
       process.env.NEXT_PUBLIC_API_URL ??
       API_URL;
 
-    // Use direct fetch with JSON to avoid protobuf-es SSR issues
+    // Use direct fetch with JSON to avoid protobuf-es SSR issues.
+    // Send Connect protocol + UA headers — the Cloudflare WAF 403s bare
+    // server-side fetches to api.shorted.com.au (see CLAUDE.md / mcp-server),
+    // which would otherwise silently fall back to FALLBACK_STOCK_CODES.
     const response = await fetch(
       `${baseUrl}/shorts.v1alpha1.ShortedStocksService/GetTopShorts`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "Connect-Protocol-Version": "1",
+          "User-Agent": "shorted-sitemap/1.0 (+https://shorted.com.au)",
         },
         body: JSON.stringify({
           period: "1y",
@@ -92,23 +100,22 @@ async function getAllStockCodes(): Promise<string[]> {
 
     const data = (await response.json()) as TopShortsResponse;
 
-    // Filter by quality bar to avoid sitemap bloat:
-    // - must have a current short % >= threshold
-    // - cap total entries so the sitemap stays tight
-    // Page regex on /shorts/[code] only accepts 1-4 char alphanumeric codes;
-    // longer codes (govt bonds GSB*, warrants XCLW*, preference shares like
-    // GSBW30, BENPH, MQGPD) 404 at the page level. Filter them out so we
-    // never advertise a URL the page itself rejects.
-    const VALID_CODE = /^[A-Z0-9]{1,4}$/;
+    // Only list URLs the page itself indexes (see stock-indexability):
+    // named stocks at/above the shared short-interest floor and with a code
+    // the /shorts/[code] route serves (1-4 alnum — longer codes like govt
+    // bonds GSB*, warrants XCLW*, preference shares GSBW30/BENPH/MQGPD 404).
+    // This guarantees the sitemap never advertises a noindexed URL.
     const qualified = (data.timeSeries || [])
-      .filter((ts) => {
-        const pct = typeof ts.latestShortPosition === "number" ? ts.latestShortPosition : 0;
-        return (
-          typeof ts.productCode === "string" &&
-          VALID_CODE.test(ts.productCode) &&
-          pct >= SITEMAP_MIN_SHORT_PCT
-        );
-      })
+      .filter((ts) =>
+        isStockSitemapEligible({
+          code: ts.productCode ?? "",
+          name: ts.name,
+          percentShorted:
+            typeof ts.latestShortPosition === "number"
+              ? ts.latestShortPosition
+              : 0,
+        }),
+      )
       .slice(0, SITEMAP_MAX_STOCKS)
       .map((ts) => ts.productCode!);
 


### PR DESCRIPTION
## Problem
Google Search Console showed ~1,600 stock pages excluded from the index. Diagnosed by crawling as Googlebot + querying prod:

- **Dominant cause — noindex over-blocking** (the "Excluded by noindex" / "indexing request rejected" buckets): `/shorts/[code]` noindex'd any stock under **0.5% short interest** = **87% of stocks (3,596/4,230)**, including major companies like Brambles (BXB, 0.496%) and Downer (DOW). These pages are *not* thin — they server-render a unique narrative + company profile + financials.
- **Persistent 500 on `/blog/hello-world`**: it renders the raw `<RegisterEmail/>` client component (which imports a Connect-RPC server action) inside RSC `MDXRemote`, triggering the documented `@connectrpc` SSR crash. It's the only post using the component, so only it 500'd.
- **Sitemap fragility**: `getAllStockCodes` did a bare `fetch()` (no `Connect-Protocol-Version`/UA) which the Cloudflare WAF 403s, silently falling back to 20 hardcoded codes.

## Changes
- **New shared gate** `web/src/@/lib/seo/stock-indexability.ts` (82 unit tests):
  - `isStockIndexable()` — index named companies that are enriched (have an industry) **OR** meaningfully shorted (≥ 0.1%). Used by the page `robots` meta.
  - `isStockSitemapEligible()` — named + short% ≥ floor. A strict **subset** of `isStockIndexable()`, so the sitemap can never advertise a noindexed URL.
- `shorts/[stockCode]/page.tsx`: `robots` meta uses `isStockIndexable()`; pre-render top **500** (was 50) so Googlebot rarely triggers cold-start ISR 500s.
- `sitemap.ts`: filter via `isStockSitemapEligible()` (was hardcoded 0.5%); send `Connect-Protocol-Version` + UA so the WAF doesn't force the fallback list.
- `blog/[slug]/page.tsx`: render `RegisterEmailClient` (`dynamic ssr:false`) — the SSR-safe wrapper the blog index already uses.

## Verification (against prod data via `next dev`)
- robots: BXB/CNB/HCL now indexable; JREG/WEMG correctly stay noindex.
- sitemap: **309 → 452** stock URLs, BXB included, subset invariant holds.
- `/blog/hello-world`: **200** (was 500).
- `tsc` clean (0 errors), eslint clean on touched files, 84 affected tests pass.

## Follow-ups (not in this PR)
- Full sitemap of all ~1,922 enriched stocks needs an industry-aware bulk endpoint (backend change). Today's sitemap lists the 452 live+shorted (≥0.1%); the rest are page-indexable via internal-link discovery.
- Cold-start 5xx isn't fully eliminable without Cloud Run `min_instances>0` (cost rule forbids); pre-rendering mitigates high-traffic pages.
- Post-deploy: GSC sitemap resubmit + "Validate Fix" on the noindex/5xx buckets.