### PR TITLE
fix(housing): default suburb explorer to SA (populated state)

### DIFF
--- a/web/src/@/components/housing/suburb-explorer.tsx
+++ b/web/src/@/components/housing/suburb-explorer.tsx
@@ -55,7 +55,7 @@ export function SuburbExplorer() {
     [regionsResp],
   );
 
-  const [stateFilter, setStateFilter] = useState("VIC");
+  const [stateFilter, setStateFilter] = useState("SA");
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState<string | null>(null);
 


### PR DESCRIPTION
VIC suburbs are empty in prod (land.vic Cloudflare 403s the Cloud Run datacenter IP); SA populates cleanly (434 suburbs). Defaults the explorer to SA so it shows the Voronoi map + data on load. One-line change.

The explorer + map are verified rendering in prod (SA view). VIC strategy (residential proxy vs manual backfill vs opt-in) is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)