### PR TITLE
fix(infra): drop crawler_hints zone setting (unblocks terraform apply)

### DIFF
--- a/terraform/modules/cloudflare-edge/main.tf
+++ b/terraform/modules/cloudflare-edge/main.tf
@@ -574,15 +574,12 @@ resource "cloudflare_zone_setting" "security_zero_rtt" {
   value      = "on"
 }
 
-# Crawler Hints: Cloudflare auto-emits IndexNow signals to Bing/Yandex when
-# content changes, so freshly-indexable stock pages get picked up faster on
-# those engines. (Google does not consume IndexNow; for Google we rely on the
-# sitemap + Search Console.)
-resource "cloudflare_zone_setting" "crawler_hints" {
-  zone_id    = var.cloudflare_zone_id
-  setting_id = "crawlhints"
-  value      = "on"
-}
+# NOTE: Crawler Hints (IndexNow for Bing/Yandex) is NOT settable via
+# cloudflare_zone_setting in provider v5 — the API rejects a PATCH with
+# setting_id="crawlhints" ("failed to make http request"), which broke
+# terraform apply. Enable it via the Cloudflare dashboard instead
+# (Caching → Configuration → Crawler Hints). Google does not consume IndexNow,
+# so this only affects Bing/Yandex; for Google we rely on the sitemap + GSC.
 
 resource "cloudflare_tiered_cache" "smart" {
   zone_id = var.cloudflare_zone_id


### PR DESCRIPTION
The `cloudflare_zone_setting` with `setting_id="crawlhints"` is rejected by the Cloudflare API under provider v5 ("failed to make http request" on PATCH) — it was the only fatal error left in the prod terraform apply after #203's GCP fixes landed (the cross-project bucket IAM + missing REVALIDATION_SECRET are resolved). Removing it lets apply complete so the backend `GetTopShorts` industry change deploys (→ sitemap expands to ~900). Crawler Hints (Bing/Yandex IndexNow; Google ignores it) can be enabled via the Cloudflare dashboard (Caching → Configuration → Crawler Hints).