### PR TITLE
feat(infra): enable event-driven cache revalidation

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -917,6 +917,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
           ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
+          REVALIDATION_SECRET: ${{ secrets.REVALIDATION_SECRET }}
         run: |
           # Only add a new version if the value has actually changed.
           # This prevents version bloat ($0.06/version/month — was costing $130+/month).
@@ -950,6 +951,10 @@ jobs:
           # Alpha Vantage (with placeholder fallback)
           AV_KEY="${ALPHA_VANTAGE_API_KEY:-placeholder-set-in-secret-manager}"
           ensure_secret "ALPHA_VANTAGE_API_KEY" "$AV_KEY"
+
+          # Revalidation secret (event-driven cache invalidation; must match the
+          # frontend Vercel REVALIDATION_SECRET env). Maintained from the GH secret.
+          ensure_secret "REVALIDATION_SECRET" "$REVALIDATION_SECRET"
 
           # Database secrets (environment-specific)
           if [ "$ENVIRONMENT" = "prod" ] && [ -n "$DATABASE_URL_PROD" ]; then

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -169,6 +169,9 @@ module "short_data_sync" {
   environment      = "production"
   image_url        = var.short_data_sync_image
   bucket_name      = "shorted-short-selling-data-prod" # Prod-specific bucket
+  # REVALIDATION_SECRET now exists in prod Secret Manager + the matching value
+  # is set in the Vercel frontend env, so enable event-driven cache busting.
+  manage_revalidation_secret = true
 
   depends_on = [
     google_project_service.required_apis,


### PR DESCRIPTION
Completes the dormant event-driven cache invalidation. REVALIDATION_SECRET is now provisioned in prod Secret Manager + Vercel frontend env (matching values) + GH Actions secret. This PR: maintains it via the ensure-secrets step, and flips `manage_revalidation_secret = true` so short-data-sync mounts it + pings `/api/revalidate` after each sync. Verified: secret exists in all three stores; `terraform validate` passes.