### PR TITLE
fix(jobs): repair failing/zombie cron jobs + GCP failure alerting

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -435,6 +435,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cache_purge_secret: ${{ secrets.CACHE_PURGE_SECRET }}
+          TF_VAR_alert_recipient_email: ${{ secrets.ALERT_RECIPIENT_EMAIL }}
         run: |
           terraform plan \
             -var="stock_price_ingestion_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/stock-price-ingestion:${{ needs.determine-environment.outputs.image-tag }}" \
@@ -997,6 +998,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cache_purge_secret: ${{ secrets.CACHE_PURGE_SECRET }}
+          TF_VAR_alert_recipient_email: ${{ secrets.ALERT_RECIPIENT_EMAIL }}
         run: |
           terraform apply \
             -var="stock_price_ingestion_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/stock-price-ingestion:${{ needs.determine-environment.outputs.image-tag }}" \

--- a/services/asx-announcement-crawler/main.go
+++ b/services/asx-announcement-crawler/main.go
@@ -11,14 +11,16 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	shortedotel "github.com/castlemilk/shorted.com.au/services/pkg/otel"
 	"github.com/castlemilk/shorted.com.au/services/pkg/stealthhttp"
-	"github.com/skunkworq/stealth/brws/engine"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/skunkworq/stealth/brws/engine"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
@@ -35,26 +37,42 @@ type FinancialReport struct {
 
 // ASXAnnouncement represents a parsed announcement from the ASX HTML page
 type ASXAnnouncement struct {
-	Date           string
-	IsPriceSens    bool
-	Headline       string
-	PDFURL         string
-	Pages          string
-	FileSize       string
+	Date        string
+	IsPriceSens bool
+	Headline    string
+	PDFURL      string
+	Pages       string
+	FileSize    string
 }
 
 var (
-	flagDryRun     = flag.Bool("dry-run", false, "Parse and display results without updating the database")
-	flagCodes      = flag.String("codes", "", "Comma-separated stock codes to crawl (default: all from company-metadata)")
-	flagYears      = flag.String("years", "2024,2025", "Comma-separated years to crawl")
-	flagLimit      = flag.Int("limit", 0, "Limit number of stocks to process (0 = all)")
-	flagDelay = flag.Duration("delay", 1500*time.Millisecond, "Delay between requests")
-	flagVerbose    = flag.Bool("verbose", false, "Verbose output")
+	flagDryRun           = flag.Bool("dry-run", false, "Parse and display results without updating the database")
+	flagCodes            = flag.String("codes", "", "Comma-separated stock codes to crawl (default: all from company-metadata)")
+	flagYears            = flag.String("years", "2024,2025", "Comma-separated years to crawl")
+	flagLimit            = flag.Int("limit", 0, "Limit number of stocks to process (0 = all)")
+	flagDelay            = flag.Duration("delay", 1500*time.Millisecond, "Delay between requests")
+	flagVerbose          = flag.Bool("verbose", false, "Verbose output")
 	flagAllAnnouncements = flag.Bool("all-announcements", false, "Store all announcements to asx_announcements table (not just financial reports)")
 	flagNewsTable        = flag.Bool("news-table", false, "Also write announcements into news_articles table")
 	flagDirectorTrades   = flag.Bool("director-trades", false, "Extract director trades from Appendix 3Y announcements into director_trades table")
 	flagDividends        = flag.Bool("dividends", false, "Extract dividend announcements into dividend_history table")
+	flagWorkers          = flag.Int("workers", 6, "Number of concurrent crawl workers (network-bound; keep modest to respect ASX rate limits)")
 )
+
+// crawlStats holds the cross-worker tallies. All fields are int64 and updated
+// only via sync/atomic so the worker pool can share one instance safely.
+// (int64 fields are kept first so they stay 8-byte aligned for atomic ops.)
+type crawlStats struct {
+	processed      int64
+	reports        int64
+	reportsUpdated int64
+	errors         int64
+	announcements  int64
+	annStored      int64
+	newsStored     int64
+	dirTrades      int64
+	dividends      int64
+}
 
 // Financial report headline keywords/patterns
 var financialKeywords = []string{
@@ -114,7 +132,14 @@ func main() {
 		log.Fatalf("Failed to parse DATABASE_URL: %v", err)
 	}
 	config.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
-	config.MaxConns = 3
+	// Size the pool to cover the worker fan-out (each worker does several short
+	// INSERT/UPDATEs per stock); otherwise a 3-conn pool serializes DB writes and
+	// negates the parallelism. Safe against the Supabase transaction pooler.
+	numWorkers := *flagWorkers
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+	config.MaxConns = int32(numWorkers + 2)
 
 	db, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
@@ -154,142 +179,169 @@ func main() {
 	}
 	defer func() { _ = client.Close() }()
 
-	// Process stocks
-	var (
-		totalProcessed      int
-		totalReports        int
-		totalUpdated        int
-		totalErrors         int
-		totalAnnouncements  int
-		totalAnnStored      int
-		totalNewsStored     int
-		totalDirTrades      int
-		totalDividends      int
-	)
+	// Process stocks concurrently with a bounded worker pool. The crawl is
+	// network-bound (one ASX page fetch per year per stock), so a small pool cuts
+	// wall-clock ~Nx and keeps the job well inside its timeout instead of running
+	// sequentially for >4h. Each worker owns its own stealth client (the engine is
+	// not guaranteed concurrency-safe) and keeps the per-stock jittered delay, so
+	// the aggregate request rate stays ~workers/delay — modest enough for ASX.
+	stats := &crawlStats{}
+	codesCh := make(chan string)
+	var wg sync.WaitGroup
+	var progress int64
 
-	for i, code := range codes {
-		if i > 0 && i%50 == 0 {
-			log.Printf("Progress: %d/%d stocks processed, %d reports found, %d updated, %d errors",
-				i, len(codes), totalReports, totalUpdated, totalErrors)
+	worker := func() {
+		defer wg.Done()
+		wClient, werr := stealthhttp.New(stealthhttp.WithTimeout(30 * time.Second))
+		if werr != nil {
+			log.Printf("worker: failed to create stealth client, using shared: %v", werr)
+			wClient = client
+		} else {
+			defer func() { _ = wClient.Close() }()
 		}
 
-		reports, allAnns, err := crawlStockAnnouncementsFull(client, code, years)
-		if err != nil {
-			if *flagVerbose {
-				log.Printf("  ERROR %s: %v", code, err)
+		for code := range codesCh {
+			if n := atomic.AddInt64(&progress, 1); n%50 == 0 {
+				log.Printf("Progress: %d/%d stocks | ann stored: %d, news: %d, dir-trades: %d, dividends: %d, reports: %d, errors: %d",
+					n, len(codes),
+					atomic.LoadInt64(&stats.annStored), atomic.LoadInt64(&stats.newsStored),
+					atomic.LoadInt64(&stats.dirTrades), atomic.LoadInt64(&stats.dividends),
+					atomic.LoadInt64(&stats.reports), atomic.LoadInt64(&stats.errors))
 			}
-			totalErrors++
-			continue
-		}
 
-		totalProcessed++
-
-		// Store all announcements to asx_announcements table
-		if *flagAllAnnouncements && len(allAnns) > 0 {
-			totalAnnouncements += len(allAnns)
-			if !*flagDryRun {
-				stored, err := storeAnnouncements(ctx, db, code, allAnns)
-				if err != nil {
-					log.Printf("  ERROR storing announcements for %s: %v", code, err)
-				} else {
-					totalAnnStored += stored
-				}
-			} else if *flagVerbose {
-				log.Printf("  %s: %d total announcements", code, len(allAnns))
-			}
-		}
-
-		// Write announcements as news articles
-		if *flagNewsTable && len(allAnns) > 0 && !*flagDryRun {
-			stored, err := storeAsNewsArticles(ctx, db, code, allAnns)
+			reports, allAnns, err := crawlStockAnnouncementsFull(wClient, code, years)
 			if err != nil {
-				log.Printf("  ERROR storing news for %s: %v", code, err)
-			} else {
-				totalNewsStored += stored
+				if *flagVerbose {
+					log.Printf("  ERROR %s: %v", code, err)
+				}
+				atomic.AddInt64(&stats.errors, 1)
+				continue
 			}
-		}
 
-		// Extract director trades from Appendix 3Y announcements
-		if *flagDirectorTrades && !*flagDryRun {
-			var trades []*DirectorTradeRecord
-			for _, ann := range allAnns {
-				if isAppendix3Y(ann.Headline) {
-					trade := parseDirectorTradeFromHeadline(ann, code)
-					trades = append(trades, trade)
+			atomic.AddInt64(&stats.processed, 1)
+
+			// Store all announcements to asx_announcements table
+			if *flagAllAnnouncements && len(allAnns) > 0 {
+				atomic.AddInt64(&stats.announcements, int64(len(allAnns)))
+				if !*flagDryRun {
+					stored, err := storeAnnouncements(ctx, db, code, allAnns)
+					if err != nil {
+						log.Printf("  ERROR storing announcements for %s: %v", code, err)
+					} else {
+						atomic.AddInt64(&stats.annStored, int64(stored))
+					}
+				} else if *flagVerbose {
+					log.Printf("  %s: %d total announcements", code, len(allAnns))
 				}
 			}
-			if len(trades) > 0 {
-				stored, err := storeDirectorTrades(ctx, db, trades)
+
+			// Write announcements as news articles
+			if *flagNewsTable && len(allAnns) > 0 && !*flagDryRun {
+				stored, err := storeAsNewsArticles(ctx, db, code, allAnns)
 				if err != nil {
-					log.Printf("  ERROR storing director trades for %s: %v", code, err)
+					log.Printf("  ERROR storing news for %s: %v", code, err)
 				} else {
-					totalDirTrades += stored
+					atomic.AddInt64(&stats.newsStored, int64(stored))
 				}
 			}
-		}
 
-		// Extract dividend announcements
-		if *flagDividends && !*flagDryRun {
-			var dividends []*DividendParseResult
-			for _, ann := range allAnns {
-				if isDividendAnnouncement(ann.Headline) {
-					div := parseDividendFromHeadline(ann, code)
-					if div.AmountPerShare != nil {
-						dividends = append(dividends, div)
+			// Extract director trades from Appendix 3Y announcements
+			if *flagDirectorTrades && !*flagDryRun {
+				var trades []*DirectorTradeRecord
+				for _, ann := range allAnns {
+					if isAppendix3Y(ann.Headline) {
+						trade := parseDirectorTradeFromHeadline(ann, code)
+						trades = append(trades, trade)
+					}
+				}
+				if len(trades) > 0 {
+					stored, err := storeDirectorTrades(ctx, db, trades)
+					if err != nil {
+						log.Printf("  ERROR storing director trades for %s: %v", code, err)
+					} else {
+						atomic.AddInt64(&stats.dirTrades, int64(stored))
 					}
 				}
 			}
-			if len(dividends) > 0 {
-				stored, err := storeDividends(ctx, db, dividends)
-				if err != nil {
-					log.Printf("  ERROR storing dividends for %s: %v", code, err)
-				} else {
-					totalDividends += stored
+
+			// Extract dividend announcements
+			if *flagDividends && !*flagDryRun {
+				var dividends []*DividendParseResult
+				for _, ann := range allAnns {
+					if isDividendAnnouncement(ann.Headline) {
+						div := parseDividendFromHeadline(ann, code)
+						if div.AmountPerShare != nil {
+							dividends = append(dividends, div)
+						}
+					}
+				}
+				if len(dividends) > 0 {
+					stored, err := storeDividends(ctx, db, dividends)
+					if err != nil {
+						log.Printf("  ERROR storing dividends for %s: %v", code, err)
+					} else {
+						atomic.AddInt64(&stats.dividends, int64(stored))
+					}
 				}
 			}
-		}
 
-		if len(reports) == 0 {
+			if len(reports) == 0 {
+				// Jittered delay to be polite
+				jitter := time.Duration(rand.Int63n(int64(*flagDelay / 2)))
+				time.Sleep(*flagDelay + jitter)
+				continue
+			}
+
+			atomic.AddInt64(&stats.reports, int64(len(reports)))
+
+			if *flagDryRun {
+				log.Printf("  %s: found %d financial reports", code, len(reports))
+				for _, r := range reports {
+					log.Printf("    [%s] %s — %s", r.Date, r.Title, r.URL)
+				}
+				jitter := time.Duration(rand.Int63n(int64(*flagDelay / 2)))
+				time.Sleep(*flagDelay + jitter)
+				continue
+			}
+
+			// Merge with existing reports and update DB
+			updated, err := mergeAndUpdateReports(ctx, db, code, reports)
+			if err != nil {
+				log.Printf("  ERROR updating %s: %v", code, err)
+				atomic.AddInt64(&stats.errors, 1)
+				continue
+			}
+			if updated {
+				atomic.AddInt64(&stats.reportsUpdated, 1)
+			}
+
 			// Jittered delay to be polite
 			jitter := time.Duration(rand.Int63n(int64(*flagDelay / 2)))
 			time.Sleep(*flagDelay + jitter)
-			continue
 		}
-
-		totalReports += len(reports)
-
-		if *flagDryRun {
-			log.Printf("  %s: found %d financial reports", code, len(reports))
-			for _, r := range reports {
-				log.Printf("    [%s] %s — %s", r.Date, r.Title, r.URL)
-			}
-			jitter := time.Duration(rand.Int63n(int64(*flagDelay / 2)))
-			time.Sleep(*flagDelay + jitter)
-			continue
-		}
-
-		// Merge with existing reports and update DB
-		updated, err := mergeAndUpdateReports(ctx, db, code, reports)
-		if err != nil {
-			log.Printf("  ERROR updating %s: %v", code, err)
-			totalErrors++
-			continue
-		}
-		if updated {
-			totalUpdated++
-		}
-
-		// Jittered delay to be polite
-		jitter := time.Duration(rand.Int63n(int64(*flagDelay / 2)))
-		time.Sleep(*flagDelay + jitter)
 	}
 
-	log.Printf("Done! Processed: %d, Reports found: %d, DB updated: %d, Announcements: %d (stored: %d), News: %d, Director trades: %d, Dividends: %d, Errors: %d",
-		totalProcessed, totalReports, totalUpdated, totalAnnouncements, totalAnnStored, totalNewsStored, totalDirTrades, totalDividends, totalErrors)
+	wg.Add(numWorkers)
+	for w := 0; w < numWorkers; w++ {
+		go worker()
+	}
+	for _, code := range codes {
+		codesCh <- code
+	}
+	close(codesCh)
+	wg.Wait()
+
+	// NOTE: "financial_reports updated" is legitimately near-zero on steady-state
+	// runs (the JSONB merge is idempotent once a stock's report URLs are known).
+	// The real work is the announcements/news/dir-trades/dividends written below.
+	log.Printf("Done! Processed: %d, Reports found: %d (financial_reports updated: %d), Announcements: %d (stored: %d), News: %d, Director trades: %d, Dividends: %d, Errors: %d",
+		atomic.LoadInt64(&stats.processed), atomic.LoadInt64(&stats.reports), atomic.LoadInt64(&stats.reportsUpdated),
+		atomic.LoadInt64(&stats.announcements), atomic.LoadInt64(&stats.annStored), atomic.LoadInt64(&stats.newsStored),
+		atomic.LoadInt64(&stats.dirTrades), atomic.LoadInt64(&stats.dividends), atomic.LoadInt64(&stats.errors))
 
 	// Record sync metrics
 	shortedotel.SyncDuration.Record(ctx, time.Since(syncStart).Seconds(), syncAttrs)
-	shortedotel.SyncRecordsProcessed.Add(ctx, int64(totalProcessed), syncAttrs)
+	shortedotel.SyncRecordsProcessed.Add(ctx, atomic.LoadInt64(&stats.processed), syncAttrs)
 	shortedotel.SyncStatus.Add(ctx, 1, otelmetric.WithAttributes(
 		attribute.String("sync_job", "asx-announcement-crawler"),
 		attribute.String("status", "success"),

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -55,6 +55,8 @@ resource "google_project_service" "required_apis" {
     "compute.googleapis.com",
     "iam.googleapis.com",
     "pubsub.googleapis.com",
+    "monitoring.googleapis.com",
+    "logging.googleapis.com",
   ])
 
   project = var.project_id
@@ -356,8 +358,9 @@ module "signals_collector" {
 }
 
 # Report extractor — director-trade + financial-report digest jobs (§6.9). Scale-to-zero.
-# gemini_secret_exists=false: GEMINI_API_KEY is not yet provisioned in prod, so both jobs
-# deploy but exit early until the secret exists (same posture as weekly-report-generator).
+# gemini_secret_exists=true: the GEMINI_API_KEY secret IS provisioned in prod (enabled
+# version 1, also used by news-aggregator + chat-service). Without it both jobs exit(1)
+# on startup (director) / silently produce zero digests (financial), so it must be wired.
 module "report_extractor" {
   source = "../../modules/report-extractor"
 
@@ -366,12 +369,27 @@ module "report_extractor" {
   scheduler_region     = "australia-southeast1"
   environment          = "production"
   image_url            = var.report_extractor_image
-  gemini_secret_exists = false
+  gemini_secret_exists = true
 
   depends_on = [
     google_project_service.required_apis,
     google_artifact_registry_repository.shorted
   ]
+}
+
+# =============================================================================
+# Observability — Cloud Monitoring alerting on Cloud Run Job failures
+# =============================================================================
+# GCP-native, free, no DB dependency. Pages on hard execution failures AND on
+# ERROR-log / timeout terminations (the "exit 0 but did nothing" class, e.g. the
+# short-data-sync uvicorn-zombie). No-op until alert_recipient_email is set.
+module "job_monitoring" {
+  source = "../../modules/job-monitoring"
+
+  project_id            = var.project_id
+  alert_recipient_email = var.alert_recipient_email
+
+  depends_on = [google_project_service.required_apis]
 }
 
 # =============================================================================

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -164,3 +164,9 @@ variable "cache_purge_secret" {
   sensitive   = true
   default     = ""
 }
+
+variable "alert_recipient_email" {
+  description = "Email for Cloud Run Job failure + ERROR-log/timeout alerts. Empty disables all alerting (the job_monitoring module becomes a no-op)."
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/asx-announcement-crawler/main.tf
+++ b/terraform/modules/asx-announcement-crawler/main.tf
@@ -56,7 +56,11 @@ resource "google_cloud_run_v2_job" "asx_announcement_crawler" {
       service_account = google_service_account.asx_announcement_crawler.email
 
       max_retries = 2
-      timeout     = "14400s" # 4 hours - crawling director trades, dividends, and news for 2024-2026 takes significant time
+      # 90 min cap. The crawl now runs a 6-worker pool (see -workers), finishing
+      # ~4471 stocks in ~1h instead of the old sequential >4h that silently hit
+      # the 14400s timeout at ~3000 stocks. A tighter cap turns a hang into a
+      # fast, visible failure instead of a 4h zombie.
+      timeout = "5400s"
 
       containers {
         image = var.image_url
@@ -64,7 +68,9 @@ resource "google_cloud_run_v2_job" "asx_announcement_crawler" {
         # Enable director trades, dividends, news, and all-announcements extraction.
         # -all-announcements populates the asx_announcements table (material events:
         # trading halts, capital raises, takeovers) which feeds the event timeline.
-        args = ["-director-trades", "-dividends", "-news-table", "-all-announcements", "-years", "2024,2025,2026"]
+        # -workers 6: bounded concurrent crawl pool (network-bound; respects ASX
+        # rate limits via the per-stock jittered delay inside each worker).
+        args = ["-director-trades", "-dividends", "-news-table", "-all-announcements", "-years", "2024,2025,2026", "-workers", "6"]
 
         env {
           name  = "ENVIRONMENT"
@@ -104,8 +110,10 @@ resource "google_cloud_run_v2_job" "asx_announcement_crawler" {
 
         resources {
           limits = {
-            cpu    = "1"
-            memory = "512Mi"
+            # 2 vCPU + 1Gi for the 6-worker pool (concurrent HTML parsing with
+            # goquery + several in-flight response bodies). 512Mi was tight.
+            cpu    = "2"
+            memory = "1Gi"
           }
         }
       }

--- a/terraform/modules/job-monitoring/main.tf
+++ b/terraform/modules/job-monitoring/main.tf
@@ -1,0 +1,153 @@
+# Job monitoring — GCP-native crash + error backstop for all scheduled jobs.
+#
+# Two complementary alerts, both free Cloud Monitoring config (no DB, no app code):
+#  1. cloud_run_job_failed   — fires when a Cloud Run Job EXECUTION is marked
+#     failed (non-zero exit, OOM, startup failure). Catches hard crashes like the
+#     director-trade-extractor exit(1) on a missing API key.
+#  2. job_log_errors         — fires on ERROR-severity logs or "Terminating task
+#     … timeout" terminations. Catches the silent class the count metric misses:
+#     a job that exits 0 having done nothing, or runs to its timeout (e.g. the
+#     short-data-sync uvicorn-zombie that sat "running" for ~18h).
+#
+# The filters match resource.type="cloud_run_job", so EVERY Cloud Run Job in the
+# project is covered automatically — no per-job allowlist to maintain.
+#
+# All resources are gated on alert_recipient_email, so the module is a no-op
+# until an address is provided.
+
+locals {
+  enabled = var.alert_recipient_email != ""
+}
+
+# Email notification channel.
+resource "google_monitoring_notification_channel" "email" {
+  count        = local.enabled ? 1 : 0
+  project      = var.project_id
+  display_name = "Job alerts (email)"
+  type         = "email"
+
+  labels = {
+    email_address = var.alert_recipient_email
+  }
+}
+
+# Alert 1: any Cloud Run Job had a FAILED execution. Grouped by job name so each
+# failing job raises its own incident.
+resource "google_monitoring_alert_policy" "cloud_run_job_failed" {
+  count        = local.enabled ? 1 : 0
+  project      = var.project_id
+  display_name = "Cloud Run Job execution failed"
+  combiner     = "OR"
+  severity     = "ERROR"
+
+  conditions {
+    display_name = "A Cloud Run Job execution failed"
+
+    condition_threshold {
+      filter = join(" AND ", [
+        "resource.type = \"cloud_run_job\"",
+        "metric.type = \"run.googleapis.com/job/completed_execution_count\"",
+        "metric.label.\"result\" = \"failed\"",
+      ])
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = ["resource.label.\"job_name\""]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
+
+  documentation {
+    content   = "A Cloud Run Job execution failed (non-zero exit / OOM / startup failure). Check the job's logs in Cloud Run and the admin Jobs overview at /admin."
+    mime_type = "text/markdown"
+  }
+
+  alert_strategy {
+    # Auto-close if no further failures for 30m (the next successful scheduled run
+    # is the real "all clear"; this just keeps incidents tidy).
+    auto_close = "1800s"
+  }
+}
+
+# Log-based metric: ERROR-severity lines or timeout/deadline terminations from any
+# Cloud Run Job, labelled by job name.
+resource "google_logging_metric" "job_errors" {
+  count   = local.enabled ? 1 : 0
+  project = var.project_id
+  name    = "cloud_run_job_errors"
+  filter = join(" AND ", [
+    "resource.type=\"cloud_run_job\"",
+    "(severity>=ERROR OR textPayload:\"Terminating task\" OR textPayload:\"DeadlineExceeded\")",
+  ])
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    labels {
+      key         = "job_name"
+      value_type  = "STRING"
+      description = "Cloud Run Job name"
+    }
+  }
+
+  label_extractors = {
+    "job_name" = "EXTRACT(resource.labels.job_name)"
+  }
+}
+
+# Alert 2: a Cloud Run Job logged an ERROR or hit a timeout termination. Catches
+# the "exit 0 but did nothing" / zombie-timeout class the count metric misses.
+resource "google_monitoring_alert_policy" "job_log_errors" {
+  count        = local.enabled ? 1 : 0
+  project      = var.project_id
+  display_name = "Cloud Run Job logged ERROR / timeout"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "A Cloud Run Job emitted an ERROR log or timed out"
+
+    condition_threshold {
+      filter = join(" AND ", [
+        "resource.type = \"cloud_run_job\"",
+        "metric.type = \"logging.googleapis.com/user/${google_logging_metric.job_errors[0].name}\"",
+      ])
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = ["metric.label.\"job_name\""]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
+
+  documentation {
+    content   = "A Cloud Run Job logged an ERROR-severity line or was terminated for hitting its task timeout. Catches jobs that exit 0 having done nothing and runs that hang to their deadline. Tune the log filter if a job emits non-fatal ERRORs. Check logs + /admin."
+    mime_type = "text/markdown"
+  }
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+}

--- a/terraform/modules/job-monitoring/outputs.tf
+++ b/terraform/modules/job-monitoring/outputs.tf
@@ -1,0 +1,14 @@
+output "notification_channel_id" {
+  description = "ID of the email notification channel (empty if disabled)"
+  value       = local.enabled ? google_monitoring_notification_channel.email[0].id : ""
+}
+
+output "alert_policy_id" {
+  description = "ID of the Cloud Run Job failure alert policy (empty if disabled)"
+  value       = local.enabled ? google_monitoring_alert_policy.cloud_run_job_failed[0].id : ""
+}
+
+output "log_alert_policy_id" {
+  description = "ID of the Cloud Run Job ERROR/timeout log alert policy (empty if disabled)"
+  value       = local.enabled ? google_monitoring_alert_policy.job_log_errors[0].id : ""
+}

--- a/terraform/modules/job-monitoring/variables.tf
+++ b/terraform/modules/job-monitoring/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "alert_recipient_email" {
+  description = "Email address for Cloud Run Job failure + ERROR/timeout alerts. If empty, no notification channel or alert policies are created (module is a no-op)."
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/short-data-sync/main.tf
+++ b/terraform/modules/short-data-sync/main.tf
@@ -103,6 +103,9 @@ resource "google_cloud_run_v2_job" "short_data_sync" {
       containers {
         image = var.image_url
         # Use Dockerfile's default CMD: python comprehensive_daily_sync.py
+        # NOTE: the deployed image is built from services/daily-sync/Dockerfile
+        # (CMD ["python","comprehensive_daily_sync.py"]) — NOT services/short-data-sync/.
+        # Do not override the command here unless you also repoint the build.
 
         env {
           name  = "ENVIRONMENT"


### PR DESCRIPTION
The new `/admin` jobs dashboard (#206) revealed scheduled jobs failing **silently for weeks** with no alerting. Each was root-caused from prod logs/config and **validated by running the jobs in prod**.

## Job fixes

**director-trade-extractor + financial-report-extractor** — exited(1) on `GEMINI_API_KEY (or LANGEXTRACT_API_KEY) required`. The `report-extractor` module already wires the key; it was gated behind `gemini_secret_exists = false` in prod. **Fix:** flip the flag → wires `GEMINI_API_KEY` + `LANGEXTRACT_API_KEY` + secretAccessor IAM for both jobs.
- ⚠️ Validation uncovered two further layers: (a) the Secret Manager `GEMINI_API_KEY` **value** was invalid (HTTP 400) — **rotated to the working key** out-of-band (new version, validates 200; also un-breaks news-aggregator/weekly-report Gemini paths); (b) the Gemini project has **exceeded its monthly spend cap** (HTTP 429) — director now exits 0 gracefully but extracts nothing until the cap is raised at ai.studio/spend. **That last one is a billing decision, not code.**

**asx-announcement-crawler** — hit its 4h timeout at ~3000/4471 stocks crawling sequentially. **Fix:** bounded worker pool (`-workers`, default 6; each worker its own stealth client; per-stock jittered delay preserved) → ~6× faster (~1h). cpu 1→2, mem 512Mi→1Gi, timeout 14400s→5400s. The "0 updated" was a *misleading metric* (idempotent `financial_reports` merge counter) — logs now report real announcement/news/dir-trade/dividend write counts. (Builds from `services/asx-announcement-crawler` — confirmed in the CI matrix, so the Go change deploys.)

**shorts-data-sync** — **correction:** this is NOT a uvicorn zombie. The deployed image is built from `services/daily-sync/Dockerfile` (`CMD python comprehensive_daily_sync.py`, a run-once sync) — **not** `services/short-data-sync/`. Its intermittent failures are timeouts of that slow ~6h deprecated sync — a separate effort. **No functional change**; added a NOTE documenting the build-context landmine. (An earlier wrong fix was applied + reverted in prod during validation.)

**signals-collector** — verified sound (`--workers 2`), just not-run-yet.

## Observability / error reporting
New `terraform/modules/job-monitoring` — GCP Cloud Monitoring alerting, **no DB dependency**:
1. alert on **failed Cloud Run Job executions**;
2. **log-based metric + alert** on ERROR logs / `Terminating task` timeouts (the exit-0/timeout class the count metric misses).

Email channel via `alert_recipient_email`, wired through `TF_VAR_alert_recipient_email` (repo secret `ALERT_RECIPIENT_EMAIL` = ben.ebsworth@gmail.com) in the plan + apply steps; `monitoring`+`logging` APIs added to `required_apis`.
- Known gap: a job that exits 0 having done nothing (e.g. Gemini quota-exhausted, logged WARNING) isn't caught — best addressed later by per-job record-count instrumentation.

## Verification
- `go build`/`vet`/`golangci-lint` clean on the crawler; `terraform fmt` clean; `job-monitoring` `terraform validate` passes.
- Validated GEMINI + (reverted) shorts fixes by executing the jobs in prod and reading logs.

## Deploy notes
- Merge → CI rebuilds the asx-crawler image + `terraform apply` deploys everything (GEMINI flag, asx config, observability + alerts).
- After deploy: trigger one manual run per fixed job; seed `asx_announcements` once before relying on the parallel daily run.
- **Action required (billing):** raise the Gemini monthly spend cap to make director/financial actually extract.