### PR TITLE
ci(housing): wire house-price-collector Cloud Run Job (Terraform) — plan for review

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -271,6 +271,9 @@ jobs:
           - name: asx-announcement-crawler
             dockerfile: services/asx-announcement-crawler/Dockerfile
             context: services
+          - name: house-price-collector
+            dockerfile: services/house-price-collector/Dockerfile
+            context: services
           - name: signals-collector
             dockerfile: services/signals-collector/Dockerfile
             context: services/signals-collector
@@ -447,6 +450,7 @@ jobs:
             -var="enrichment_processor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/enrichment-processor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="news_aggregator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/news-aggregator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="asx_announcement_crawler_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/asx-announcement-crawler:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="house_price_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/house-price-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="signals_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/signals-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="report_extractor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/report-extractor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="grafana_auth=${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}" \
@@ -1010,6 +1014,7 @@ jobs:
             -var="enrichment_processor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/enrichment-processor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="news_aggregator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/news-aggregator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="asx_announcement_crawler_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/asx-announcement-crawler:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="house_price_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/house-price-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="signals_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/signals-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="report_extractor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/report-extractor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="grafana_auth=${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}" \

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -126,6 +126,17 @@ module "short_data_sync" {
   ]
 }
 
+# House-price collector (ABS/RBA quarterly ingest + MV refresh)
+module "house_price_collector" {
+  source = "../../modules/house-price-collector"
+
+  project_id       = var.project_id
+  region           = var.region
+  scheduler_region = "australia-southeast1" # Cloud Scheduler only available in southeast1
+  environment      = "production"
+  image_url        = var.house_price_collector_image
+}
+
 # Shorts API Service
 module "shorts_api" {
   source = "../../modules/shorts-api"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -22,6 +22,12 @@ variable "short_data_sync_image" {
   default     = "australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/short-data-sync:latest"
 }
 
+variable "house_price_collector_image" {
+  description = "Docker image URL for house-price-collector job"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/shorted-dev-aba5688f/shorted/house-price-collector:latest"
+}
+
 variable "shorts_api_image" {
   description = "Docker image URL for shorts API service"
   type        = string

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -181,6 +181,22 @@ module "short_data_sync" {
   ]
 }
 
+# House-price collector (ABS/RBA quarterly ingest + MV refresh)
+module "house_price_collector" {
+  source = "../../modules/house-price-collector"
+
+  project_id       = var.project_id
+  region           = var.region
+  scheduler_region = "australia-southeast1" # Cloud Scheduler only available in southeast1
+  environment      = "production"
+  image_url        = var.house_price_collector_image
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_artifact_registry_repository.shorted
+  ]
+}
+
 # Shorts API Service
 module "shorts_api" {
   source = "../../modules/shorts-api"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -22,6 +22,12 @@ variable "short_data_sync_image" {
   default     = "australia-southeast2-docker.pkg.dev/rosy-clover-477102-t5/shorted/short-data-sync:latest"
 }
 
+variable "house_price_collector_image" {
+  description = "Docker image URL for house-price-collector job"
+  type        = string
+  default     = "australia-southeast2-docker.pkg.dev/rosy-clover-477102-t5/shorted/house-price-collector:latest"
+}
+
 variable "shorts_api_image" {
   description = "Docker image URL for shorts API service"
   type        = string


### PR DESCRIPTION
Wires the house-price collector (code merged in #210) into CI + Terraform so it deploys + runs on a schedule.

## Changes
- **CI** (`terraform-deploy.yml`): add `house-price-collector` to the `build-docker-images` matrix; add `house_price_collector_image` to both the Terraform **Plan** and **Apply** `-var` lists.
- **dev + prod**: `house_price_collector_image` variable + a `module "house_price_collector"` block (mirrors `short_data_sync`; no GCS — fetches ABS/RBA over HTTPS).

## What it creates (review the CI terraform-plan on this PR)
A service account, `DATABASE_URL` Secret Manager IAM binding, a Cloud Run **Job** (`-mode all` = ABS/RBA ingest + MV refresh, 1 vCPU / 512Mi / `min_instance_count` n/a for jobs), and a **monthly Cloud Scheduler** (`0 16 5 * *`, catches the quarterly ABS releases). The supplementary crawl tier is NOT scheduled.

## ⚠️ This is the "plan for approval" step
The PR's **CI terraform-plan** job is the canonical plan in the real prod environment/state. Please review it, then merging applies it (main → prod / rosy-clover). After it's live, the prod data self-refreshes monthly (currently a one-time manual load).

Validated: `terraform fmt` clean, workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)