### PR TITLE
feat(housing): rock-solid stealth crawl tier + collector deploy job

### DIFF
--- a/services/house-price-collector/Dockerfile
+++ b/services/house-price-collector/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+FROM scratch AS stealth
+FROM golang:1.26.0 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+# Download dependencies (with private module auth if available). The collector
+# imports services/pkg/stealthhttp for the crawl tier, which depends on the
+# skunkworq/stealth private module — same bind-mount/PAT pattern as the other
+# stealth-using services.
+RUN --mount=type=secret,id=github_token \
+    --mount=type=bind,from=stealth,target=/stealth-src \
+    if [ -f /run/secrets/github_token ]; then \
+      git config --global url."https://x-access-token:$(cat /run/secrets/github_token)@github.com/skunkworq/".insteadOf "https://github.com/skunkworq/"; \
+    elif [ -f /stealth-src/go.mod ]; then \
+      cp -r /stealth-src /stealth && \
+      go mod edit -replace github.com/skunkworq/stealth=/stealth && \
+      cp go.mod /tmp/go.mod.stealth; \
+    fi && \
+    GOPRIVATE=github.com/skunkworq/* GONOSUMCHECK=github.com/skunkworq/* go mod download && \
+    rm -f ~/.gitconfig
+
+COPY . .
+
+# Restore go.mod with the replace directive if using local stealth source.
+RUN [ -f /tmp/go.mod.stealth ] && cp /tmp/go.mod.stealth go.mod || true
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /house-price-collector ./house-price-collector/
+
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /house-price-collector /house-price-collector
+
+# Default mode is "all" = ABS/RBA official ingest + MV refresh. The supplementary
+# crawl (-mode crawl) is opt-in and needs Chromium + residential egress — it is
+# NOT run by the scheduled job.
+ENTRYPOINT ["/house-price-collector"]

--- a/services/house-price-collector/crawl.go
+++ b/services/house-price-collector/crawl.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/castlemilk/shorted.com.au/services/pkg/stealthhttp"
+)
+
+// The Tier-3 crawl. SUPPLEMENTARY and OPTIONAL: realestate.com.au (Kasada) and
+// domain.com.au (Akamai) actively block and — in REA's case — feed false data to
+// suspected bots. So this tier is built to FAIL SAFE: it never blocks the
+// pipeline, never stores a value that fails validation, and self-throttles via a
+// per-site circuit breaker. The official ABS/RBA backbone is the source of truth;
+// the crawl only ever adds licence-gated suburb detail on top.
+
+type crawlConfig struct {
+	maxSuburbs      int
+	minDelay        time.Duration
+	maxDelay        time.Duration
+	proxy           string
+	disableChromium bool
+	dryRun          bool
+	maxConsecBlocks int
+	perFetchRetries int
+	fetchTimeout    time.Duration
+}
+
+func loadCrawlConfig() crawlConfig {
+	return crawlConfig{
+		maxSuburbs:      envInt("CRAWL_MAX_SUBURBS", len(crawlTargets)),
+		minDelay:        time.Duration(envInt("CRAWL_MIN_DELAY_MS", 5000)) * time.Millisecond,
+		maxDelay:        time.Duration(envInt("CRAWL_MAX_DELAY_MS", 15000)) * time.Millisecond,
+		proxy:           os.Getenv("CRAWL_PROXY"),
+		disableChromium: os.Getenv("CRAWL_DISABLE_CHROMIUM") == "true",
+		dryRun:          os.Getenv("CRAWL_DRY_RUN") == "true",
+		maxConsecBlocks: envInt("CRAWL_MAX_CONSEC_BLOCKS", 3),
+		perFetchRetries: envInt("CRAWL_FETCH_RETRIES", 2),
+		fetchTimeout:    time.Duration(envInt("CRAWL_FETCH_TIMEOUT_S", 30)) * time.Second,
+	}
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+type fetchOutcome int
+
+const (
+	outcomeOK fetchOutcome = iota
+	outcomeBlocked
+	outcomeError
+)
+
+type crawlStats struct {
+	attempted, accepted, blocked, rejected, diverged int
+}
+
+type crawler struct {
+	native    *stealthhttp.Client
+	chromium  *stealthhttp.Client // nil if unavailable
+	baselines map[string]float64  // capital GCCSA region_code -> trusted ABS median
+	cfg       crawlConfig
+	reaBlocks int // consecutive-block counters for the circuit breaker
+	domBlocks int
+	stats     crawlStats
+}
+
+// runCrawl is the -mode=crawl entry point.
+func runCrawl(ctx context.Context, pool *pgxpool.Pool) {
+	cfg := loadCrawlConfig()
+
+	baselines, err := loadCapitalBaselines(ctx, pool)
+	if err != nil {
+		log.Printf("[crawl] ABS baselines unavailable (%v) — capital-band validation OFF, absolute bounds still enforced", err)
+		baselines = map[string]float64{}
+	}
+
+	nativeOpts := []stealthhttp.Option{stealthhttp.WithTimeout(cfg.fetchTimeout)}
+	if cfg.proxy != "" {
+		nativeOpts = append(nativeOpts, stealthhttp.WithProxy(cfg.proxy))
+	}
+	native, err := stealthhttp.New(nativeOpts...)
+	if err != nil {
+		log.Printf("[crawl] native client init failed: %v — aborting crawl (non-fatal)", err)
+		_ = updateRun(ctx, pool, "crawl", nil, 0, "error", "native client init: "+err.Error())
+		return
+	}
+
+	var chromium *stealthhttp.Client
+	if !cfg.disableChromium {
+		copts := []stealthhttp.Option{stealthhttp.WithTimeout(cfg.fetchTimeout + 30*time.Second)}
+		if cfg.proxy != "" {
+			copts = append(copts, stealthhttp.WithProxy(cfg.proxy))
+		}
+		if c, cerr := stealthhttp.NewChromium(copts...); cerr != nil {
+			log.Printf("[crawl] chromium unavailable (%v) — REA/Kasada likely unreachable; native-only", cerr)
+		} else {
+			chromium = c
+		}
+	}
+
+	cr := &crawler{native: native, chromium: chromium, baselines: baselines, cfg: cfg}
+
+	targets := crawlTargets
+	if cfg.maxSuburbs >= 0 && cfg.maxSuburbs < len(targets) {
+		targets = targets[:cfg.maxSuburbs]
+	}
+	log.Printf("[crawl] start: %d suburbs · chromium=%v · proxy=%v · dryRun=%v", len(targets), chromium != nil, cfg.proxy != "", cfg.dryRun)
+
+	var obs []Observation
+	for i, t := range targets {
+		if i > 0 {
+			cr.sleepJitter(ctx)
+		}
+		obs = append(obs, cr.crawlSuburb(ctx, t)...)
+	}
+
+	status, detail := "ok", ""
+	if cfg.dryRun {
+		log.Printf("[crawl] dry-run: %d observations NOT written", len(obs))
+	} else if len(obs) > 0 {
+		if err := upsertRegions(ctx, pool, obs); err != nil {
+			status, detail = "error", err.Error()
+			log.Printf("[crawl] region upsert error: %v", err)
+		} else if n, err := upsertObservations(ctx, pool, obs); err != nil {
+			status, detail = "error", err.Error()
+			log.Printf("[crawl] obs upsert error: %v", err)
+		} else {
+			log.Printf("[crawl] upserted %d suburb observations", n)
+		}
+	}
+	_ = updateRun(ctx, pool, "crawl", nil, len(obs), status, detail)
+
+	s := cr.stats
+	log.Printf("[crawl] done: attempted=%d accepted=%d blocked=%d rejected=%d diverged=%d",
+		s.attempted, s.accepted, s.blocked, s.rejected, s.diverged)
+}
+
+// crawlSuburb fetches both sources, validates, and applies the cross-source
+// trust rule. Returns the observations to store (0, 1, or 2).
+func (cr *crawler) crawlSuburb(ctx context.Context, t CrawlTarget) []Observation {
+	cr.stats.attempted++
+	base := cr.baselines[t.Capital] // 0 == unknown -> capital-band check skipped
+
+	reaMed, reaOK := cr.siteMedian(ctx, "rea", t.reaURL(), base, &cr.reaBlocks)
+	domMed, domOK := cr.siteMedian(ctx, "domain", t.domainURL(), base, &cr.domBlocks)
+
+	switch {
+	case reaOK && domOK:
+		if !crossSourceAgrees(reaMed, domMed) {
+			cr.stats.diverged++
+			log.Printf("[crawl] %s: REA $%.0f vs Domain $%.0f diverge — rejecting BOTH (possible poisoning)", t.Display, reaMed, domMed)
+			return nil
+		}
+		cr.stats.accepted++
+		log.Printf("[crawl] %s: accepted (REA $%.0f ~ Domain $%.0f)", t.Display, reaMed, domMed)
+		return []Observation{cr.obs(t, reaMed, "crawl_rea", false), cr.obs(t, domMed, "crawl_domain", false)}
+	case reaOK:
+		cr.stats.accepted++
+		log.Printf("[crawl] %s: accepted single-source REA $%.0f (preliminary)", t.Display, reaMed)
+		return []Observation{cr.obs(t, reaMed, "crawl_rea", true)}
+	case domOK:
+		cr.stats.accepted++
+		log.Printf("[crawl] %s: accepted single-source Domain $%.0f (preliminary)", t.Display, domMed)
+		return []Observation{cr.obs(t, domMed, "crawl_domain", true)}
+	default:
+		return nil
+	}
+}
+
+// siteMedian fetches one source (with the circuit breaker), extracts candidate
+// medians and returns the validated robust median for that page.
+func (cr *crawler) siteMedian(ctx context.Context, site, url string, baseline float64, blockCounter *int) (float64, bool) {
+	if *blockCounter >= cr.cfg.maxConsecBlocks {
+		return 0, false // breaker open: stop hammering this source for the rest of the run
+	}
+
+	doc, outcome := cr.fetchWaterfall(ctx, url)
+	switch outcome {
+	case outcomeBlocked:
+		*blockCounter++
+		cr.stats.blocked++
+		if *blockCounter == cr.cfg.maxConsecBlocks {
+			log.Printf("[crawl] %s circuit-breaker tripped (%d consecutive blocks) — skipping remaining %s fetches", site, *blockCounter, site)
+		}
+		return 0, false
+	case outcomeError:
+		return 0, false
+	}
+	*blockCounter = 0 // a success resets the breaker
+
+	candidates := extractSaleMedians(doc)
+	med, ok := robustMedian(candidates, baseline)
+	if !ok {
+		if len(candidates) > 0 {
+			cr.stats.rejected++ // page returned numbers but none survived validation (poison / wrong page)
+		}
+		return 0, false
+	}
+	return med, true
+}
+
+// fetchWaterfall tries the cheap native engine first, then escalates to Chromium
+// (for JS challenges) only if the native fetch was actively blocked.
+func (cr *crawler) fetchWaterfall(ctx context.Context, url string) (*goquery.Document, fetchOutcome) {
+	doc, oc := cr.fetchOne(ctx, cr.native, url)
+	if oc == outcomeOK {
+		return doc, outcomeOK
+	}
+	if oc == outcomeBlocked && cr.chromium != nil {
+		if doc2, oc2 := cr.fetchOne(ctx, cr.chromium, url); oc2 == outcomeOK {
+			return doc2, outcomeOK
+		} else if oc2 == outcomeBlocked {
+			return nil, outcomeBlocked
+		}
+	}
+	return nil, oc
+}
+
+// fetchOne fetches with one engine, retrying transient failures with quadratic
+// backoff but returning immediately on a hard block (403/429/401).
+func (cr *crawler) fetchOne(ctx context.Context, client *stealthhttp.Client, url string) (*goquery.Document, fetchOutcome) {
+	if client == nil {
+		return nil, outcomeError
+	}
+	for attempt := 0; attempt <= cr.cfg.perFetchRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(time.Duration(attempt*attempt) * time.Second):
+			case <-ctx.Done():
+				return nil, outcomeError
+			}
+		}
+		doc, _, err := client.FetchHTML(ctx, url)
+		if err == nil {
+			return doc, outcomeOK
+		}
+		switch stealthhttp.StatusError(err) {
+		case 401, 403, 429:
+			return nil, outcomeBlocked // hard block — don't retry the same engine
+		}
+		// otherwise transient (timeout / 5xx / network) — retry
+	}
+	return nil, outcomeError
+}
+
+func (cr *crawler) obs(t CrawlTarget, value float64, source string, prelim bool) Observation {
+	return Observation{
+		RegionCode:    t.regionCode(),
+		RegionType:    "suburb",
+		RegionName:    t.regionName(),
+		StateCode:     t.State,
+		Postcode:      t.Postcode,
+		Measure:       "median_price",
+		DwellingType:  "all",
+		Period:        currentQuarterEnd(),
+		PeriodFreq:    "Q",
+		Value:         value,
+		Unit:          "AUD",
+		IsPreliminary: prelim,
+		Source:        source,
+		// ToS-restricted: gated out of any commercial/republished surface via
+		// the house_prices.source_licence column.
+		SourceLicence: "proprietary-tos-restricted",
+	}
+}
+
+func (cr *crawler) sleepJitter(ctx context.Context) {
+	d := cr.cfg.minDelay
+	if cr.cfg.maxDelay > cr.cfg.minDelay {
+		d += time.Duration(rand.Int63n(int64(cr.cfg.maxDelay - cr.cfg.minDelay)))
+	}
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}
+
+// loadCapitalBaselines reads the trusted ABS GCCSA established-house medians that
+// every crawled value is validated against.
+func loadCapitalBaselines(ctx context.Context, pool *pgxpool.Pool) (map[string]float64, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT region_code, value FROM mv_housing_headline
+		WHERE measure = 'median_price' AND dwelling_type = 'established_house'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	m := map[string]float64{}
+	for rows.Next() {
+		var code string
+		var val float64
+		if err := rows.Scan(&code, &val); err != nil {
+			return nil, err
+		}
+		m[code] = val
+	}
+	return m, rows.Err()
+}
+
+func currentQuarterEnd() time.Time {
+	now := time.Now().UTC()
+	q := (int(now.Month())-1)/3 + 1
+	firstNext := time.Date(now.Year(), time.Month(q*3)+1, 1, 0, 0, 0, 0, time.UTC)
+	return firstNext.AddDate(0, 0, -1)
+}

--- a/services/house-price-collector/crawl_extract.go
+++ b/services/house-price-collector/crawl_extract.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// Extraction is deliberately schema-AGNOSTIC. realestate.com.au embeds state in
+// `window.ArgonautExchange` and domain.com.au in `__NEXT_DATA__`, but the exact
+// key paths are unverified and change often — and Kasada serves *deliberately
+// different* DOM to bots. So we never bind to a fixed path: we harvest every
+// "median sale price"-looking number from every JSON blob on the page and let
+// the validator (crawl_validate.go) decide what to trust.
+
+var assignOpenRe = regexp.MustCompile(`=\s*[\{\[]`)
+
+// extractSaleMedians walks every <script> JSON blob and returns all candidate
+// median *sale* prices found (rent and non-numeric values excluded).
+func extractSaleMedians(doc *goquery.Document) []float64 {
+	var out []float64
+	doc.Find("script").Each(func(_ int, s *goquery.Selection) {
+		for _, blob := range jsonBlobs(s.Text()) {
+			var v any
+			if err := json.Unmarshal([]byte(blob), &v); err != nil {
+				continue
+			}
+			walkForMedians(v, &out)
+		}
+	})
+	return out
+}
+
+func walkForMedians(v any, out *[]float64) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if isSaleMedianKey(k) {
+				if n, ok := toMoney(child); ok {
+					*out = append(*out, n)
+				}
+			}
+			walkForMedians(child, out)
+		}
+	case []any:
+		for _, child := range t {
+			walkForMedians(child, out)
+		}
+	}
+}
+
+// isSaleMedianKey matches keys like medianPrice / medianSoldPrice /
+// medianSalePrice, but never rent.
+func isSaleMedianKey(k string) bool {
+	kl := strings.ToLower(k)
+	if !strings.Contains(kl, "median") || strings.Contains(kl, "rent") {
+		return false
+	}
+	return strings.Contains(kl, "price") || strings.Contains(kl, "sold") || strings.Contains(kl, "sale")
+}
+
+func toMoney(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, t > 0
+	case json.Number:
+		f, err := t.Float64()
+		return f, err == nil && f > 0
+	case string:
+		return parseMoney(t)
+	}
+	return 0, false
+}
+
+var moneyRe = regexp.MustCompile(`([0-9][0-9,]*\.?[0-9]*)\s*([mk])?`)
+
+// parseMoney handles "$1.25m", "1,250,000", "$985k", "1.2 M".
+func parseMoney(s string) (float64, bool) {
+	m := moneyRe.FindStringSubmatch(strings.ToLower(strings.TrimSpace(s)))
+	if m == nil {
+		return 0, false
+	}
+	num, err := strconv.ParseFloat(strings.ReplaceAll(m[1], ",", ""), 64)
+	if err != nil {
+		return 0, false
+	}
+	switch m[2] {
+	case "m":
+		num *= 1_000_000
+	case "k":
+		num *= 1_000
+	}
+	return num, num > 0
+}
+
+// jsonBlobs returns candidate JSON object/array substrings from a <script> body:
+// the whole body when it's raw JSON (e.g. __NEXT_DATA__), plus any `x = {…}`
+// assignment value (e.g. window.ArgonautExchange).
+func jsonBlobs(text string) []string {
+	var blobs []string
+	if t := strings.TrimSpace(text); len(t) > 0 && (t[0] == '{' || t[0] == '[') {
+		if b, ok := balancedJSON(t, 0); ok {
+			blobs = append(blobs, b)
+		}
+	}
+	for _, loc := range assignOpenRe.FindAllStringIndex(text, -1) {
+		if b, ok := balancedJSON(text, loc[1]-1); ok {
+			blobs = append(blobs, b)
+		}
+	}
+	return blobs
+}
+
+// balancedJSON returns the balanced {…} or […] substring beginning at `start`,
+// respecting string literals and escapes (so braces inside strings don't count).
+func balancedJSON(s string, start int) (string, bool) {
+	if start < 0 || start >= len(s) {
+		return "", false
+	}
+	open := s[start]
+	var closer byte
+	switch open {
+	case '{':
+		closer = '}'
+	case '[':
+		closer = ']'
+	default:
+		return "", false
+	}
+	depth, inStr, esc := 0, false, false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case open:
+			depth++
+		case closer:
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}

--- a/services/house-price-collector/crawl_targets.go
+++ b/services/house-price-collector/crawl_targets.go
@@ -1,0 +1,47 @@
+package main
+
+import "strings"
+
+// CrawlTarget is one suburb to crawl. Capital is the GCCSA region_code of the
+// suburb's capital city (e.g. "1GSYD"), used to look up the TRUSTED ABS median
+// that every crawled value is validated against.
+type CrawlTarget struct {
+	Suburb   string // url slug: "bondi", "st-kilda"
+	Display  string // "Bondi"
+	Postcode string // "2026"
+	State    string // "NSW"
+	Capital  string // GCCSA region_code: "1GSYD"
+}
+
+// A tight, curated seed set — deliberately small so the default footprint stays
+// low (suburb medians move monthly at most). A production run would expand this
+// from an ABS suburb gazetteer.
+var crawlTargets = []CrawlTarget{
+	{"bondi", "Bondi", "2026", "NSW", "1GSYD"},
+	{"parramatta", "Parramatta", "2150", "NSW", "1GSYD"},
+	{"chatswood", "Chatswood", "2067", "NSW", "1GSYD"},
+	{"st-kilda", "St Kilda", "3182", "VIC", "2GMEL"},
+	{"brunswick", "Brunswick", "3056", "VIC", "2GMEL"},
+	{"south-yarra", "South Yarra", "3141", "VIC", "2GMEL"},
+	{"new-farm", "New Farm", "4005", "QLD", "3GBRI"},
+	{"toowong", "Toowong", "4066", "QLD", "3GBRI"},
+	{"glenelg", "Glenelg", "5045", "SA", "4GADE"},
+	{"fremantle", "Fremantle", "6160", "WA", "5GPER"},
+}
+
+func (t CrawlTarget) reaURL() string {
+	return "https://www.realestate.com.au/neighbourhoods/" + t.Suburb + "-" + t.Postcode + "-" + strings.ToLower(t.State)
+}
+
+func (t CrawlTarget) domainURL() string {
+	return "https://www.domain.com.au/suburb-profile/" + t.Suburb + "-" + strings.ToLower(t.State) + "-" + t.Postcode
+}
+
+// regionCode is the canonical house_price_regions key for a suburb.
+func (t CrawlTarget) regionCode() string {
+	return "SUBURB:" + t.State + "-" + t.Postcode + "-" + strings.ToUpper(t.Suburb)
+}
+
+func (t CrawlTarget) regionName() string {
+	return t.Display + ", " + t.State + " " + t.Postcode
+}

--- a/services/house-price-collector/crawl_test.go
+++ b/services/house-price-collector/crawl_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// These tests are the crawl tier's "rock solid" proof: the anti-poisoning
+// guarantees are verified here, not against the live (adversarial) sites.
+
+func TestValidateMedian_AbsoluteBounds(t *testing.T) {
+	cases := []struct {
+		name  string
+		value float64
+		base  float64
+		want  bool
+	}{
+		{"too low", 50_000, 0, false},
+		{"too high", 80_000_000, 0, false},
+		{"plausible, no baseline", 1_200_000, 0, true},
+		{"zero", 0, 0, false},
+		{"floor ok", 100_000, 0, true},
+	}
+	for _, c := range cases {
+		if got := validateMedian(c.value, c.base).ok; got != c.want {
+			t.Errorf("%s: validateMedian(%v,%v).ok=%v want %v", c.name, c.value, c.base, got, c.want)
+		}
+	}
+}
+
+func TestValidateMedian_CapitalBand(t *testing.T) {
+	const sydney = 1_485_000.0
+	// In-band: a premium suburb at ~2.4× the capital median.
+	if !validateMedian(3_500_000, sydney).ok {
+		t.Error("premium suburb within band should pass")
+	}
+	// Poison: a Kasada-style fixed/garbage value far outside the band.
+	if validateMedian(25_000_000, sydney).ok {
+		t.Error("value 16x the capital median should be rejected")
+	}
+	if validateMedian(150_000, sydney).ok {
+		t.Error("value at 10% of the capital median should be rejected")
+	}
+}
+
+func TestRobustMedian_DropsPoisonOutlier(t *testing.T) {
+	const sydney = 1_485_000.0
+	// Three plausible + one poisoned outlier that sneaks past absolute bounds.
+	cands := []float64{1_800_000, 1_900_000, 2_000_000, 49_000_000}
+	med, ok := robustMedian(cands, sydney)
+	if !ok {
+		t.Fatal("expected a robust median")
+	}
+	if med < 1_800_000 || med > 2_000_000 {
+		t.Errorf("robust median %v should be among the plausible cluster, not dragged by the outlier", med)
+	}
+}
+
+func TestRobustMedian_AllPoisonReturnsFalse(t *testing.T) {
+	const sydney = 1_485_000.0
+	if _, ok := robustMedian([]float64{40_000_000, 60_000_000, 90_000_000}, sydney); ok {
+		t.Error("a fully-poisoned page must yield no value")
+	}
+	if _, ok := robustMedian(nil, sydney); ok {
+		t.Error("empty candidates must yield no value")
+	}
+}
+
+func TestCrossSourceAgrees(t *testing.T) {
+	if !crossSourceAgrees(1_500_000, 1_600_000) {
+		t.Error("6.25%% apart should agree")
+	}
+	if crossSourceAgrees(1_500_000, 2_500_000) {
+		t.Error("40%% apart should NOT agree (one source likely poisoned)")
+	}
+	if crossSourceAgrees(0, 1_500_000) {
+		t.Error("a zero source can't agree")
+	}
+}
+
+func TestParseMoney(t *testing.T) {
+	cases := map[string]float64{
+		"$1.25m":     1_250_000,
+		"1,250,000":  1_250_000,
+		"$985k":      985_000,
+		"$1.2 M":     1_200_000,
+		"not a price": 0,
+	}
+	for in, want := range cases {
+		got, ok := parseMoney(in)
+		if want == 0 {
+			if ok {
+				t.Errorf("parseMoney(%q) should fail", in)
+			}
+			continue
+		}
+		if !ok || got != want {
+			t.Errorf("parseMoney(%q)=%v,%v want %v", in, got, ok, want)
+		}
+	}
+}
+
+func TestBalancedJSON_NestedAndStrings(t *testing.T) {
+	in := `prefix = {"a":1,"b":{"c":[2,3]},"s":"a } brace in a string"};suffix`
+	want := `{"a":1,"b":{"c":[2,3]},"s":"a } brace in a string"}`
+	got, ok := balancedJSON(in, strings.IndexByte(in, '{'))
+	if !ok || got != want {
+		t.Errorf("balancedJSON got %q ok=%v want %q", got, ok, want)
+	}
+}
+
+func docFrom(html string) *goquery.Document {
+	d, _ := goquery.NewDocumentFromReader(strings.NewReader(html))
+	return d
+}
+
+func TestExtractSaleMedians_DomainNextData(t *testing.T) {
+	// Domain-style embedded JSON (raw JSON in __NEXT_DATA__ script).
+	html := `<html><body><script id="__NEXT_DATA__" type="application/json">
+	{"props":{"suburbInsights":{"medianPrice":1850000,"medianRentPrice":850,"avgDaysOnMarket":42}}}
+	</script></body></html>`
+	got := extractSaleMedians(docFrom(html))
+	if len(got) != 1 || got[0] != 1_850_000 {
+		t.Errorf("expected [1850000], got %v (rent must be excluded)", got)
+	}
+}
+
+func TestExtractSaleMedians_REAArgonaut(t *testing.T) {
+	// REA-style window assignment with a stringified money value.
+	html := `<html><body><script>
+	window.ArgonautExchange = {"suburb":{"metrics":{"medianSoldPrice":"$2.1m","medianRentPrice":"$1,100"}}};
+	</script></body></html>`
+	got := extractSaleMedians(docFrom(html))
+	if len(got) != 1 || got[0] != 2_100_000 {
+		t.Errorf("expected [2100000], got %v", got)
+	}
+}

--- a/services/house-price-collector/crawl_validate.go
+++ b/services/house-price-collector/crawl_validate.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"math"
+	"sort"
+)
+
+// The crawl tier's trust model: realestate.com.au (Kasada) is known to serve
+// DELIBERATELY FALSE data to clients it suspects are bots, and domain.com.au
+// (Akamai) blocks outright. So a crawled number is guilty until proven innocent.
+// Every candidate must survive THREE independent checks before it is stored:
+//
+//  1. Absolute sanity bounds (a suburb median is never < $100k or > $50M).
+//  2. Plausibility vs the TRUSTED ABS capital-city median for that market
+//     (a real suburb sits within a sane band of its capital's median).
+//  3. Cross-source agreement (REA vs Domain) where both are available.
+//
+// A value that fails any check is dropped, never stored. This is what makes the
+// crawl safe to run despite the adversarial, poisoning data source.
+
+const (
+	minPlausibleMedian       = 100_000.0    // $100k absolute floor
+	maxPlausibleMedian       = 50_000_000.0 // $50M absolute ceiling
+	minCapitalRatio          = 0.15         // suburb median ≥ 15% of capital median
+	maxCapitalRatio          = 8.0          // suburb median ≤ 8× capital median
+	maxCrossSourceDivergence = 0.30         // REA vs Domain must agree within 30%
+)
+
+type validation struct {
+	ok     bool
+	reason string
+}
+
+// validateMedian applies the absolute + capital-relative checks to one value.
+// absCapitalMedian ≤ 0 means "no trusted baseline" → the capital check is skipped
+// (the absolute bounds still apply).
+func validateMedian(value, absCapitalMedian float64) validation {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return validation{false, "non-finite"}
+	}
+	if value < minPlausibleMedian || value > maxPlausibleMedian {
+		return validation{false, "out-of-absolute-bounds"}
+	}
+	if absCapitalMedian > 0 {
+		r := value / absCapitalMedian
+		if r < minCapitalRatio || r > maxCapitalRatio {
+			return validation{false, "out-of-capital-band"}
+		}
+	}
+	return validation{true, ""}
+}
+
+// robustMedian filters a page's raw candidate medians through validateMedian and
+// returns the MEDIAN of the survivors — a central estimate that shrugs off a
+// stray poisoned outlier even if it happens to land inside the bounds. Returns
+// (0, false) if nothing survives (blocked page / fully poisoned / empty).
+func robustMedian(candidates []float64, absCapitalMedian float64) (float64, bool) {
+	var ok []float64
+	for _, c := range candidates {
+		if validateMedian(c, absCapitalMedian).ok {
+			ok = append(ok, c)
+		}
+	}
+	if len(ok) == 0 {
+		return 0, false
+	}
+	sort.Float64s(ok)
+	n := len(ok)
+	if n%2 == 1 {
+		return ok[n/2], true
+	}
+	return (ok[n/2-1] + ok[n/2]) / 2, true
+}
+
+// crossSourceAgrees reports whether two independent suburb medians agree within
+// the divergence threshold — a strong anti-poisoning signal (a poisoned source
+// will rarely match a clean one).
+func crossSourceAgrees(a, b float64) bool {
+	if a <= 0 || b <= 0 {
+		return false
+	}
+	hi, lo := a, b
+	if lo > hi {
+		hi, lo = lo, hi
+	}
+	return (hi-lo)/hi <= maxCrossSourceDivergence
+}

--- a/services/house-price-collector/main.go
+++ b/services/house-price-collector/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	mode := flag.String("mode", "all", "official | refresh | all")
+	mode := flag.String("mode", "all", "official | crawl | refresh | all")
 	flag.Parse()
 
 	dbURL := os.Getenv("DATABASE_URL")
@@ -36,10 +36,15 @@ func main() {
 	case "official", "abs", "all":
 		runOfficial(ctx, pool)
 		refresh(ctx, pool)
+	case "crawl":
+		// Supplementary suburb crawl — opt-in only, never part of the default
+		// scheduled run (it's slow, adversarial and licence-gated).
+		runCrawl(ctx, pool)
+		refresh(ctx, pool)
 	case "refresh":
 		refresh(ctx, pool)
 	default:
-		log.Fatalf("unknown -mode %q (want official|refresh|all)", *mode)
+		log.Fatalf("unknown -mode %q (want official|crawl|refresh|all)", *mode)
 	}
 }
 

--- a/terraform/modules/house-price-collector/main.tf
+++ b/terraform/modules/house-price-collector/main.tf
@@ -1,0 +1,129 @@
+/**
+ * House-Price Collector Module
+ *
+ * Cloud Run Job + Cloud Scheduler that runs services/house-price-collector in
+ * its default mode (ABS + RBA official ingest + materialized-view refresh).
+ * Monthly cadence catches the quarterly ABS releases (~10-11 weeks after quarter
+ * end). No GCS bucket — the collector fetches ABS/RBA over HTTPS and writes to
+ * Postgres. The supplementary crawl tier (-mode crawl) is NOT scheduled here.
+ */
+
+locals {
+  service_name = "house-price-collector"
+  labels = {
+    service     = "house-price-collector"
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+resource "google_service_account" "collector" {
+  account_id   = local.service_name
+  display_name = "House Price Collector Job"
+  description  = "Service account for the ABS/RBA house-price collector"
+  project      = var.project_id
+}
+
+# Read DATABASE_URL from Secret Manager.
+resource "google_secret_manager_secret_iam_member" "database_url" {
+  secret_id = "DATABASE_URL"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.collector.email}"
+  project   = var.project_id
+}
+
+resource "google_cloud_run_v2_job" "collector" {
+  name     = local.service_name
+  location = var.region
+  project  = var.project_id
+  labels   = local.labels
+
+  template {
+    task_count = 1
+
+    template {
+      service_account = google_service_account.collector.email
+      max_retries     = 2
+      timeout         = "1800s" # 30 min — the official ingest is small and fast
+
+      containers {
+        image = var.image_url
+        # Default ENTRYPOINT runs -mode all (official ingest + MV refresh).
+
+        env {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+        env {
+          name  = "GCP_PROJECT"
+          value = var.project_id
+        }
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = "DATABASE_URL"
+              version = "latest"
+            }
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [google_secret_manager_secret_iam_member.database_url]
+}
+
+# Service account for Cloud Scheduler to invoke the job.
+resource "google_service_account" "scheduler_invoker" {
+  account_id   = "${local.service_name}-sched"
+  display_name = "House Price Collector Scheduler"
+  description  = "Service account for Cloud Scheduler to invoke the house-price collector"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
+  name     = google_cloud_run_v2_job.collector.name
+  location = google_cloud_run_v2_job.collector.location
+  project  = var.project_id
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+resource "google_cloud_scheduler_job" "monthly" {
+  name             = "${local.service_name}-monthly"
+  description      = "Monthly ABS/RBA house-price ingest (catches quarterly releases)"
+  schedule         = "0 16 5 * *" # 5th of month, 16:00 UTC (~2-3 AM AEST)
+  time_zone        = "UTC"
+  attempt_deadline = "1800s"
+  region           = var.scheduler_region
+  project          = var.project_id
+
+  retry_config {
+    retry_count          = 2
+    max_retry_duration   = "3600s"
+    min_backoff_duration = "10s"
+    max_backoff_duration = "600s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.collector.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+    }
+  }
+
+  depends_on = [
+    google_cloud_run_v2_job.collector,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker
+  ]
+}

--- a/terraform/modules/house-price-collector/outputs.tf
+++ b/terraform/modules/house-price-collector/outputs.tf
@@ -1,0 +1,14 @@
+output "job_name" {
+  description = "Name of the Cloud Run job"
+  value       = google_cloud_run_v2_job.collector.name
+}
+
+output "service_account_email" {
+  description = "Email of the collector job's service account"
+  value       = google_service_account.collector.email
+}
+
+output "scheduler_job_name" {
+  description = "Name of the Cloud Scheduler job"
+  value       = google_cloud_scheduler_job.monthly.name
+}

--- a/terraform/modules/house-price-collector/variables.tf
+++ b/terraform/modules/house-price-collector/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud Run job"
+  type        = string
+  default     = "australia-southeast2"
+}
+
+variable "scheduler_region" {
+  description = "GCP region for Cloud Scheduler (only available in southeast1)"
+  type        = string
+  default     = "australia-southeast1"
+}
+
+variable "environment" {
+  description = "Environment name (development, staging, production)"
+  type        = string
+  default     = "production"
+}
+
+variable "image_url" {
+  description = "Docker image URL for the house-price collector Cloud Run job"
+  type        = string
+}


### PR DESCRIPTION
Builds on the merged house-price tracker (#209). Two parts:

## 1. Rock-solid stealth crawl tier (Tier 3 — supplementary, opt-in)

A fail-safe suburb-level crawler for realestate.com.au (Kasada) + domain.com.au (Akamai) via `services/pkg/stealthhttp`. REA **serves deliberately false data to suspected bots**, so the entire tier is *guilty-until-proven-innocent* and built to **never break the pipeline and never ingest bad data**:

- **`crawl_validate.go`** — the trust core. Every value must survive (1) absolute sanity bounds, (2) plausibility vs the **trusted ABS capital-city median**, and (3) **REA↔Domain cross-source agreement**. `robustMedian()` takes the median of survivors so a stray poisoned outlier can't drag the estimate.
- **`crawl_extract.go`** — schema-agnostic extraction (REA/Domain JSON keys are unverified + bot-variant): balanced-brace JSON finder + recursive walk harvesting "median sale price" numbers (rent/non-numeric excluded).
- **`crawl.go`** — native→Chromium waterfall, quadratic-backoff retries, jittered rate-limiting, per-site **circuit breaker**, licence-gated rows (`source_licence='proprietary-tos-restricted'`), all non-fatal. `-mode=crawl`, never in the default scheduled run.

**Verified:** unit tests prove the poisoning/validation/extraction guarantees (`crawl_test.go`); a live dry-run probe degraded gracefully — 4/4 native fetches blocked by Kasada/Akamai → **0 accepted, 0 bad data, no crash**. Live extraction needs residential egress + a challenge solver (flagged, not assumed).

## 2. Collector deploy job

- **Dockerfile** — distroless Go build with the stealth bind-mount/PAT pattern. Default ENTRYPOINT = `-mode all` (official ingest + MV refresh).
- **`terraform/modules/house-price-collector/`** — Cloud Run Job + Scheduler (monthly, catches quarterly ABS releases), SA + Secret Manager IAM, no GCS. Mirrors `short-data-sync`.

## ⚠️ Remaining infra wiring (left for review)
Registering the job into the CI build matrix (`terraform-deploy.yml`) + dev/prod environments (module block + image var) — it touches the prod build/deploy and can't be `terraform validate`d locally. Until then, prod data is refreshed by running the collector manually (the official tier needs no Chromium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)