### PR TITLE
fix(infra): import pre-existing shorts-SA project IAM into prod state (unbreak apply)

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -220,6 +220,23 @@ module "shorts_api" {
   ]
 }
 
+# Reconcile pre-existing project-level IAM grants for the shorts SA into state.
+# These bindings (run.viewer + cloudscheduler.viewer, added in #206 so the
+# /api/admin/jobs endpoint can read Cloud Run executions + schedulers) already
+# exist in prod (granted out-of-band). The CI deploy SA can getIamPolicy (read)
+# but not setIamPolicy (write) at the project level, so a plain create 403s.
+# Importing reconciles state without a write — after this applies once, there
+# is no diff and the apply stays green. (import blocks are inert once in state.)
+import {
+  to = module.shorts_api.google_project_iam_member.shorts_api_run_viewer
+  id = "rosy-clover-477102-t5 roles/run.viewer serviceAccount:shorts@rosy-clover-477102-t5.iam.gserviceaccount.com"
+}
+
+import {
+  to = module.shorts_api.google_project_iam_member.shorts_api_scheduler_viewer
+  id = "rosy-clover-477102-t5 roles/cloudscheduler.viewer serviceAccount:shorts@rosy-clover-477102-t5.iam.gserviceaccount.com"
+}
+
 # Enrichment Processor Service
 module "enrichment_processor" {
   source = "../../modules/enrichment-processor"


### PR DESCRIPTION
## Why
The main→prod **Deploy Infrastructure** apply went red after #206 merged. Root cause:

- #206 added project-level `google_project_iam_member` resources in `terraform/modules/shorts-api/main.tf` (`run.viewer` + `cloudscheduler.viewer`) so `/api/admin/jobs` can read Cloud Run executions + Cloud Scheduler from GCP's own history.
- Those bindings **already exist in prod** (granted out-of-band) but aren't in terraform state.
- The CI deploy SA (`github-actions-sa`) can `getIamPolicy` (read) but **not** `setIamPolicy` (write) at the project level — so terraform's *create* attempt 403'd (`Policy update access denied`), failing the apply and skipping the post-apply health checks.

Note: #211 applied fine — the `house-price-collector` Cloud Run Job + `house-price-collector-monthly` scheduler are live in prod. Only these two IAM bindings broke the apply.

## Fix
Add `import {}` blocks so the next apply **reads** the existing bindings into state (no `setIamPolicy`, no CI-SA privilege escalation). After the import there's no diff and the apply stays green. Import blocks are inert once the resources are in state.

## Verify
The **CI terraform-plan on this PR is the gate**: expect `2 to import, 0 to add, 0 to change, 0 to destroy` for the two `module.shorts_api.google_project_iam_member.*` resources. Merging applies it (main → prod / rosy-clover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)