### PR TITLE
feat(admin): show sync status across all async jobs (GCP-native)

### DIFF
--- a/services/shorts/internal/jobmonitor/jobmonitor.go
+++ b/services/shorts/internal/jobmonitor/jobmonitor.go
@@ -1,0 +1,555 @@
+// Package jobmonitor reports the run status of every scheduled async job by
+// reading Google Cloud's own execution history — Cloud Run Jobs (executions)
+// and Cloud Scheduler (triggers) — rather than relying on each job to write a
+// row into a database table.
+//
+// This gives the /admin dashboard universal coverage of the whole fleet
+// (~16 scheduled triggers across ~9 jobs/services) with zero per-job
+// instrumentation: any job that exists in the project shows up automatically.
+//
+// All GCP reads are best-effort: a partial failure (e.g. one job's executions
+// cannot be listed) degrades that one entry rather than failing the whole call,
+// and a hard failure falls back to the last successfully cached result.
+package jobmonitor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	cloudscheduler "google.golang.org/api/cloudscheduler/v1"
+	"google.golang.org/api/option"
+	run "google.golang.org/api/run/v2"
+)
+
+// Health classifies a job's most recent run for at-a-glance dashboard colouring.
+type Health string
+
+const (
+	HealthOK       Health = "ok"
+	HealthRunning  Health = "running"
+	HealthWarning  Health = "warning" // succeeded but stale, or scheduler paused
+	HealthCritical Health = "critical"
+	HealthUnknown  Health = "unknown" // never run / no data
+)
+
+// JobStatus is the unified, source-agnostic status of a single scheduled job.
+type JobStatus struct {
+	Name            string  `json:"name"`
+	DisplayName     string  `json:"displayName"`
+	Category        string  `json:"category"`
+	Type            string  `json:"type"` // "job" (Cloud Run Job) | "service" (scheduler-triggered HTTP service)
+	Schedule        string  `json:"schedule"`
+	ScheduleHuman   string  `json:"scheduleHuman"`
+	SchedulerState  string  `json:"schedulerState"` // ENABLED | PAUSED | ""
+	LastRunAt       string  `json:"lastRunAt"`      // RFC3339, "" if never
+	LastRunStatus   string  `json:"lastRunStatus"`  // succeeded | failed | running | unknown | never
+	LastSuccessAt   string  `json:"lastSuccessAt"`
+	DurationSeconds float64 `json:"durationSeconds"`
+	SucceededCount  int64   `json:"succeededCount"`
+	FailedCount     int64   `json:"failedCount"`
+	RunningCount    int64   `json:"runningCount"`
+	ExecutionName   string  `json:"executionName"`
+	Message         string  `json:"message"`
+	LogUri          string  `json:"logUri"`
+	LastAttemptAt   string  `json:"lastAttemptAt"` // scheduler last trigger attempt
+	Health          Health  `json:"health"`
+}
+
+// Config controls which project/regions are queried.
+type Config struct {
+	ProjectID       string
+	RunRegion       string
+	SchedulerRegion string
+}
+
+// ConfigFromEnv resolves the project + regions from the environment, falling
+// back to the production defaults this service runs in.
+func ConfigFromEnv() Config {
+	project := firstNonEmpty(
+		os.Getenv("JOBS_GCP_PROJECT"),
+		os.Getenv("GOOGLE_CLOUD_PROJECT"),
+		os.Getenv("GCP_PROJECT_ID"),
+		os.Getenv("GOOGLE_CLOUD_PROJECT_ID"),
+	)
+	return Config{
+		ProjectID:       project,
+		RunRegion:       firstNonEmpty(os.Getenv("JOBS_RUN_REGION"), "australia-southeast2"),
+		SchedulerRegion: firstNonEmpty(os.Getenv("JOBS_SCHEDULER_REGION"), "australia-southeast1"),
+	}
+}
+
+// Collector lists job status with a short TTL cache so repeated dashboard loads
+// don't hammer the Cloud Run / Scheduler admin APIs.
+type Collector struct {
+	cfg Config
+	ttl time.Duration
+
+	mu       sync.Mutex
+	cached   []JobStatus
+	cachedAt time.Time
+}
+
+// NewCollector builds a Collector with a 60s cache TTL.
+func NewCollector(cfg Config) *Collector {
+	return &Collector{cfg: cfg, ttl: 60 * time.Second}
+}
+
+// Collect returns the unified job status list, served from cache when fresh.
+// On a hard error it returns the last cached result (if any) alongside the error
+// so callers can choose to serve stale data.
+func (c *Collector) Collect(ctx context.Context) ([]JobStatus, error) {
+	c.mu.Lock()
+	if c.cached != nil && time.Since(c.cachedAt) < c.ttl {
+		out := c.cached
+		c.mu.Unlock()
+		return out, nil
+	}
+	c.mu.Unlock()
+
+	fresh, err := collect(ctx, c.cfg)
+	if err != nil {
+		c.mu.Lock()
+		stale := c.cached
+		c.mu.Unlock()
+		if stale != nil {
+			return stale, err
+		}
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.cached = fresh
+	c.cachedAt = time.Now()
+	c.mu.Unlock()
+	return fresh, nil
+}
+
+// collect does the actual GCP queries and merge. Exported indirectly via Collect.
+// authOpts are applied to every client (used by tests to inject credentials).
+func collect(ctx context.Context, cfg Config, authOpts ...option.ClientOption) ([]JobStatus, error) {
+	if cfg.ProjectID == "" {
+		return nil, fmt.Errorf("jobmonitor: project ID not configured (set JOBS_GCP_PROJECT / GOOGLE_CLOUD_PROJECT)")
+	}
+
+	// --- Cloud Run Jobs (regional endpoint) ---
+	runOpts := append([]option.ClientOption{regionalRunEndpoint(cfg.RunRegion)}, authOpts...)
+	runSvc, err := run.NewService(ctx, runOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("jobmonitor: create run client: %w", err)
+	}
+
+	jobsParent := fmt.Sprintf("projects/%s/locations/%s", cfg.ProjectID, cfg.RunRegion)
+	jobsResp, err := runSvc.Projects.Locations.Jobs.List(jobsParent).PageSize(200).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("jobmonitor: list jobs: %w", err)
+	}
+
+	byName := map[string]*JobStatus{}
+	order := []string{}
+	for _, job := range jobsResp.Jobs {
+		name := basename(job.Name)
+		st := &JobStatus{
+			Name:          name,
+			DisplayName:   humanize(name),
+			Category:      categoryFor(name),
+			Type:          "job",
+			LastRunStatus: "never",
+			Health:        HealthUnknown,
+		}
+
+		// Latest executions for this job (best-effort).
+		execResp, execErr := runSvc.Projects.Locations.Jobs.Executions.
+			List(job.Name).PageSize(20).Context(ctx).Do()
+		if execErr == nil && execResp != nil && len(execResp.Executions) > 0 {
+			applyExecutions(st, execResp.Executions)
+		} else if job.LatestCreatedExecution != nil {
+			// Fall back to the reference embedded on the job itself.
+			st.ExecutionName = basename(job.LatestCreatedExecution.Name)
+			st.LastRunAt = firstNonEmpty(job.LatestCreatedExecution.CompletionTime, job.LatestCreatedExecution.CreateTime)
+			st.LastRunStatus = "unknown"
+		}
+
+		byName[name] = st
+		order = append(order, name)
+	}
+
+	// --- Cloud Scheduler triggers (global endpoint, regional parent) ---
+	schedSvc, schedErr := cloudscheduler.NewService(ctx, authOpts...)
+	if schedErr == nil {
+		schedParent := fmt.Sprintf("projects/%s/locations/%s", cfg.ProjectID, cfg.SchedulerRegion)
+		schedResp, listErr := schedSvc.Projects.Locations.Jobs.List(schedParent).PageSize(200).Context(ctx).Do()
+		if listErr == nil {
+			mergeSchedulers(byName, &order, schedResp.Jobs)
+		}
+	}
+
+	// Finalise health + assemble in stable order.
+	out := make([]JobStatus, 0, len(order))
+	for _, n := range order {
+		st := byName[n]
+		finalizeHealth(st)
+		out = append(out, *st)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		return healthRank(out[i].Health) < healthRank(out[j].Health)
+	})
+	return out, nil
+}
+
+// applyExecutions picks the newest execution for last-run status and scans for
+// the most recent successful one for the "last success" timestamp.
+func applyExecutions(st *JobStatus, execs []*run.GoogleCloudRunV2Execution) {
+	sort.SliceStable(execs, func(i, j int) bool {
+		return execStart(execs[i]) > execStart(execs[j]) // newest first
+	})
+
+	latest := execs[0]
+	st.ExecutionName = basename(latest.Name)
+	st.LastRunAt = firstNonEmpty(latest.StartTime, latest.CreateTime)
+	st.SucceededCount = latest.SucceededCount
+	st.FailedCount = latest.FailedCount
+	st.RunningCount = latest.RunningCount
+	st.LogUri = latest.LogUri
+	st.LastRunStatus = execStatus(latest)
+	if latest.CompletionTime != "" && latest.StartTime != "" {
+		if d := parseTime(latest.CompletionTime).Sub(parseTime(latest.StartTime)); d > 0 {
+			st.DurationSeconds = d.Seconds()
+		}
+	}
+	if msg := failureMessage(latest); msg != "" {
+		st.Message = msg
+	}
+
+	for _, e := range execs {
+		if execStatus(e) == "succeeded" {
+			st.LastSuccessAt = firstNonEmpty(e.CompletionTime, e.StartTime, e.CreateTime)
+			break
+		}
+	}
+}
+
+// mergeSchedulers attaches schedule/state to matching Cloud Run jobs and adds a
+// row for any scheduler trigger that targets a service rather than a job.
+func mergeSchedulers(byName map[string]*JobStatus, order *[]string, schedulers []*cloudscheduler.Job) {
+	// Stable order so "primary" selection is deterministic.
+	sort.SliceStable(schedulers, func(i, j int) bool {
+		return basename(schedulers[i].Name) < basename(schedulers[j].Name)
+	})
+
+	// Match scheduler -> run job by name prefix (e.g. "shorts-data-sync-daily" -> "shorts-data-sync").
+	runNames := make([]string, 0, len(byName))
+	for n := range byName {
+		runNames = append(runNames, n)
+	}
+	// Longest job name first so the most specific match wins.
+	sort.Slice(runNames, func(i, j int) bool { return len(runNames[i]) > len(runNames[j]) })
+
+	for _, sj := range schedulers {
+		sName := basename(sj.Name)
+		matched := ""
+		for _, rn := range runNames {
+			if sName == rn || strings.HasPrefix(sName, rn+"-") {
+				matched = rn
+				break
+			}
+		}
+
+		if matched != "" {
+			st := byName[matched]
+			// Prefer the trigger with the most recent attempt as the primary schedule.
+			if st.Schedule == "" || sj.LastAttemptTime > st.LastAttemptAt {
+				st.Schedule = sj.Schedule
+				st.ScheduleHuman = humanizeCron(sj.Schedule)
+				st.SchedulerState = sj.State
+			}
+			if sj.LastAttemptTime > st.LastAttemptAt {
+				st.LastAttemptAt = sj.LastAttemptTime
+			}
+			continue
+		}
+
+		// No matching Cloud Run Job: this scheduler triggers an HTTP service.
+		st := &JobStatus{
+			Name:           sName,
+			DisplayName:    humanize(sName),
+			Category:       categoryFor(sName),
+			Type:           "service",
+			Schedule:       sj.Schedule,
+			ScheduleHuman:  humanizeCron(sj.Schedule),
+			SchedulerState: sj.State,
+			LastAttemptAt:  sj.LastAttemptTime,
+			LastRunAt:      sj.LastAttemptTime,
+			LastRunStatus:  schedulerStatus(sj),
+			Health:         HealthUnknown,
+		}
+		if sj.Status != nil && sj.Status.Code != 0 {
+			st.Message = sj.Status.Message
+		}
+		if sj.LastAttemptTime != "" && st.LastRunStatus == "succeeded" {
+			st.LastSuccessAt = sj.LastAttemptTime
+		}
+		byName[sName] = st
+		*order = append(*order, sName)
+	}
+}
+
+// --- status helpers ---
+
+func execStatus(e *run.GoogleCloudRunV2Execution) string {
+	if e.RunningCount > 0 {
+		return "running"
+	}
+	if e.FailedCount > 0 {
+		return "failed"
+	}
+	if e.SucceededCount > 0 {
+		return "succeeded"
+	}
+	// Fall back to the Completed condition when counts are absent.
+	for _, c := range e.Conditions {
+		if c.Type == "Completed" {
+			switch c.State {
+			case "CONDITION_SUCCEEDED":
+				return "succeeded"
+			case "CONDITION_FAILED":
+				return "failed"
+			case "CONDITION_RECONCILING", "CONDITION_PENDING":
+				return "running"
+			}
+		}
+	}
+	return "unknown"
+}
+
+func failureMessage(e *run.GoogleCloudRunV2Execution) string {
+	for _, c := range e.Conditions {
+		if c.Type == "Completed" && c.State == "CONDITION_FAILED" {
+			if c.Message != "" {
+				return c.Message
+			}
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+// schedulerStatus maps a scheduler's last attempt status code to a run status.
+// Code 0 == OK (google.rpc.Code), non-zero == the last trigger failed.
+func schedulerStatus(sj *cloudscheduler.Job) string {
+	if sj.LastAttemptTime == "" {
+		return "never"
+	}
+	if sj.Status != nil && sj.Status.Code != 0 {
+		return "failed"
+	}
+	return "succeeded"
+}
+
+func finalizeHealth(st *JobStatus) {
+	if st.Health != "" && st.Health != HealthUnknown && st.LastRunStatus == "" {
+		return
+	}
+	switch st.LastRunStatus {
+	case "running":
+		st.Health = HealthRunning
+		// A run still "running" well past its expected duration is likely a
+		// stuck/zombie execution — surface it as a warning.
+		if t := parseTime(st.LastRunAt); !t.IsZero() && time.Since(t) > 90*time.Minute {
+			st.Health = HealthWarning
+			if st.Message == "" {
+				st.Message = "Running unusually long — may be stuck"
+			}
+		}
+	case "failed":
+		st.Health = HealthCritical
+	case "succeeded":
+		st.Health = HealthOK
+		if isStale(st) {
+			st.Health = HealthWarning
+		}
+	case "never", "unknown", "":
+		st.Health = HealthUnknown
+	default:
+		st.Health = HealthUnknown
+	}
+
+	// A paused trigger on an otherwise-ok job is worth surfacing.
+	if st.SchedulerState == "PAUSED" && st.Health == HealthOK {
+		st.Health = HealthWarning
+	}
+}
+
+// isStale flags a successful job whose last run is older than the expected
+// cadence (derived loosely from its cron) plus a grace margin.
+func isStale(st *JobStatus) bool {
+	ref := firstNonEmpty(st.LastSuccessAt, st.LastRunAt)
+	if ref == "" || st.Schedule == "" {
+		return false
+	}
+	last := parseTime(ref)
+	if last.IsZero() {
+		return false
+	}
+	gap := time.Since(last)
+	return gap > expectedMaxGap(st.Schedule)
+}
+
+// expectedMaxGap returns a generous upper bound on the interval between runs for
+// a cron expression. It is intentionally coarse: daily ~ 30h, weekly ~ 8d,
+// monthly ~ 32d, sub-daily ~ 3h.
+func expectedMaxGap(cron string) time.Duration {
+	fields := strings.Fields(cron)
+	if len(fields) < 5 {
+		return 36 * time.Hour
+	}
+	minute, hour, dom, _, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
+
+	if dom != "*" && dom != "?" {
+		return 32 * 24 * time.Hour // monthly-ish
+	}
+	if dow != "*" && dow != "?" {
+		// A range/list of weekdays (e.g. "1-5") runs multiple days a week but can
+		// still gap across a weekend (Fri -> Mon ~= 72h), so allow ~80h before
+		// calling it stale. A single weekday is a genuine weekly cadence.
+		if strings.ContainsAny(dow, ",-/") {
+			return 80 * time.Hour
+		}
+		return 8 * 24 * time.Hour // weekly
+	}
+	// Sub-hourly/hourly cadence: minute or hour contains a step.
+	if strings.Contains(hour, "/") || strings.Contains(minute, "/") || strings.Contains(hour, ",") {
+		return 3 * time.Hour
+	}
+	return 30 * time.Hour // daily
+}
+
+// --- formatting helpers ---
+
+func regionalRunEndpoint(region string) option.ClientOption {
+	return option.WithEndpoint(fmt.Sprintf("https://%s-run.googleapis.com/", region))
+}
+
+// humanizeCron turns common cron expressions into a short human label. Falls
+// back to the raw expression for anything it doesn't recognise.
+func humanizeCron(cron string) string {
+	fields := strings.Fields(cron)
+	if len(fields) < 5 {
+		return cron
+	}
+	minute, hour, dom, _, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
+	atTime := func() string {
+		if strings.ContainsAny(hour, "*/,") || strings.ContainsAny(minute, "*/,") {
+			return ""
+		}
+		return fmt.Sprintf(" at %02s:%02s", hour, minute)
+	}
+
+	switch {
+	case dom != "*" && dom != "?":
+		return "Monthly" + atTime()
+	case dow == "1-5":
+		return "Weekdays" + atTime()
+	case dow != "*" && dow != "?" && !strings.ContainsAny(dow, ",-/"):
+		return "Weekly (" + weekdayName(dow) + ")" + atTime()
+	case strings.Contains(hour, "/"):
+		return "Every " + strings.TrimPrefix(hour[strings.Index(hour, "/"):], "/") + "h"
+	case strings.Contains(minute, "/"):
+		return "Every " + strings.TrimPrefix(minute[strings.Index(minute, "/"):], "/") + "m"
+	default:
+		return "Daily" + atTime()
+	}
+}
+
+func weekdayName(dow string) string {
+	names := map[string]string{
+		"0": "Sun", "1": "Mon", "2": "Tue", "3": "Wed",
+		"4": "Thu", "5": "Fri", "6": "Sat", "7": "Sun",
+	}
+	if n, ok := names[dow]; ok {
+		return n
+	}
+	return dow
+}
+
+func basename(resource string) string {
+	if i := strings.LastIndex(resource, "/"); i >= 0 {
+		return resource[i+1:]
+	}
+	return resource
+}
+
+func humanize(name string) string {
+	parts := strings.FieldsFunc(name, func(r rune) bool { return r == '-' || r == '_' })
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func categoryFor(name string) string {
+	switch {
+	case strings.Contains(name, "short") || strings.Contains(name, "market-data") || strings.Contains(name, "stock-price") || strings.Contains(name, "key-metrics") || strings.Contains(name, "discovery"):
+		return "Market data"
+	case strings.Contains(name, "news"):
+		return "News"
+	case strings.Contains(name, "report") || strings.Contains(name, "director") || strings.Contains(name, "announcement") || strings.Contains(name, "financial"):
+		return "Filings & reports"
+	case strings.Contains(name, "signal"):
+		return "Signals"
+	default:
+		return "Other"
+	}
+}
+
+func execStart(e *run.GoogleCloudRunV2Execution) string {
+	return firstNonEmpty(e.StartTime, e.CreateTime)
+}
+
+func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			return time.Time{}
+		}
+	}
+	return t
+}
+
+func healthRank(h Health) int {
+	switch h {
+	case HealthCritical:
+		return 0
+	case HealthWarning:
+		return 1
+	case HealthRunning:
+		return 2
+	case HealthUnknown:
+		return 3
+	case HealthOK:
+		return 4
+	default:
+		return 5
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/services/shorts/internal/jobmonitor/jobmonitor_test.go
+++ b/services/shorts/internal/jobmonitor/jobmonitor_test.go
@@ -1,0 +1,215 @@
+package jobmonitor
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+	cloudscheduler "google.golang.org/api/cloudscheduler/v1"
+	"google.golang.org/api/option"
+	run "google.golang.org/api/run/v2"
+)
+
+func TestExpectedMaxGap(t *testing.T) {
+	cases := []struct {
+		cron string
+		max  time.Duration
+	}{
+		{"0 10 * * *", 30 * time.Hour},     // daily
+		{"0 8 * * 1-5", 80 * time.Hour},    // weekdays (weekend gap allowed)
+		{"0 13 * * 1", 8 * 24 * time.Hour}, // weekly (single DOW)
+		{"0 1 1 * *", 32 * 24 * time.Hour}, // monthly (DOM set)
+		{"30 */2 * * *", 3 * time.Hour},    // every 2h
+		{"garbage", 36 * time.Hour},        // unparseable
+	}
+	for _, c := range cases {
+		if got := expectedMaxGap(c.cron); got != c.max {
+			t.Errorf("expectedMaxGap(%q) = %v, want %v", c.cron, got, c.max)
+		}
+	}
+}
+
+func TestHumanizeCron(t *testing.T) {
+	cases := map[string]string{
+		"0 10 * * *":   "Daily at 10:00",
+		"0 8 * * 1-5":  "Weekdays at 08:00",
+		"0 13 * * 1":   "Weekly (Mon) at 13:00",
+		"0 1 1 * *":    "Monthly at 01:00",
+		"30 */2 * * *": "Every 2h",
+	}
+	for cron, want := range cases {
+		if got := humanizeCron(cron); got != want {
+			t.Errorf("humanizeCron(%q) = %q, want %q", cron, got, want)
+		}
+	}
+}
+
+func TestExecStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		exec *run.GoogleCloudRunV2Execution
+		want string
+	}{
+		{"succeeded", &run.GoogleCloudRunV2Execution{SucceededCount: 1}, "succeeded"},
+		{"failed", &run.GoogleCloudRunV2Execution{FailedCount: 1}, "failed"},
+		{"running", &run.GoogleCloudRunV2Execution{RunningCount: 1}, "running"},
+		{"failed-takes-priority-over-succeeded", &run.GoogleCloudRunV2Execution{SucceededCount: 1, FailedCount: 1}, "failed"},
+		{"running-takes-priority", &run.GoogleCloudRunV2Execution{RunningCount: 1, FailedCount: 1}, "running"},
+		{"condition-fallback-succeeded", &run.GoogleCloudRunV2Execution{
+			Conditions: []*run.GoogleCloudRunV2Condition{{Type: "Completed", State: "CONDITION_SUCCEEDED"}},
+		}, "succeeded"},
+		{"condition-fallback-failed", &run.GoogleCloudRunV2Execution{
+			Conditions: []*run.GoogleCloudRunV2Condition{{Type: "Completed", State: "CONDITION_FAILED"}},
+		}, "failed"},
+		{"empty", &run.GoogleCloudRunV2Execution{}, "unknown"},
+	}
+	for _, c := range cases {
+		if got := execStatus(c.exec); got != c.want {
+			t.Errorf("%s: execStatus = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestApplyExecutionsPicksNewestAndLastSuccess(t *testing.T) {
+	st := &JobStatus{Name: "x"}
+	execs := []*run.GoogleCloudRunV2Execution{
+		{Name: "p/old-success", StartTime: "2026-06-19T10:00:00Z", CompletionTime: "2026-06-19T10:05:00Z", SucceededCount: 1},
+		{Name: "p/newest-failed", StartTime: "2026-06-21T10:00:00Z", CompletionTime: "2026-06-21T10:01:00Z", FailedCount: 1},
+		{Name: "p/mid-success", StartTime: "2026-06-20T10:00:00Z", CompletionTime: "2026-06-20T10:06:00Z", SucceededCount: 1},
+	}
+	applyExecutions(st, execs)
+
+	if st.ExecutionName != "newest-failed" {
+		t.Errorf("latest exec = %q, want newest-failed", st.ExecutionName)
+	}
+	if st.LastRunStatus != "failed" {
+		t.Errorf("LastRunStatus = %q, want failed", st.LastRunStatus)
+	}
+	// last success should be the most recent succeeded one (mid-success, 06-20).
+	if st.LastSuccessAt != "2026-06-20T10:06:00Z" {
+		t.Errorf("LastSuccessAt = %q, want 2026-06-20T10:06:00Z", st.LastSuccessAt)
+	}
+	if st.DurationSeconds != 60 {
+		t.Errorf("DurationSeconds = %v, want 60", st.DurationSeconds)
+	}
+}
+
+func TestMergeSchedulers(t *testing.T) {
+	byName := map[string]*JobStatus{
+		"shorts-data-sync": {Name: "shorts-data-sync", Type: "job"},
+		"news-aggregator":  {Name: "news-aggregator", Type: "job"},
+	}
+	order := []string{"shorts-data-sync", "news-aggregator"}
+
+	schedulers := []*cloudscheduler.Job{
+		{Name: "p/l/jobs/shorts-data-sync-daily", Schedule: "0 10 * * *", State: "ENABLED", LastAttemptTime: "2026-06-21T10:00:00Z"},
+		{Name: "p/l/jobs/news-aggregator-periodic", Schedule: "0 */4 * * *", State: "ENABLED", LastAttemptTime: "2026-06-22T04:00:00Z"},
+		{Name: "p/l/jobs/news-aggregator-cluster", Schedule: "30 */2 * * *", State: "ENABLED", LastAttemptTime: "2026-06-22T04:30:00Z"},
+		// Service-triggered (no matching run job):
+		{Name: "p/l/jobs/market-data-sync-daily", Schedule: "0 10 * * 1-5", State: "ENABLED", LastAttemptTime: "2026-06-19T10:00:00Z"},
+	}
+
+	mergeSchedulers(byName, &order, schedulers)
+
+	// Matched job gets a schedule.
+	if byName["shorts-data-sync"].Schedule != "0 10 * * *" {
+		t.Errorf("shorts-data-sync schedule = %q", byName["shorts-data-sync"].Schedule)
+	}
+	// News had two triggers; primary is the most recent attempt (cluster @ 04:30).
+	if byName["news-aggregator"].Schedule != "30 */2 * * *" {
+		t.Errorf("news-aggregator primary schedule = %q, want cluster", byName["news-aggregator"].Schedule)
+	}
+	// Service-triggered scheduler becomes its own entry.
+	mds, ok := byName["market-data-sync-daily"]
+	if !ok {
+		t.Fatalf("market-data-sync-daily not added as service entry")
+	}
+	if mds.Type != "service" {
+		t.Errorf("market-data-sync-daily type = %q, want service", mds.Type)
+	}
+	if mds.LastRunStatus != "succeeded" {
+		t.Errorf("market-data-sync-daily status = %q, want succeeded", mds.LastRunStatus)
+	}
+}
+
+func TestFinalizeHealthAndSort(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	staleOK := &JobStatus{LastRunStatus: "succeeded", Schedule: "0 10 * * *", LastSuccessAt: "2026-01-01T00:00:00Z"}
+	freshOK := &JobStatus{LastRunStatus: "succeeded", Schedule: "0 10 * * *", LastSuccessAt: now}
+	failed := &JobStatus{LastRunStatus: "failed"}
+	running := &JobStatus{LastRunStatus: "running"}
+	never := &JobStatus{LastRunStatus: "never"}
+
+	finalizeHealth(staleOK)
+	finalizeHealth(freshOK)
+	finalizeHealth(failed)
+	finalizeHealth(running)
+	finalizeHealth(never)
+
+	if staleOK.Health != HealthWarning {
+		t.Errorf("stale ok health = %v, want warning", staleOK.Health)
+	}
+	if freshOK.Health != HealthOK {
+		t.Errorf("fresh ok health = %v, want ok", freshOK.Health)
+	}
+	if failed.Health != HealthCritical {
+		t.Errorf("failed health = %v, want critical", failed.Health)
+	}
+	if running.Health != HealthRunning {
+		t.Errorf("running health = %v, want running", running.Health)
+	}
+	if never.Health != HealthUnknown {
+		t.Errorf("never health = %v, want unknown", never.Health)
+	}
+
+	// healthRank ordering: critical < warning < running < unknown < ok
+	order := []Health{HealthCritical, HealthWarning, HealthRunning, HealthUnknown, HealthOK}
+	for i := 1; i < len(order); i++ {
+		if healthRank(order[i-1]) >= healthRank(order[i]) {
+			t.Errorf("healthRank(%s) should sort before healthRank(%s)", order[i-1], order[i])
+		}
+	}
+}
+
+// TestCollectE2E hits the real Cloud Run + Scheduler APIs. Guarded so it only
+// runs when explicitly opted in:
+//
+//	JOBMONITOR_E2E=1 \
+//	JOBMONITOR_E2E_TOKEN=$(gcloud auth print-access-token --account=ben@shorted.com.au) \
+//	JOBS_GCP_PROJECT=rosy-clover-477102-t5 \
+//	go test -run TestCollectE2E -v ./shorts/internal/jobmonitor/
+func TestCollectE2E(t *testing.T) {
+	if os.Getenv("JOBMONITOR_E2E") != "1" {
+		t.Skip("set JOBMONITOR_E2E=1 to run the live Cloud Run/Scheduler E2E test")
+	}
+	cfg := ConfigFromEnv()
+	if cfg.ProjectID == "" {
+		t.Fatal("JOBS_GCP_PROJECT must be set for E2E")
+	}
+
+	var opts []option.ClientOption
+	if tok := os.Getenv("JOBMONITOR_E2E_TOKEN"); tok != "" {
+		opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	jobs, err := collect(ctx, cfg, opts...)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(jobs) == 0 {
+		t.Fatal("expected at least one job, got 0")
+	}
+	pretty, _ := json.MarshalIndent(jobs, "", "  ")
+	t.Logf("collected %d jobs:\n%s", len(jobs), pretty)
+	if out := os.Getenv("JOBMONITOR_E2E_OUT"); out != "" {
+		if err := os.WriteFile(out, pretty, 0o644); err != nil {
+			t.Fatalf("write out: %v", err)
+		}
+	}
+}

--- a/services/shorts/internal/services/shorts/serve.go
+++ b/services/shorts/internal/services/shorts/serve.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"connectrpc.com/connect"
 	connectcors "connectrpc.com/cors"
@@ -17,6 +18,7 @@ import (
 	"github.com/castlemilk/shorted.com.au/services/pkg/log"
 	shortedotel "github.com/castlemilk/shorted.com.au/services/pkg/otel"
 	"github.com/castlemilk/shorted.com.au/services/pkg/ratelimit"
+	"github.com/castlemilk/shorted.com.au/services/shorts/internal/jobmonitor"
 
 	"github.com/castlemilk/shorted.com.au/services/gen/proto/go/register/v1/registerv1connect"
 	shortsv1alpha1connect "github.com/castlemilk/shorted.com.au/services/gen/proto/go/shorts/v1alpha1/shortsv1alpha1connect"
@@ -203,7 +205,7 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 
 		// Check cache first
 		cacheKey := s.cache.GetSearchStocksKey(query, limit)
-		
+
 		// Use cached result or fetch from Algolia/database
 		cachedResult, err := s.cache.GetOrSet(cacheKey, func() (interface{}, error) {
 			// Try Algolia first if configured
@@ -215,7 +217,7 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 				}
 				logger.Warnf("Algolia search failed or returned no results for '%s', falling back to PostgreSQL: %v", query, algoliaErr)
 			}
-			
+
 			// Fall back to PostgreSQL
 			logger.Debugf("cache miss for SearchStocks, fetching from database: query='%s'", query)
 			return s.store.SearchStocks(query, limit)
@@ -231,7 +233,7 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 			}
 			return
 		}
-		
+
 		stocks := cachedResult.([]*stocksv1alpha1.Stock)
 
 		// Convert to JSON response
@@ -449,10 +451,10 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 		if limit > 100 {
 			limit = 100
 		}
-		
+
 		// Environment filter: "production", "development", or empty for all
 		environment := r.URL.Query().Get("environment")
-		
+
 		// Exclude local runs by default for cleaner production view
 		excludeLocal := r.URL.Query().Get("excludeLocal") != "false"
 
@@ -510,6 +512,52 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(Response{Runs: runResponses}); err != nil {
 			logger.Errorf("Error encoding JSON response: %v", err)
+			return
+		}
+	}))
+
+	// Add admin jobs overview endpoint (requires INTERNAL_SERVICE_SECRET auth).
+	// Reports the run status of EVERY scheduled async job by reading Cloud Run
+	// Job executions + Cloud Scheduler triggers directly — no per-job DB
+	// instrumentation required, so the whole fleet is visible immediately.
+	mux.HandleFunc("/api/admin/jobs", adminAuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		jobs, err := s.jobsCollector.Collect(ctx)
+		stale := false
+		if err != nil {
+			if jobs == nil {
+				logger.Errorf("Failed to collect job status: %v", err)
+				http.Error(w, "Failed to get job status", http.StatusInternalServerError)
+				return
+			}
+			// Serving last-known-good data on a transient GCP error.
+			stale = true
+			logger.Warnf("Serving stale job status after collect error: %v", err)
+		}
+
+		type Response struct {
+			Jobs  []jobmonitor.JobStatus `json:"jobs"`
+			Stale bool                   `json:"stale"`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(Response{Jobs: jobs, Stale: stale}); err != nil {
+			logger.Errorf("Error encoding job status response: %v", err)
 			return
 		}
 	}))

--- a/services/shorts/internal/services/shorts/server.go
+++ b/services/shorts/internal/services/shorts/server.go
@@ -9,6 +9,7 @@ import (
 
 	shortsv1alpha1connect "github.com/castlemilk/shorted.com.au/services/gen/proto/go/shorts/v1alpha1/shortsv1alpha1connect"
 	"github.com/castlemilk/shorted.com.au/services/pkg/ratelimit"
+	"github.com/castlemilk/shorted.com.au/services/shorts/internal/jobmonitor"
 	"github.com/castlemilk/shorted.com.au/services/shorts/internal/services/register"
 	"github.com/castlemilk/shorted.com.au/services/shorts/internal/store/shorts"
 )
@@ -22,9 +23,10 @@ type ShortsServer struct {
 	shortsv1alpha1connect.UnimplementedShortedStocksServiceHandler
 	registerServer *register.RegisterServer
 	tokenService   *TokenService
-	pubSubClient PubSubClient
+	pubSubClient   PubSubClient
 	rateLimiter    ratelimit.RateLimiter
 	httpClient     *http.Client
+	jobsCollector  *jobmonitor.Collector
 }
 
 // New creates instance of the Server
@@ -97,8 +99,9 @@ func New(ctx context.Context, cfg Config) (*ShortsServer, error) {
 		logger:         logger,
 		registerServer: registerServer,
 		tokenService:   tokenService,
-		pubSubClient: pubSubClient,
+		pubSubClient:   pubSubClient,
 		rateLimiter:    rateLimiter,
 		httpClient:     &http.Client{Timeout: 10 * time.Second},
+		jobsCollector:  jobmonitor.NewCollector(jobmonitor.ConfigFromEnv()),
 	}, nil
 }

--- a/terraform/modules/shorts-api/main.tf
+++ b/terraform/modules/shorts-api/main.tf
@@ -24,6 +24,21 @@ resource "google_service_account" "shorts_api" {
   project      = var.project_id
 }
 
+# Read-only access to Cloud Run Jobs/Executions + Cloud Scheduler so the
+# /api/admin/jobs endpoint can report the status of every scheduled async job
+# from GCP's own execution history (no per-job DB instrumentation required).
+resource "google_project_iam_member" "shorts_api_run_viewer" {
+  project = var.project_id
+  role    = "roles/run.viewer"
+  member  = "serviceAccount:${google_service_account.shorts_api.email}"
+}
+
+resource "google_project_iam_member" "shorts_api_scheduler_viewer" {
+  project = var.project_id
+  role    = "roles/cloudscheduler.viewer"
+  member  = "serviceAccount:${google_service_account.shorts_api.email}"
+}
+
 # Grant Secret Manager access to service account
 resource "google_secret_manager_secret_iam_member" "postgres_password" {
   secret_id = "APP_STORE_POSTGRES_PASSWORD"
@@ -98,10 +113,10 @@ resource "google_secret_manager_secret_iam_member" "otel_headers" {
 
 # Grant Pub/Sub Publisher role to shorts API service account (for publishing enrichment jobs)
 resource "google_pubsub_topic_iam_member" "enrichment_jobs_publisher" {
-  topic    = "enrichment-jobs"
-  role     = "roles/pubsub.publisher"
-  member   = "serviceAccount:${google_service_account.shorts_api.email}"
-  project  = var.project_id
+  topic   = "enrichment-jobs"
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.shorts_api.email}"
+  project = var.project_id
 }
 
 # Cloud Run Service
@@ -131,6 +146,24 @@ resource "google_cloud_run_v2_service" "shorts_api" {
       env {
         name  = "GCP_PROJECT_ID"
         value = var.project_id
+      }
+
+      # Job-status monitor (/api/admin/jobs): which project/regions to inspect.
+      # Cloud Run Jobs live in this service's region; Cloud Scheduler is in
+      # australia-southeast1 (scheduler is unavailable in -southeast2).
+      env {
+        name  = "JOBS_GCP_PROJECT"
+        value = var.project_id
+      }
+
+      env {
+        name  = "JOBS_RUN_REGION"
+        value = var.region
+      }
+
+      env {
+        name  = "JOBS_SCHEDULER_REGION"
+        value = "australia-southeast1"
       }
 
       env {
@@ -256,7 +289,7 @@ resource "google_cloud_run_v2_service" "shorts_api" {
           cpu    = "0.5"
           memory = "256Mi"
         }
-        cpu_idle          = true  # Throttle CPU when idle to reduce costs
+        cpu_idle          = true # Throttle CPU when idle to reduce costs
         startup_cpu_boost = true
       }
 
@@ -283,7 +316,7 @@ resource "google_cloud_run_v2_service" "shorts_api" {
       }
     }
 
-    max_instance_request_concurrency = 1  # Required: cpu < 1 requires concurrency = 1
+    max_instance_request_concurrency = 1 # Required: cpu < 1 requires concurrency = 1
 
     scaling {
       min_instance_count = var.min_instances

--- a/web/src/app/actions/getJobsOverview.ts
+++ b/web/src/app/actions/getJobsOverview.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import { cache } from "react";
+import { SHORTS_API_URL } from "./config";
+import { retryWithBackoff } from "@/lib/retry";
+
+/**
+ * Unified status of a single scheduled async job, as reported by the backend
+ * /api/admin/jobs endpoint (which reads Cloud Run Job executions + Cloud
+ * Scheduler triggers directly). Mirrors jobmonitor.JobStatus in Go.
+ */
+export interface JobStatus {
+  name: string;
+  displayName: string;
+  category: string;
+  type: "job" | "service";
+  schedule: string;
+  scheduleHuman: string;
+  schedulerState: string; // ENABLED | PAUSED | ""
+  lastRunAt: string; // RFC3339 or ""
+  lastRunStatus: string; // succeeded | failed | running | unknown | never
+  lastSuccessAt: string;
+  durationSeconds: number;
+  succeededCount: number;
+  failedCount: number;
+  runningCount: number;
+  executionName: string;
+  message: string;
+  logUri: string;
+  lastAttemptAt: string;
+  health: "ok" | "running" | "warning" | "critical" | "unknown";
+}
+
+export interface JobsOverview {
+  jobs: JobStatus[];
+  /** true if the backend served last-known-good data after a transient error */
+  stale: boolean;
+  /** true if the request failed entirely (auth/network) */
+  errored: boolean;
+}
+
+interface JobsResponse {
+  jobs?: JobStatus[];
+  stale?: boolean;
+}
+
+// Internal service secret for admin endpoints (same var used by subscription.ts).
+const INTERNAL_SECRET = process.env.INTERNAL_SERVICE_SECRET ?? "dev-internal-secret";
+
+const RETRY_OPTIONS = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 5000,
+};
+
+export const getJobsOverview = cache(async (): Promise<JobsOverview> => {
+  try {
+    const data = await retryWithBackoff<JobsResponse>(async () => {
+      const response = await fetch(`${SHORTS_API_URL}/api/admin/jobs`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          // The backend admin endpoints require INTERNAL_SERVICE_SECRET. Send it
+          // both as a bearer token and the x-internal-secret header the Go
+          // middleware also accepts. A browser-like UA avoids the Cloudflare WAF
+          // blocking the bare server-side fetch.
+          Authorization: `Bearer ${INTERNAL_SECRET}`,
+          "x-internal-secret": INTERNAL_SECRET,
+          "User-Agent": "Mozilla/5.0 (compatible; ShortedAdmin)",
+        },
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to get jobs overview: ${response.status}`);
+      }
+
+      return (await response.json()) as JobsResponse;
+    }, RETRY_OPTIONS);
+
+    return {
+      jobs: data.jobs ?? [],
+      stale: data.stale ?? false,
+      errored: false,
+    };
+  } catch (err) {
+    console.error("Failed to get jobs overview:", err);
+    return { jobs: [], stale: false, errored: true };
+  }
+});

--- a/web/src/app/actions/getSyncStatus.ts
+++ b/web/src/app/actions/getSyncStatus.ts
@@ -4,6 +4,9 @@ import { cache } from "react";
 import { SHORTS_API_URL } from "./config";
 import { retryWithBackoff } from "@/lib/retry";
 
+// Internal service secret for admin endpoints (same var used by subscription.ts).
+const INTERNAL_SECRET = process.env.INTERNAL_SERVICE_SECRET ?? "dev-internal-secret";
+
 // Define SyncRun type locally until proto is regenerated
 export interface SyncRun {
   runId: string;
@@ -67,6 +70,11 @@ export const getSyncStatus = cache(
             method: "GET",
             headers: {
               "Content-Type": "application/json",
+              // Admin endpoint requires INTERNAL_SERVICE_SECRET; a browser-like
+              // UA avoids the Cloudflare WAF blocking the bare server fetch.
+              Authorization: `Bearer ${INTERNAL_SECRET}`,
+              "x-internal-secret": INTERNAL_SECRET,
+              "User-Agent": "Mozilla/5.0 (compatible; ShortedAdmin)",
             },
             cache: "no-store",
           },

--- a/web/src/app/admin/jobs-overview.tsx
+++ b/web/src/app/admin/jobs-overview.tsx
@@ -1,0 +1,293 @@
+import type { JobsOverview as JobsOverviewData, JobStatus } from "~/app/actions/getJobsOverview";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDistanceToNow } from "date-fns";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Activity,
+  HelpCircle,
+  ExternalLink,
+  ServerCog,
+  CalendarClock,
+} from "lucide-react";
+
+function relative(ts: string): string {
+  if (!ts) return "Never";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return "Never";
+  return formatDistanceToNow(d, { addSuffix: true });
+}
+
+function duration(seconds: number): string {
+  if (!seconds || seconds <= 0) return "–";
+  if (seconds >= 60) {
+    return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  }
+  return `${seconds.toFixed(1)}s`;
+}
+
+function statusLabel(job: JobStatus): string {
+  switch (job.health) {
+    case "critical":
+      return "failed";
+    case "running":
+      return "running";
+    case "warning":
+      if (job.lastRunStatus === "running") return "stuck?";
+      if (job.schedulerState === "PAUSED") return "paused";
+      return "stale";
+    case "unknown":
+      return job.lastRunStatus === "never" ? "never run" : "no data";
+    default:
+      return "ok";
+  }
+}
+
+function JobHealthBadge({ job }: { job: JobStatus }) {
+  const label = statusLabel(job);
+  switch (job.health) {
+    case "critical":
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <XCircle className="h-3 w-3" />
+          {label}
+        </Badge>
+      );
+    case "running":
+      return (
+        <Badge variant="outline" className="gap-1 animate-pulse border-blue-300 text-blue-700 dark:text-blue-400">
+          <Activity className="h-3 w-3" />
+          {label}
+        </Badge>
+      );
+    case "warning":
+      return (
+        <Badge
+          variant="secondary"
+          className="gap-1 bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+        >
+          <AlertTriangle className="h-3 w-3" />
+          {label}
+        </Badge>
+      );
+    case "unknown":
+      return (
+        <Badge variant="outline" className="gap-1 text-muted-foreground">
+          <HelpCircle className="h-3 w-3" />
+          {label}
+        </Badge>
+      );
+    default:
+      return (
+        <Badge
+          variant="secondary"
+          className="gap-1 bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400"
+        >
+          <CheckCircle2 className="h-3 w-3" />
+          {label}
+        </Badge>
+      );
+  }
+}
+
+function StatCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "ok" | "critical" | "warning" | "muted";
+}) {
+  const toneClass =
+    tone === "critical"
+      ? "text-red-600 dark:text-red-400"
+      : tone === "warning"
+        ? "text-amber-600 dark:text-amber-400"
+        : tone === "ok"
+          ? "text-emerald-600 dark:text-emerald-400"
+          : "text-foreground";
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className={`text-3xl font-bold tabular-nums ${toneClass}`}>{value}</div>
+        <p className="text-xs text-muted-foreground mt-1">{label}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function JobsOverview({ overview }: { overview: JobsOverviewData }) {
+  const { jobs, stale, errored } = overview;
+
+  const counts = {
+    total: jobs.length,
+    ok: jobs.filter((j) => j.health === "ok").length,
+    failing: jobs.filter((j) => j.health === "critical").length,
+    attention: jobs.filter((j) => j.health === "warning" || j.health === "running").length,
+    unknown: jobs.filter((j) => j.health === "unknown").length,
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <ServerCog className="h-5 w-5" />
+              All Async Jobs
+            </CardTitle>
+            <CardDescription>
+              Live status of every scheduled job &amp; sync from Cloud Run + Cloud Scheduler
+            </CardDescription>
+          </div>
+          {stale && (
+            <Badge variant="outline" className="gap-1 text-amber-600 w-fit">
+              <Clock className="h-3 w-3" />
+              showing cached data
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {errored ? (
+          <div className="flex flex-col items-center gap-2 py-10 text-center text-muted-foreground">
+            <AlertTriangle className="h-8 w-8 text-amber-500" />
+            <span className="font-medium">Couldn&apos;t load job status</span>
+            <span className="text-xs max-w-md">
+              The backend /api/admin/jobs call failed. Confirm INTERNAL_SERVICE_SECRET is set in the
+              web app, the shorts service is deployed with the endpoint, and its service account has
+              the Cloud Run Viewer + Cloud Scheduler Viewer roles.
+            </span>
+          </div>
+        ) : (
+          <>
+            {/* Summary */}
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+              <StatCard label="Total jobs" value={counts.total} tone="muted" />
+              <StatCard label="Healthy" value={counts.ok} tone="ok" />
+              <StatCard label="Failing" value={counts.failing} tone="critical" />
+              <StatCard label="Needs attention" value={counts.attention} tone="warning" />
+              <StatCard label="No data" value={counts.unknown} tone="muted" />
+            </div>
+
+            {/* Table */}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[120px]">Status</TableHead>
+                  <TableHead>Job</TableHead>
+                  <TableHead>Schedule</TableHead>
+                  <TableHead>Last run</TableHead>
+                  <TableHead className="text-right">Duration</TableHead>
+                  <TableHead className="w-[60px]">Logs</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {jobs.map((job) => (
+                  <TableRow
+                    key={job.name}
+                    className={
+                      job.health === "critical"
+                        ? "bg-red-50/50 dark:bg-red-950/10"
+                        : job.health === "warning"
+                          ? "bg-amber-50/40 dark:bg-amber-950/10"
+                          : ""
+                    }
+                  >
+                    <TableCell>
+                      <JobHealthBadge job={job} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium">{job.displayName}</span>
+                        <span className="text-xs text-muted-foreground flex items-center gap-1.5">
+                          {job.category}
+                          <span className="opacity-50">·</span>
+                          {job.type === "service" ? "scheduled service" : "Cloud Run job"}
+                        </span>
+                        {job.message && (
+                          <span
+                            className="text-xs text-red-500/90 max-w-[420px] truncate cursor-help mt-0.5"
+                            title={job.message}
+                          >
+                            {job.message}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="text-sm flex items-center gap-1.5">
+                          <CalendarClock className="h-3 w-3 text-muted-foreground" />
+                          {job.scheduleHuman || "–"}
+                        </span>
+                        {job.schedulerState && job.schedulerState !== "ENABLED" && (
+                          <span className="text-[10px] text-amber-600">{job.schedulerState}</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="text-sm" title={job.lastRunAt}>
+                          {relative(job.lastRunAt)}
+                        </span>
+                        {job.lastSuccessAt && job.health !== "ok" && (
+                          <span className="text-[10px] text-muted-foreground" title={job.lastSuccessAt}>
+                            last ok {relative(job.lastSuccessAt)}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-sm">
+                      {duration(job.durationSeconds)}
+                    </TableCell>
+                    <TableCell>
+                      {job.logUri ? (
+                        <a
+                          href={job.logUri}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-muted-foreground hover:text-foreground"
+                          title="View logs in Cloud Console"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground/30">–</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {jobs.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-muted-foreground h-24">
+                      No scheduled jobs found.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,5 +1,7 @@
 import { getSyncStatus, type SyncRun } from "~/app/actions/getSyncStatus";
+import { getJobsOverview, type JobsOverview as JobsOverviewData } from "~/app/actions/getJobsOverview";
 import { isStuckRun, isZeroRecordRun, getRunHealth } from "./sync-utils";
+import { JobsOverview } from "./jobs-overview";
 import Container from "@/components/ui/container";
 import {
   Card,
@@ -24,11 +26,9 @@ import {
   CheckCircle2,
   XCircle,
   Clock,
-  AlertCircle,
   Activity,
   Server,
   Database,
-  Zap,
 } from "lucide-react";
 import { AdminFilters } from "./admin-filters";
 
@@ -41,87 +41,43 @@ interface AdminPageProps {
   }>;
 }
 
-function getSystemHealthStatus(runs: SyncRun[]): {
+interface FleetHealth {
   status: "healthy" | "degraded" | "critical";
   message: string;
   issues: string[];
-} {
-  if (runs.length === 0) {
+}
+
+// getFleetHealth derives the overall banner from the all-jobs overview (the
+// primary signal), not the single market-data sync_status feed.
+function getFleetHealth(overview: JobsOverviewData): FleetHealth {
+  if (overview.errored) {
     return {
       status: "critical",
-      message: "No sync data available",
-      issues: ["No sync runs found - scheduler may not be running"],
+      message: "Couldn't load job status",
+      issues: ["The /api/admin/jobs call failed — see the All Async Jobs card below."],
     };
   }
 
-  const issues: string[] = [];
-  const recentRuns = runs.slice(0, 10);
+  const failing = overview.jobs.filter((j) => j.health === "critical");
+  const attention = overview.jobs.filter((j) => j.health === "warning");
 
-  // Check for stuck runs
-  const stuckRuns = recentRuns.filter(isStuckRun);
-  if (stuckRuns.length > 0) {
-    issues.push(`${stuckRuns.length} job(s) stuck in running state`);
-  }
-
-  // Check for failed runs
-  const failedRuns = recentRuns.filter((r) => r.status === "failed");
-  if (failedRuns.length > 0) {
-    issues.push(`${failedRuns.length} recent job failure(s)`);
-  }
-
-  // Check for zero-record completions (suspicious)
-  const zeroRecordRuns = recentRuns.filter(isZeroRecordRun);
-  if (zeroRecordRuns.length >= 3) {
-    issues.push(`${zeroRecordRuns.length} completed jobs with 0 records`);
-  }
-
-  // Check last successful run age
-  const lastSuccessful = runs.find(
-    (r) => r.status === "completed" && !isZeroRecordRun(r)
-  );
-  if (lastSuccessful) {
-    const hoursSinceSuccess = differenceInMinutes(
-      new Date(),
-      new Date(lastSuccessful.startedAt)
-    ) / 60;
-    if (hoursSinceSuccess > 48) {
-      issues.push(`No successful sync in ${Math.round(hoursSinceSuccess)} hours`);
-    }
-  } else {
-    issues.push("No successful syncs with data found");
-  }
-
-  // Check if latest run is healthy
-  const latestRun = runs[0];
-  if (latestRun && getRunHealth(latestRun) === "error") {
-    issues.push("Latest job has errors");
-  }
-
-  // Determine overall status
-  if (
-    issues.length >= 3 ||
-    stuckRuns.length > 2 ||
-    failedRuns.length > 3 ||
-    issues.some((i) => i.includes("No successful"))
-  ) {
+  if (failing.length > 0) {
     return {
       status: "critical",
-      message: "System requires immediate attention",
-      issues,
+      message: `${failing.length} job${failing.length > 1 ? "s" : ""} failing`,
+      issues: failing.map((j) => `${j.displayName}: ${j.message || "last run failed"}`),
     };
-  } else if (issues.length > 0) {
+  }
+  if (attention.length > 0) {
     return {
       status: "degraded",
-      message: "System has some issues",
-      issues,
+      message: `${attention.length} job${attention.length > 1 ? "s" : ""} need attention`,
+      issues: attention.map(
+        (j) => `${j.displayName}: ${j.message || (j.schedulerState === "PAUSED" ? "scheduler paused" : "stale")}`,
+      ),
     };
   }
-
-  return {
-    status: "healthy",
-    message: "All systems operational",
-    issues: [],
-  };
+  return { status: "healthy", message: "All jobs healthy", issues: [] };
 }
 
 function StatusIcon({ status }: { status: "healthy" | "degraded" | "critical" }) {
@@ -162,8 +118,8 @@ function RunHealthBadge({ run }: { run: SyncRun }) {
   if (run.status === "running") {
     const startedAt = new Date(run.startedAt);
     const runningMins = differenceInMinutes(new Date(), startedAt);
-    const progress = run.checkpointStocksTotal > 0 
-      ? Math.round((run.checkpointStocksProcessed / run.checkpointStocksTotal) * 100) 
+    const progress = run.checkpointStocksTotal > 0
+      ? Math.round((run.checkpointStocksProcessed / run.checkpointStocksTotal) * 100)
       : 0;
 
     return (
@@ -186,8 +142,8 @@ function RunHealthBadge({ run }: { run: SyncRun }) {
   }
 
   if (run.status === "partial") {
-    const progress = run.checkpointStocksTotal > 0 
-      ? Math.round((run.checkpointStocksProcessed / run.checkpointStocksTotal) * 100) 
+    const progress = run.checkpointStocksTotal > 0
+      ? Math.round((run.checkpointStocksProcessed / run.checkpointStocksTotal) * 100)
       : 0;
 
     return (
@@ -216,7 +172,7 @@ function RunHealthBadge({ run }: { run: SyncRun }) {
           variant="secondary"
           className="gap-1 bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
         >
-          <AlertCircle className="h-3 w-3" />
+          <AlertTriangle className="h-3 w-3" />
           0 records
         </Badge>
       </div>
@@ -234,7 +190,7 @@ function RunHealthBadge({ run }: { run: SyncRun }) {
 function EnvironmentBadge({ environment, hostname }: { environment: string; hostname: string }) {
   const isProduction = environment === "production";
   const isCloudRun = hostname && !hostname.includes("local") && !hostname.includes(".local");
-  
+
   return (
     <div className="flex flex-col gap-0.5">
       <Badge
@@ -263,78 +219,70 @@ function EnvironmentBadge({ environment, hostname }: { environment: string; host
 
 export default async function AdminDashboard({ searchParams }: AdminPageProps) {
   const params = await searchParams;
-  const environment = params.environment ?? "production";
-  const showLocal = params.showLocal === "true";
+  // Market-data sync_status detail: default to "all" because the active writer
+  // (market-data-sync) leaves environment/hostname NULL, so the production
+  // filter would hide every real run.
+  const environment = params.environment ?? "all";
+  const showLocal = params.showLocal !== "false";
 
-  const runs = await getSyncStatus({
-    limit: 30,
-    environment: environment === "all" ? "" : environment,
-    excludeLocal: !showLocal,
-  }) || [];
+  const [jobsOverview, runs] = await Promise.all([
+    getJobsOverview(),
+    getSyncStatus({
+      limit: 20,
+      environment: environment === "all" ? "" : environment,
+      excludeLocal: !showLocal,
+    }).then((r) => r ?? []),
+  ]);
 
-  const systemHealth = getSystemHealthStatus(runs);
+  const fleet = getFleetHealth(jobsOverview);
 
-  // Calculate stats from production runs
-  const lastRun = runs[0];
-  const completedRuns = runs.filter((r) => r.status === "completed");
-  const successfulRuns = completedRuns.filter((r) => !isZeroRecordRun(r));
-  const failedRuns = runs.filter(
-    (r) => r.status === "failed" || isStuckRun(r)
-  );
-  const stuckRuns = runs.filter(isStuckRun);
-
-  // Find last successful run with actual data
+  // Market-data sync detail stats
   const lastSuccessfulWithData = runs.find(
-    (r) => r.status === "completed" && !isZeroRecordRun(r)
+    (r) => r.status === "completed" && !isZeroRecordRun(r),
   );
 
   return (
     <Container>
       <div className="space-y-6 py-8">
-        {/* Header with System Status */}
+        {/* Header with fleet status */}
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">Admin Dashboard</h1>
             <p className="text-muted-foreground mt-1">
-              Cloud Run job monitoring and sync status
+              Sync status across all scheduled async jobs
             </p>
           </div>
 
-          {/* System Health Badge */}
           <div
             className={`flex items-center gap-3 rounded-lg border p-3 ${
-              systemHealth.status === "healthy"
+              fleet.status === "healthy"
                 ? "border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/30"
-                : systemHealth.status === "degraded"
+                : fleet.status === "degraded"
                   ? "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30"
                   : "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/30"
             }`}
           >
-            <StatusIcon status={systemHealth?.status ?? "critical"} />
+            <StatusIcon status={fleet.status} />
             <div>
-              <div className="font-semibold text-sm capitalize">
-                {systemHealth?.status ?? "unknown"}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {systemHealth?.message ?? "Unknown status"}
-              </div>
+              <div className="font-semibold text-sm capitalize">{fleet.status}</div>
+              <div className="text-xs text-muted-foreground">{fleet.message}</div>
             </div>
           </div>
         </div>
 
-        {/* Issues Alert */}
-        {systemHealth?.issues && systemHealth.issues.length > 0 && (
+        {/* Issues alert */}
+        {fleet.issues.length > 0 && (
           <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20">
             <CardHeader className="pb-2">
               <CardTitle className="text-base flex items-center gap-2 text-amber-800 dark:text-amber-400">
                 <AlertTriangle className="h-4 w-4" />
-                Detected Issues
+                Needs attention
               </CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="list-disc list-inside space-y-1">
-                {systemHealth.issues.map((issue, i) => (
-                  <li key={i} className="text-sm text-amber-700 dark:text-amber-400">
+                {fleet.issues.map((issue, i) => (
+                  <li key={i} className="text-sm text-amber-700 dark:text-amber-400 truncate" title={issue}>
                     {issue}
                   </li>
                 ))}
@@ -343,116 +291,25 @@ export default async function AdminDashboard({ searchParams }: AdminPageProps) {
           </Card>
         )}
 
-        {/* Filters */}
-        <AdminFilters
-          currentEnvironment={environment}
-          showLocal={showLocal}
-        />
+        {/* PRIMARY: all async jobs */}
+        <JobsOverview overview={jobsOverview} />
 
-        {/* Stats Cards */}
-        <div className="grid gap-4 md:grid-cols-4">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Last Sync</CardTitle>
-              <Clock className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {lastRun
-                  ? formatDistanceToNow(new Date(lastRun.startedAt), {
-                      addSuffix: true,
-                    })
-                  : "Never"}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {lastRun ? (
-                  <span className="flex items-center gap-1">
-                    Status: <RunHealthBadge run={lastRun} />
-                  </span>
-                ) : (
-                  "N/A"
-                )}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Last Successful</CardTitle>
-              <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {lastSuccessfulWithData
-                  ? formatDistanceToNow(new Date(lastSuccessfulWithData.startedAt), {
-                      addSuffix: true,
-                    })
-                  : "Never"}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {lastSuccessfulWithData
-                  ? `${(
-                      lastSuccessfulWithData.shortsRecordsUpdated +
-                      lastSuccessfulWithData.pricesRecordsUpdated +
-                      lastSuccessfulWithData.metricsRecordsUpdated
-                    ).toLocaleString()} records updated`
-                  : "No successful syncs found"}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Success Rate</CardTitle>
-              <Zap className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {runs.length > 0
-                  ? Math.round((successfulRuns.length / runs.length) * 100)
-                  : 0}
-                %
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {successfulRuns.length} successful, {failedRuns.length} failed
-                {stuckRuns.length > 0 && `, ${stuckRuns.length} stuck`}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Records (Last)</CardTitle>
-              <Database className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {lastSuccessfulWithData
-                  ? (
-                      lastSuccessfulWithData.shortsRecordsUpdated +
-                      lastSuccessfulWithData.pricesRecordsUpdated +
-                      lastSuccessfulWithData.metricsRecordsUpdated
-                    ).toLocaleString()
-                  : 0}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                S: {lastSuccessfulWithData?.shortsRecordsUpdated ?? 0} | P:{" "}
-                {lastSuccessfulWithData?.pricesRecordsUpdated ?? 0} | M:{" "}
-                {lastSuccessfulWithData?.metricsRecordsUpdated ?? 0}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Sync History Table */}
+        {/* SECONDARY: market-data sync_status record detail */}
         <Card>
           <CardHeader>
-            <CardTitle>Sync History</CardTitle>
+            <CardTitle className="flex items-center gap-2">
+              <Database className="h-5 w-5" />
+              Market Data Sync — record detail
+            </CardTitle>
             <CardDescription>
-              Recent Cloud Run scheduler job executions ({environment === "all" ? "all environments" : environment})
+              Per-run record counts written to <code>sync_status</code> by the market-data sync
+              {lastSuccessfulWithData
+                ? ` · last successful ${formatDistanceToNow(new Date(lastSuccessfulWithData.startedAt), { addSuffix: true })}`
+                : ""}
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
+            <AdminFilters currentEnvironment={environment} showLocal={showLocal} />
             <Table>
               <TableHeader>
                 <TableRow>
@@ -513,28 +370,17 @@ export default async function AdminDashboard({ searchParams }: AdminPageProps) {
                         {run.algoliaRecordsSynced.toLocaleString()}
                       </TableCell>
                       <TableCell>
-                        <EnvironmentBadge
-                          environment={run.environment}
-                          hostname={run.hostname}
-                        />
+                        <EnvironmentBadge environment={run.environment} hostname={run.hostname} />
                       </TableCell>
                     </TableRow>
                   );
                 })}
                 {runs.length === 0 && (
                   <TableRow>
-                    <TableCell
-                      colSpan={8}
-                      className="text-center text-muted-foreground h-24"
-                    >
+                    <TableCell colSpan={8} className="text-center text-muted-foreground h-24">
                       <div className="flex flex-col items-center gap-2">
                         <Database className="h-8 w-8 text-muted-foreground/50" />
-                        <span>No sync history available for selected filters.</span>
-                        {environment !== "all" && (
-                          <span className="text-xs">
-                            Try selecting &quot;All Environments&quot; to see more data.
-                          </span>
-                        )}
+                        <span>No market-data sync runs recorded.</span>
                       </div>
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
## Problem
The `/admin` dashboard showed **no data**. Root cause was a stack of three issues:
1. `getSyncStatus.ts` called the auth-gated `/api/admin/sync-status` with **no `INTERNAL_SERVICE_SECRET` header** → always `401`, swallowed to `[]` (confirmed live against prod).
2. Even authed, the store filter required `environment='production' AND hostname IS NOT NULL`, but the market-data writer leaves both NULL → every row excluded.
3. `sync_status` only ever reflects **one** pipeline (market-data sync). The other ~9 scheduled jobs were structurally invisible.

## Approach: GCP-native
Instead of instrumenting every job to write a DB row, a new `jobmonitor` collector reads job status from **GCP's own execution history** — Cloud Run Job executions + Cloud Scheduler triggers — so every scheduled job appears automatically with zero per-job instrumentation.

## Changes
- **`services/shorts/internal/jobmonitor/`** (new): collector over `run/v2` + `cloudscheduler/v1`, 60s TTL cache, stale-on-error fallback, health/staleness/stuck heuristics. Unit tests + guarded prod E2E (`JOBMONITOR_E2E=1`).
- **`serve.go` / `server.go`**: new `GET /api/admin/jobs` (admin-auth) + collector wired into `ShortsServer`.
- **`web/src/app/actions/getJobsOverview.ts`** (new) + **`admin/jobs-overview.tsx`** (new "All Async Jobs" card); `admin/page.tsx` reworked — overview is the hero, market-data `sync_status` record detail kept as a secondary section.
- **`getSyncStatus.ts`**: fixed the missing auth header (+ browser UA for the CF WAF).
- **`terraform/modules/shorts-api/main.tf`**: granted SA `roles/run.viewer` + `roles/cloudscheduler.viewer`, added `JOBS_*` env.

## Verification
- `go build` / `go vet` / `golangci-lint` clean; 6 unit tests pass.
- Collector run **live against prod** → 12 jobs with accurate status.
- Rendered the real UI locally with the live data (screenshot in the work log).

## Real issues this surfaced (pre-existing, not from this PR)
- **director-trade-extractor** — failing daily (container exit 1)
- **asx-announcement-crawler** — failing daily (timeout)
- **shorts-data-sync** — execution stuck running ~18h
- **financial-report-extractor**, **signals-collector** — never successfully run

## Deploy notes
- Prod IAM (`run.viewer` + `cloudscheduler.viewer` on the shorts SA) was granted manually via gcloud so it's live immediately; this PR's terraform makes that the source of truth (`terraform apply` will be a no-op for the bindings).
- Requires the shorts backend redeploy (new endpoint) + web deploy. Until then the card shows a clean "couldn't load job status" state.