### PR TITLE
feat(housing): residential REA/Domain crawl — brandbrain extraction, licence gate, CDP fetch

### DIFF
--- a/docs/superpowers/plans/2026-06-24-housing-crawl-phase0-spikes.md
+++ b/docs/superpowers/plans/2026-06-24-housing-crawl-phase0-spikes.md
@@ -1,0 +1,214 @@
+# Housing Crawl — Phase 0 Gating Spikes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the two unknowns that gate the whole residential-housing-crawl effort — (a) can we fetch *clean, validation-passing* REA/Domain suburb data from a residential IP, and (b) which states publish machine-readable suburb medians — and capture the real HTML fixtures + source facts the downstream build plans need.
+
+**Architecture:** Two parallel investigations run from the user's **residential** dev machine (same IP class as the eventual mac-rig runner). The feasibility spike uses the in-repo `stealth` CLI + the existing collector crawl code; the source-verification spike hits each state's open-data portal. Outputs are saved as fixtures + a findings doc that feed the build plans.
+
+**Tech Stack:** Go (collector + stealth CLI), `stealth fetch` CLI (`~/projects/stealth`), the existing `services/house-price-collector` crawl tier, government open-data portals (CKAN / Socrata / XLSX).
+
+**Authorization note:** The user has explicitly authorized scraping REA/Domain ("just scrape … just get the data"). Keep feasibility fetches **tiny and polite** — a handful of pages, with the existing 5–15s jitter — this is a feasibility probe, not a harvest.
+
+---
+
+## Pre-flight
+
+**Files:**
+- Worktree: `~/projects/shorted-housing-crawl` (branch `feat/residential-housing-crawl`, off `origin/main`)
+- Stealth CLI: `~/projects/stealth`
+- Fixtures dir (create): `~/projects/shorted-housing-crawl/services/house-price-collector/testdata/fixtures/`
+- Findings doc (create): `docs/superpowers/specs/2026-06-24-phase0-findings.md`
+
+- [ ] **Step 1: Confirm the dev machine's egress IP is residential (not VPN/datacenter)**
+
+Run:
+```bash
+curl -s https://ipinfo.io/json | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("ip"), d.get("org"), d.get("city"))'
+```
+Expected: an ISP/telco org (e.g. Telstra/TPG/Aussie BB), **not** Google/AWS/DigitalOcean/a VPN. If it shows a VPN/datacenter org, STOP — disable the VPN or move to the mac rig first; a non-residential IP invalidates the whole spike. Record the org in the findings doc.
+
+- [ ] **Step 2: Confirm the stealth CLI builds and Chrome is present**
+
+Run:
+```bash
+cd ~/projects/stealth && go build -o /tmp/stealth-cli ./cmd/stealth 2>&1 | tail -5 && /tmp/stealth-cli --help 2>&1 | head -20
+ls -la "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" 2>/dev/null && echo "Chrome present"
+```
+Expected: a `stealth` CLI binary with a `fetch` subcommand; Chrome binary present (needed for the chromium engine leg). If the CLI subcommand names differ, note the actual `fetch`/engine flags from `--help`.
+
+- [ ] **Step 3: Create the fixtures + findings scaffolding**
+
+Run:
+```bash
+mkdir -p ~/projects/shorted-housing-crawl/services/house-price-collector/testdata/fixtures
+```
+Create `docs/superpowers/specs/2026-06-24-phase0-findings.md` with headings: `## Egress IP`, `## REA feasibility`, `## Domain feasibility`, `## Go/No-Go`, `## Open-VG sources`. Commit the scaffold:
+```bash
+cd ~/projects/shorted-housing-crawl && git add docs/superpowers/specs/2026-06-24-phase0-findings.md && git commit --no-verify -m "docs(housing): phase-0 findings scaffold"
+```
+
+---
+
+## Task 1: REA (realestate.com.au / Kasada) feasibility
+
+**Files:**
+- Capture: `services/house-price-collector/testdata/fixtures/rea-<suburb>.html`
+- Findings: `docs/superpowers/specs/2026-06-24-phase0-findings.md` → `## REA feasibility`
+
+The collector builds REA URLs as `https://www.realestate.com.au/neighbourhoods/{suburb}-{postcode}-{state}` (`crawl_targets.go` `reaURL()`). Use a seed suburb (Bondi 2026 NSW).
+
+- [ ] **Step 1: Native-engine fetch (cheap TLS-spoof path)**
+
+Run:
+```bash
+/tmp/stealth-cli fetch -e native 'https://www.realestate.com.au/neighbourhoods/bondi-2026-nsw' -o /tmp/rea-native.html 2>&1 | tail -20
+wc -c /tmp/rea-native.html; head -c 400 /tmp/rea-native.html
+```
+Observe: HTTP status, body size, and whether the body is a Kasada interstitial / `<title>` is a challenge page vs a real suburb page. Record status + verdict (clean / blocked / poisoned) in findings.
+
+- [ ] **Step 2: Chromium-engine fetch (escalation path)**
+
+Run:
+```bash
+/tmp/stealth-cli fetch -e chromium 'https://www.realestate.com.au/neighbourhoods/bondi-2026-nsw' -o /tmp/rea-chromium.html 2>&1 | tail -20
+wc -c /tmp/rea-chromium.html; grep -o '__NEXT_DATA__\|__INITIAL_STATE__\|medianPrice\|"median"' /tmp/rea-chromium.html | sort | uniq -c
+```
+Observe: does the chromium page contain real data markers (`__NEXT_DATA__`/`medianPrice`/etc)? Record which engine (if either) returns real data.
+
+- [ ] **Step 3: Run the existing extractor + validation gates against the captured HTML**
+
+The collector already extracts candidate medians schema-agnostically (`crawl_extract.go` `extractSaleMedians`) and validates them (`crawl_validate.go`). Write a throwaway harness to confirm the captured HTML yields a plausible, validation-passing median:
+```bash
+cd ~/projects/shorted-housing-crawl/services && cat > /tmp/extract_probe.go <<'EOF'
+//go:build ignore
+package main
+// Probe: load a captured fixture, run extractSaleMedians + validateMedian, print results.
+// (Fill from crawl_extract.go/crawl_validate.go exported-or-copied helpers; if unexported,
+//  add a temporary _test.go in package main that calls them and run `go test -run Probe -v`.)
+EOF
+echo "Implement the probe as a *_test.go in the house-price-collector package calling extractSaleMedians(string(html)) and validateMedian(...) — these are package-private, so a test in-package is the clean way."
+```
+Concretely: add `services/house-price-collector/crawl_probe_test.go` (package `main`) that reads `/tmp/rea-chromium.html`, calls `extractSaleMedians(string(b))`, prints candidates, and asserts at least one passes `validateMedian` against Bondi's plausible band. Run:
+```bash
+cd ~/projects/shorted-housing-crawl/services && go test ./house-price-collector/ -run Probe -v 2>&1 | tail -30
+```
+Expected: ≥1 extracted median in a sane Bondi range (~$2–4M). Record the extracted value(s) + whether validation passed.
+
+- [ ] **Step 4: Save the winning HTML as a fixture (only if real, non-poisoned)**
+
+Run (use whichever engine returned real data):
+```bash
+cp /tmp/rea-chromium.html ~/projects/shorted-housing-crawl/services/house-price-collector/testdata/fixtures/rea-bondi-2026-nsw.html
+```
+This fixture is the TDD input for the brandbrain `ExtractRealEstate` build plan. If REA was blocked/poisoned on **both** engines, do NOT save a poisoned fixture — record "REA blocked from residential IP" in findings (this flips the Phase-0 gate toward the managed-unblocker escalation).
+
+- [ ] **Step 5: Commit findings + fixture**
+
+```bash
+cd ~/projects/shorted-housing-crawl && git add services/house-price-collector/testdata/fixtures docs/superpowers/specs/2026-06-24-phase0-findings.md && git commit --no-verify -m "spike(housing): REA residential feasibility result + fixture"
+```
+
+---
+
+## Task 2: Domain (domain.com.au / Akamai) feasibility
+
+**Files:**
+- Capture: `services/house-price-collector/testdata/fixtures/domain-<suburb>.html`
+- Findings: `## Domain feasibility`
+
+Domain URL shape (`crawl_targets.go` `domainURL()`): `https://www.domain.com.au/suburb-profile/{suburb}-{state}-{postcode}`.
+
+- [ ] **Step 1: Native + chromium fetch**
+
+Run:
+```bash
+/tmp/stealth-cli fetch -e native   'https://www.domain.com.au/suburb-profile/bondi-nsw-2026' -o /tmp/dom-native.html   2>&1 | tail -10; wc -c /tmp/dom-native.html
+/tmp/stealth-cli fetch -e chromium 'https://www.domain.com.au/suburb-profile/bondi-nsw-2026' -o /tmp/dom-chromium.html 2>&1 | tail -10; wc -c /tmp/dom-chromium.html
+grep -o '__NEXT_DATA__\|__INITIAL_STATE__\|medianPrice\|"median"' /tmp/dom-chromium.html | sort | uniq -c
+```
+Record status + clean/blocked verdict per engine.
+
+- [ ] **Step 2: Extractor + validation probe**
+
+Extend `crawl_probe_test.go` to also load `/tmp/dom-chromium.html` and run `extractSaleMedians` + `validateMedian`. Run:
+```bash
+cd ~/projects/shorted-housing-crawl/services && go test ./house-price-collector/ -run Probe -v 2>&1 | tail -30
+```
+Expected: ≥1 plausible Bondi median, validation passing. Record results.
+
+- [ ] **Step 3: Save fixture (only if real) + commit**
+
+```bash
+cp /tmp/dom-chromium.html ~/projects/shorted-housing-crawl/services/house-price-collector/testdata/fixtures/domain-bondi-nsw-2026.html
+cd ~/projects/shorted-housing-crawl && git add services/house-price-collector/testdata/fixtures docs/superpowers/specs/2026-06-24-phase0-findings.md && git commit --no-verify -m "spike(housing): Domain residential feasibility result + fixture"
+```
+
+---
+
+## Task 3: Phase-0 Go/No-Go decision
+
+**Files:** `docs/superpowers/specs/2026-06-24-phase0-findings.md` → `## Go/No-Go`
+
+- [ ] **Step 1: Record the decision against explicit criteria**
+
+Write the verdict using these criteria:
+- **GO (proceed with the cuttlefish home-runner architecture):** at least one of REA/Domain returns clean, validation-passing suburb data from the residential IP (chromium acceptable). The mac-rig runner will reproduce this.
+- **PARTIAL:** one site works, the other is blocked → proceed for the working site; record the blocked one as a managed-unblocker candidate.
+- **NO-GO (escalate before building):** both sites blocked/poisoned even from residential IP → STOP the cuttlefish-runner build; the design pivots to a managed unblocker (Bright Data/Oxylabs Web Unlocker) wired into `stealthhttp`. Surface this to the user — it's a cost/architecture fork.
+
+- [ ] **Step 2: Commit the decision and surface it**
+
+```bash
+cd ~/projects/shorted-housing-crawl && git add docs/superpowers/specs/2026-06-24-phase0-findings.md && git commit --no-verify -m "spike(housing): phase-0 go/no-go decision"
+```
+Report the verdict to the user before starting any Phase-2/3 build plan.
+
+---
+
+## Task 4: Open-VG source verification (NSW, QLD, WA, TAS, ACT, NT)
+
+**Files:** `docs/superpowers/specs/2026-06-24-phase0-findings.md` → `## Open-VG sources`
+
+This is independent of the REA/Domain gate (open-gov data, datacenter egress fine) and can run in parallel. For each state, find a **machine-readable suburb-level median** source, or record that none exists. Two confirmed in-repo patterns to match: CKAN datastore JSON (`sa_vg.go`) and Cloudflare-walled XLSX (`vic_vpsr.go`).
+
+- [ ] **Step 1: Probe each state's portal**
+
+For each state, identify the canonical source and confirm it returns suburb medians. Starting points to verify (do NOT assume — confirm the live URL + format + licence):
+- **NSW:** Valuer-General PSI bulk property sales (`valuation.property.nsw.gov.au`) and/or `data.nsw.gov.au` CKAN. NSW PSI is bulk `.DAT`/zip, not CKAN-friendly — confirm.
+- **QLD:** `data.qld.gov.au` CKAN "property sales data" / DNRME median-sale tables.
+- **WA:** Landgate / `data.wa.gov.au` median-house-price-by-suburb (CKAN).
+- **TAS:** `data.thelist.tas.gov.au` / Treasury property-sales (often XLSX).
+- **ACT:** `data.act.gov.au` (Socrata) residential-property-sales (districts, not suburbs).
+- **NT:** `data.nt.gov.au` property-sales (smallest; may be PDF/XLSX only).
+
+For each, run a quick reachability + shape check, e.g. for a CKAN candidate:
+```bash
+curl -s 'https://data.<state>.gov.au/api/3/action/package_search?q=property+sales+median+suburb' | python3 -c 'import sys,json; d=json.load(sys.stdin); [print(r["name"], "|", [res["format"] for res in r.get("resources",[])]) for r in d["result"]["results"][:5]]'
+```
+
+- [ ] **Step 2: Record a verification table**
+
+For each state record: **source URL**, **format** (CKAN-JSON / Socrata / XLSX / DAT / PDF / none), **granularity** (suburb / LGA / district), **licence** (CC-BY? other), **ingest pattern to reuse** (sa_vg-style / vic_vpsr-style / new), and **verdict** (machine-readable ✓ / best-effort / drop). Be explicit about any state with no machine-readable suburb medians — those get dropped with a logged note (no silent gaps).
+
+- [ ] **Step 3: Commit the source table**
+
+```bash
+cd ~/projects/shorted-housing-crawl && git add docs/superpowers/specs/2026-06-24-phase0-findings.md && git commit --no-verify -m "spike(housing): open-VG per-state source verification"
+```
+
+---
+
+## Outputs that unblock the build plans
+
+When this plan completes we will have:
+1. **A Phase-0 verdict** → decides whether the cuttlefish-runner build proceeds or we escalate to a managed unblocker.
+2. **Real REA/Domain HTML fixtures** → the TDD inputs for the brandbrain `ExtractRealEstate` build plan (so the real-estate langextract schema + `__NEXT_DATA__` parser are built against *real* markup, not guesses).
+3. **A verified per-state source table** → the concrete inputs for the open-VG ingest build plan (real URLs/formats/licences, no placeholders).
+
+## Build plans to write next (gated on this plan's outputs)
+
+- **Plan B — brandbrain `ExtractRealEstate`** (proto + real-estate schema + `__NEXT_DATA__` parser + Schema.org widening + registration test). Written against the captured fixtures. *Gated on: Task 3 = GO/PARTIAL.*
+- **Plan A — cuttlefish residential pipeline** (wire cron + declarative runner pinning + tests; register mac-rig runner; Workflow + TaskPackage; chromium crawl image). *Gated on: Task 3 = GO/PARTIAL.*
+- **Plan C — open-VG backbone** (per-state ingesters → `runOfficial`). Written against the verified source table. *Independent — can proceed regardless of the gate.*
+- **Plan D — shorted crawl integration + web hygiene** (forward bytes → brandbrain → validate → store segregated; enforce `source_licence` gate; fix state-filter bug). *Gated on: Plans A + B.*

--- a/docs/superpowers/specs/2026-06-24-phase0-findings.md
+++ b/docs/superpowers/specs/2026-06-24-phase0-findings.md
@@ -1,0 +1,56 @@
+# Phase-0 Findings — Residential Feasibility + Open-VG Source Verification
+
+**Date:** 2026-06-24
+**Verified from:** dev machine, egress `119.15.78.0` / **AS38195 Superloop** (Australian ISP, Adelaide) — confirmed **residential**, not VPN/datacenter. Same IP class as the eventual mac-rig runner.
+
+## Gate decision: **GO (full)** — with a tooling pivot
+
+Both REA (Kasada) and Domain (Akamai) return **complete suburb data from the residential IP** — *but only via a properly-driven real browser*. The stealth engine's browser path is broken and must be replaced/fixed.
+
+### REA (realestate.com.au — Kasada)
+
+| Path | Result |
+|---|---|
+| stealth `native` (HTTP + uTLS) | **Blocked** — 714 B Kasada interstitial (`window.KPSDK={}`) |
+| stealth `chromium` | **Blocked** — 758 B Kasada stub (no real browser launched / no wait) |
+| stealth `chromium-stealth` | **Blocked** — 758 B stub; logs show FSM bug `no transition from detecting on event complete`; example.com control returns only 544 B (not full DOM) |
+| **real browser (Playwright, 8 s wait)** | GO — redirects to `/nsw/bondi-2026/`, renders 537 KB with `__NEXT_DATA__`/ArgonautExchange. Extracted: **median house $4,275,000, unit $1,457,500**, rental yield 2.3%/4.0%, rent $1,800/$1,000 PW, annual growth 3.6%/3.4%, median days-on-market, 5-yr trend series |
+
+### Domain (domain.com.au — Akamai)
+
+| Path | Result |
+|---|---|
+| stealth `native` | **Blocked** — 563 B Akamai "Access Denied" |
+| stealth `chromium` | **Blocked** — 2,580 B Akamai challenge page |
+| **real browser (Playwright, 8 s wait)** | GO — 456 KB, `digitalData` embedded, median table (BEDROOMS / TYPE / MEDIAN PRICE / AVG DAYS ON MARKET / CLEARANCE RATE / SOLD THIS YEAR): house medians $3.36m–$4.77m, units $1.0m–$2.11m, rents, clearance, listings |
+
+### Pivot (changes the implementation plan)
+
+The approved architecture (cuttlefish runner running the collector's **stealth-engine** crawl) is **valid on residential IP but blocked by the stealth engine's broken browser path.** The crawl must drive a **real browser** (Playwright / a fixed chromedp flow) that:
+1. waits for the JS challenge to execute + the redirect/network-idle, then
+2. captures the fully-rendered DOM (537 KB / 456 KB with embedded JSON state).
+
+This is a concrete **dogfood finding for stealth** (the shared engine brandbrain also uses): `chromium-stealth` errors in its FSM, doesn't wait for challenge resolution, and returns the pre-challenge stub instead of the rendered page.
+
+## Open-VG source verification (public tier)
+
+| State | Open suburb medians? | Source | Verdict |
+|---|---|---|---|
+| **SA** | yes (shipped) | data.sa.gov.au CKAN | done |
+| **VIC** | yes (shipped) | land.vic Valuer-General XLSX | done |
+| **NSW** | best-effort | VG **PSI bulk DAT** (raw transactions -> aggregate ourselves; session-cookie + pacing; **licence ambiguous** — bundled file says CC-BY, pages say BY-NC-ND) | **add (new `nsw_vg-PSI` pattern), confirm licence** |
+| **QLD** | none | QVAS sales is **paid** ($20k quote); open data has only capital-city HPI + LGA land valuations | drop (open); crawl-only |
+| **WA** | none open | Landgate custom-licence/paid, SLIP OAuth-gated. **REIWA** suburb pages ARE machine-readable JSON (median house/unit/land, quartiles, by-bedroom, counts) but **proprietary** | drop (open); **crawl-tier candidate (REIWA)** |
+| **TAS** | none | LIST report is per-property PDF, paid/copyright; REIT proprietary | drop (open); crawl-only |
+| **ACT** | none | Socrata has no property data; only a copyright PDF w/ ~9 greenfield LAND suburbs. ABS GCCSA = whole-of-Canberra already covered | drop |
+| **NT** | none anywhere | No dataset exists; REINT region-level only | drop |
+
+### Implication
+
+The public open tier realistically gains **only NSW** (effortful, licence caveat). **QLD, WA, TAS, ACT, NT have no open suburb-median source at all** — for those, suburb-level data is available **only via the internal, ToS-gated REA/Domain (and WA: REIWA) crawl.** This makes the residential crawl the *de-facto suburb data source for half the country* — consistent with the acquire-only/internal directive.
+
+## Net effect on the plan
+
+- **Plan A/D (residential crawl):** GO — but swap the fetch mechanism from the stealth engine to a **real browser driver** (decision fork). brandbrain gets the full rendered HTML (excellent langextract input).
+- **Plan C (open-VG):** scope shrinks from "6 states" to **NSW only** (best-effort) + a possible REIWA crawl-tier item for WA.
+- **Stealth:** new finding — `chromium-stealth` engine is broken (FSM + no challenge wait + truncated DOM). Fixing it is the "improve the shared engine" option.

--- a/docs/superpowers/specs/2026-06-24-residential-housing-crawl-design.md
+++ b/docs/superpowers/specs/2026-06-24-residential-housing-crawl-design.md
@@ -1,0 +1,235 @@
+# Design — Residential intelligent housing crawl (cuttlefish × brandbrain × shorted)
+
+**Date:** 2026-06-24
+**Branch:** `feat/residential-housing-crawl` (shorted), plus feature branches in `cuttlefish` and `brandbrain`
+**Status:** Approved (design); implementation plan to follow
+
+## Goal
+
+Combine three of the user's systems into one scheduled, residential-IP, intelligent
+housing-data pipeline:
+
+1. **cuttlefish** (the user's DAG workflow engine) — schedules the crawl and runs it on a
+   runner pinned to a **home macOS rig**, so REA/Domain see a **residential egress IP**.
+2. **brandbrain** (the user's AI crawler/extraction platform) — turns fetched listing/suburb
+   HTML into structured real-estate metadata via a new `ExtractRealEstate` RPC.
+3. **shorted** (`services/house-price-collector`) — orchestrates the crawl, validates against
+   poisoning, and stores everything in the existing `house_prices` EAV table.
+
+Plus a parallel, low-risk **open Valuer-General backbone** (NSW/QLD/WA/TAS/ACT/NT) that needs
+no residential egress and powers the public surface.
+
+### This is also a dogfooding exercise
+
+A first-class objective is to **validate and improve cuttlefish and brandbrain** against a real
+use-case. Gaps this use-case exposes in either product are fixed *properly* — to their
+conventions, with tests — not papered over with shorted-side hacks. Concrete improvement
+targets are listed per-repo below.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Crawl target | Open-VG backbone (public) **+** residential REA/Domain (internal) |
+| Residential egress | cuttlefish runner on the home macOS rig (Docker NATs via host IP) |
+| Metadata extraction | new brandbrain `ExtractRealEstate(html, url, …)` RPC (HTML-in) |
+| Scheduling | wire cuttlefish's built-in cron (`TickCronSchedules`) |
+| **Licensing/display** | REA/Domain + brandbrain output = **acquire-only, internal, never publicly republished**. Open-VG (CC-BY) is what the public `/housing/suburbs` shows. The stored `source_licence` gate is **enforced** in the query/RPC layer. |
+
+## Architecture
+
+```
+ cuttlefish CONTROL PLANE  (DigitalOcean droplet, always-on)
+    │  wired cron → fires "au-housing-residential-crawl" workflow on a schedule
+    │  run pinned to the residential runner pool (cron trigger carries a runner selector)
+    ▼
+ cuttlefish RUNNER on the HOME MACOS RIG  ◄── residential egress IP (Docker default bridge → host NAT)
+    │  leases the run, executes the crawl task container (chromium-bearing image)
+    │  collector `-mode crawl` → stealth (native→chromium) fetches REA/Domain suburb pages
+    │  forwards RAW page bytes ──HTTPS──► brandbrain ExtractRealEstate (droplet; datacenter is fine — pure compute)
+    │                                        └─► {price, beds/baths/car, land, sale_date, agency, suburb stats…}
+    ▼
+ collector: SAME 4 anti-poisoning gates applied to brandbrain output → house_prices EAV
+            (source=brandbrain_rea / brandbrain_domain, source_licence=proprietary-tos-restricted, is_preliminary as warranted)
+    ▼
+ store.refreshHousingMV()
+
+ ── INDEPENDENT path (existing Cloud Run Job, datacenter is fine — all open-gov CC-BY) ──
+ open Valuer-General ingest NSW/QLD/WA/TAS/ACT/NT  →  house_prices  →  /housing/suburbs (PUBLIC)
+```
+
+**Key insight:** only the *fetch* needs the residential IP. Extraction is pure compute on
+already-fetched HTML, so brandbrain stays where it is (DO droplet). A DO droplet is **not**
+residential — only the home mac-rig runner provides residential egress.
+
+## Component design
+
+### A. cuttlefish (workflow engine) — improvements + integration
+
+**Gaps this use-case exposed:**
+- **Cron is implemented but never fires.** `PostgresRunStore.TickCronSchedules`
+  (`internal/controlplane/store/postgres_schedule_store.go:30`) is complete and tested, but the
+  running loop (`internal/controlplane/background_tick.go:76`) only calls `ws.Tick`. Their own
+  TODO 14.3.5 / line 381: "Cuttlefish doesn't have scheduled triggers yet."
+- **No working declarative runner pinning.** Run-level pinning works only via
+  `POST /api/runs/start` context (`run_scope.go`). The node-level `runsOn` field exists in the
+  schema and is parsed (`extractRunsOn`, `runner_handlers.go:1599`) but has **no live consumer**
+  — authoring it validates and silently does nothing. Cron-created runs get **empty**
+  pool/labels and lease to *any* runner.
+
+**Changes (proper fixes, with tests):**
+1. **Wire cron into the loop** — in `backgroundTickOnce` call
+   `ws.TickCronSchedules(ctx, time.Now(), 100)` alongside `ws.Tick`; on `created > 0` call
+   `publishWorkAvailable`. Keep it out of the poll path (`TestPollWork_DoesNotTick` guards that).
+2. **Make cron runs targetable to a pool/labels (declarative).** Add an optional runner
+   selector to the **cron trigger** in `docs/specs/schemas/workflow-v1alpha1.schema.json`
+   (strict `additionalProperties:false`, so the schema + `internal/specvalidate/workflow.go`
+   struct must be extended) — fields `runnerPoolName` / `runnerLabels`. In `TickCronSchedules`,
+   wrap ctx with `store.WithTargetRunnerPool` / `store.WithTargetRunnerLabels` before
+   `createRunTx` so the cron run pins to the residential rig via the existing lease SQL
+   (`postgres_run_store.go:2070-2075`).
+   *Fallback if we descope (2): run the rig as the only runner in a dedicated cuttlefish
+   project — runners are project-scoped, so cron runs in that project lease only to the rig
+   with zero code change. We will do the proper selector since this is a dogfood exercise; the
+   project-scoping is the smoke-test shortcut.*
+3. **Author artifacts** — a `Workflow` (`cuttlefish.dev/v1alpha1`, cron + manual triggers) and a
+   `TaskPackage` (image + `${secrets.SHORTED_DATABASE_URL}` / `${secrets.BRANDBRAIN_*}` env,
+   `protocol {version:v0, transport:stdio}`).
+4. **Optional hardening (note, not commit-blocking):** clearer error when a referenced
+   `${secrets.NAME}` is missing at lease time (currently HTTP 500); a "latest-only / no
+   backfill-burst" option for cron catch-up.
+
+**Runner setup:** register the mac rig via `cuttle agent install --start` with
+`RUNNER_POOL_NAME=residential`, `RUNNER_LABELS=residential=true,location=home`,
+`RUNNER_CAPABILITIES=docker`. Verify the container's actual egress IP is residential before
+trusting any crawl result.
+
+### B. brandbrain (AI crawler) — `ExtractRealEstate` + extraction improvements
+
+**Changes:**
+1. **New RPC `ExtractRealEstate(html, url, suburb_hint, state_hint)`** → `{listings[], agency,
+   confidence, notes}` with a `RealEstateListing` message (address, suburb, state, postcode,
+   price_display, price, property_type, bedrooms, bathrooms, car_spaces, land_size,
+   listing_url, listing_status, agent_name, rating_value, review_count).
+   - proto: `api/brandbrain/v1/discovery.proto` (`idempotency_level = NO_SIDE_EFFECTS`).
+   - **Footgun:** the server hand-registers handlers via `makeHandler` on a `ServeMux`
+     (`adapters/http/server.go:301`), **not** buf-connect. Must add the method to the anonymous
+     interface **and** a `mux.HandleFunc(".../ExtractRealEstate", makeHandler(...))` line or it
+     compiles but 404s. Add a registration test to catch this class of bug (dogfood improvement).
+2. **Real-estate langextract schema** — clone `companyMetadataExtractionPrompt` +
+   `companyMetadataExamples` (`company_metadata_langextract.go:13-172`) into
+   `realEstateExtractionPrompt` + `realEstateExamples` + `buildRealEstateFromExtractions`.
+3. **Extract-from-provided-HTML** — the extractor already supports it via
+   `CompanyMetadataExtractionInput.ArtifactHTML` (`extractionHTML()` prefers it). New
+   `real_estate_extractor.go` synthesizes a minimal `&SiteProfile{URL,Domain}` (required
+   non-nil) and runs langextract with `WithFetchURLs(false)` — **no server-side fetch**.
+4. **`__NEXT_DATA__` / `__INITIAL_STATE__` JSON-blob parser** (generalizable improvement) —
+   REA/Domain ship listing data as embedded JSON in `<script>`, not Schema.org. A dedicated
+   blob parser materially improves extraction on modern SPAs beyond this use-case.
+5. **Widen structured-data coverage** — `isContactBearingType`
+   (`jsonld_contact_extractor.go:117-132`) and the Product `@type` gate
+   (`product_extractor.go:51`) extended for `RealEstateListing/Residence/Apartment/House/
+   Place/Offer`, reading `offers.price` + `aggregateRating`.
+6. **Reliability note:** brandbrain 502s above ~2 concurrent workers (project memory). The
+   crawl is serial (5–15s jitter between suburbs) so this is fine now; flagged as a future
+   concurrency-robustness improvement, not in scope.
+
+**Deploy:** `make proto` (buf) + `make do-deploy` (DigitalOcean — **not** Cloud Run).
+
+### C. shorted (collector + web)
+
+**Crawl tier (`services/house-price-collector`):**
+1. After a validated residential fetch, forward **raw bytes** (switch crawl fetch to
+   `FetchBytes`, not `FetchHTML`, to avoid goquery re-serialization breaking JSON-blob parsing)
+   to brandbrain. New `crawl_brandbrain.go`: Connect-JSON POST with 5xx backoff (mirror
+   `signals-collector/collect.py` retry).
+2. Map brandbrain rich fields to **new EAV measures** (`measure` is free-text TEXT — no
+   migration): `rental_yield` (ratio), `days_on_market` (count), `auction_clearance` (ratio),
+   `price_growth_12m` (ratio), plus existing `median_price`/`median_rent`/`transfer_count`.
+   Store under **segregated sources** `brandbrain_rea` / `brandbrain_domain` so they never
+   collide with the raw-crawl `median_price` on the UNIQUE key.
+3. **Gate brandbrain output through the same anti-poisoning validation** as the raw median
+   (`crawl_validate.go`); poisoned/blocked HTML must not launder bad data. Mark
+   `is_preliminary` / source-segregate as warranted.
+4. All crawl + brandbrain rows keep `source_licence='proprietary-tos-restricted'`.
+5. **Chromium-bearing crawl image** — the shipped collector image is distroless/static (no
+   Chromium); native-only weakens Kasada bypass. Build a chromium variant for the residential
+   task (runs fine in Docker on the mac rig). `CRAWL_DISABLE_CHROMIUM` stays the escape hatch.
+6. The residential crawl runs **only** as the cuttlefish task — **never** on Cloud Run (GCP
+   datacenter IPs get blocked).
+
+**Open-VG backbone (runs in existing `-mode all` on Cloud Run):**
+- Add `ingestNSWMedians` / `QLD` / `WA` / `TAS` / `ACT` / `NT`, each
+  `func(ctx) ([]Observation, error)` appended to `runOfficial`'s job list (`main.go`). Two
+  reference shapes already in-repo: CKAN datastore JSON (`sa_vg.go`) and Cloudflare-walled XLSX
+  via stealth native (`vic_vpsr.go`).
+- **Each state's source is an assumption that must be verified first** (only SA/VIC confirmed).
+  Likely: NSW PSI bulk DAT files; QLD/WA/ACT via CKAN/Socrata; TAS/NT possibly XLSX/PDF.
+  `region_code='SUBURB:<STATE>-…'`, `source='vg_<state>'`, `source_licence` set per the actual
+  state licence. ACT (districts) / NT (tiny) likely `region_type='lga'`.
+
+**Web + hygiene:**
+- **Enforce the `source_licence` gate** in the RPC/query layer so
+  `proprietary-tos-restricted` rows never reach public surfaces (stored today, **not enforced**).
+- Surface the new open-VG states + any new public measures on `/housing/suburbs`.
+- Fix the pre-existing **state-filter bug** (VIC/SA return mixed results — filter ignored
+  server-side).
+
+## Data model
+
+No migration required:
+- Crawl + brandbrain measures are new free-text `measure` values under new `source` values in
+  the existing `house_prices` EAV (UNIQUE `region_code, measure, dwelling_type, period, source`).
+- New-state VG rows reuse `region_type='suburb'` (+ `'lga'` for ACT/NT) and `state_code`.
+
+## Phasing (de-risked: feasibility gate first, cheap reliable win in parallel)
+
+| Phase | What | Risk | Depends on |
+|---|---|---|---|
+| **0 — Feasibility spike** | Register mac-rig runner; run existing `-mode crawl` (native→chromium) from it manually. **Measure:** does REA/Domain return clean, validation-passing data from the residential IP? Confirm egress IP is residential. | Make-or-break | — |
+| **1 — Open-VG backbone** | Verify each state's source; add 6 ingest funcs (existing Cloud Run path). Independent — can land first. | Low | — |
+| **2 — cuttlefish pipeline** | Wire cron; declarative pool/label selector; chromium crawl image; TaskPackage + Workflow; secrets; smoke-test manual → scheduled. | Med | Phase 0 green |
+| **3 — brandbrain extraction** | `ExtractRealEstate` RPC + real-estate schema + `__NEXT_DATA__` parser + allowlist widening + deploy; collector calls it, gates output, stores segregated. | Med | Phase 2 |
+| **4 — Web + hygiene** | Enforce licence gate; surface new open-VG states; fix state-filter bug. | Low | Phases 1–3 |
+
+**Gate:** if Phase 0 shows residential IP still can't beat Kasada (REA), **stop** and escalate
+to a managed unblocker before investing in Phases 2/3. Verify before building.
+
+## Risks & mitigations
+
+- **Kasada (REA) / Akamai (Domain) may still block even from residential IP.** → Phase 0 gate;
+  chromium engine; fallback to managed unblocker if proven necessary.
+- **REA/Domain ToS.** → Acquire-only, internal, never republished; `source_licence` enforced.
+- **Poisoned data laundering via brandbrain.** → brandbrain output passes the same 4 gates;
+  source-segregated; `is_preliminary` where uncertain.
+- **Open-VG source assumptions wrong.** → Verify each source before coding; best-effort/skip
+  states with no machine-readable suburb medians (note what's dropped — no silent gaps).
+- **Stale-branch landmine.** → All work in the clean `~/projects/shorted-housing-crawl` worktree
+  off `origin/main`.
+- **cuttlefish cron backfill burst** after downtime. → bounded by `limit=100`/tick; consider
+  latest-only option (optional).
+
+## Explicitly NOT doing (YAGNI)
+
+- Kasada/Akamai sensor reverse-engineering or a wired CAPTCHA solver.
+- Commercial residential proxy pools (the mac rig *is* the residential IP).
+- Fixing stealth's broken native-proxy path.
+- Per-listing scraping at scale (suburb-level aggregates + sampled listings only).
+- The brandbrain desktop-agent route (the cuttlefish runner replaces it).
+- Public display of REA/Domain data.
+
+## Success criteria
+
+1. A scheduled cuttlefish workflow fires on cron and runs the crawl on the mac-rig runner
+   (verified by `run.triggered` event with `triggerKind:cron` + run landing on the residential
+   runner).
+2. From the residential IP, the crawl retrieves **validation-passing** REA/Domain suburb data
+   for the seed suburbs (Phase 0 proves this or we escalate).
+3. brandbrain `ExtractRealEstate` returns structured real-estate metadata for fetched HTML;
+   collector stores it as segregated, licence-gated EAV rows that pass anti-poisoning gates.
+4. Open-VG suburb medians for the remaining states (those with machine-readable sources) are
+   ingested via `-mode all` and visible on the public `/housing/suburbs`.
+5. `proprietary-tos-restricted` rows are provably excluded from public RPC/query paths.
+6. cuttlefish gains working scheduled triggers + declarative runner pinning (with tests);
+   brandbrain gains real-estate extraction + `__NEXT_DATA__` parsing + a handler-registration
+   test (with tests).

--- a/services/go.mod
+++ b/services/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/lib/pq v1.10.9
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/cors v1.11.1
 	github.com/sashabaranov/go-openai v1.40.0
@@ -79,6 +80,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/deckarep/golang-set/v2 v2.8.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -88,6 +90,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -95,6 +98,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect

--- a/services/go.sum
+++ b/services/go.sum
@@ -736,6 +736,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
+github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v27.1.1+incompatible h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY=
@@ -789,6 +791,8 @@ github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmn
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
+github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 h1:iizUGZ9pEquQS5jTGkh4AqeeHCMbfbjeb0zMt0aEFzs=
@@ -815,6 +819,8 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn0+wvQ3bZ8b/AU4=
 github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
+github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
@@ -1083,8 +1089,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
-github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+github.com/orisano/pixelmatch v0.0.0-20230914042517-fa304d1dc785 h1:J1//5K/6QF10cZ59zLcVNFGmBfiSrH8Cho/lNrViK9s=
+github.com/orisano/pixelmatch v0.0.0-20230914042517-fa304d1dc785/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
@@ -1099,6 +1105,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
+github.com/playwright-community/playwright-go v0.5700.1 h1:PNFb1byWqrTT720rEO0JL88C6Ju0EmUnR5deFLvtP/U=
+github.com/playwright-community/playwright-go v0.5700.1/go.mod h1:MlSn1dZrx8rszbCxY6x3qK89ZesJUYVx21B2JnkoNF0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/services/go.work.sum
+++ b/services/go.work.sum
@@ -312,6 +312,7 @@ github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVR
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
@@ -333,6 +334,7 @@ github.com/tdewolff/minify/v2 v2.20.14/go.mod h1:qnIJbnG2dSzk7LIa/UUwgN2OjS8ir6R
 github.com/tdewolff/parse/v2 v2.7.8/go.mod h1:3FbJWZp3XT9OWVN3Hmfp0p/a08v4h8J9W1aghka0soA=
 github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
@@ -397,7 +399,6 @@ golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix
 golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
 golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=

--- a/services/house-price-collector/Dockerfile.crawl
+++ b/services/house-price-collector/Dockerfile.crawl
@@ -1,0 +1,101 @@
+# syntax=docker/dockerfile:1
+#
+# Dockerfile.crawl — the Tier-3 RESIDENTIAL crawl image.
+#
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │ THIS IMAGE RUNS ONLY ON THE RESIDENTIAL "CUTTLEFISH" RUNNER — NEVER ON     │
+# │ CLOUD RUN.                                                                 │
+# │                                                                            │
+# │ The Tier-3 crawl drives a HEADED, persistent-profile Chromium (the only    │
+# │ client posture that survives realestate.com.au's Kasada and                │
+# │ domain.com.au's Akamai from a residential IP). A datacentre egress (Cloud  │
+# │ Run / GCP) is blocked/poisoned regardless of the browser, so deploying     │
+# │ this anywhere but the residential rig is pointless and will only burn      │
+# │ the IP. The official ABS/RBA backbone image (../Dockerfile, distroless,    │
+# │ -mode all) is the one that runs on Cloud Run.                              │
+# └──────────────────────────────────────────────────────────────────────────┘
+#
+# It bakes: the Go collector binary + Node + the Playwright CHROMIUM browser +
+# its OS deps + xvfb, and runs the collector under a virtual X display so the
+# "headed" browser has somewhere to draw.
+#
+# The persistent browser profile (CRAWL_PROFILE_DIR, default /data/pw-profile)
+# MUST be a MOUNTED VOLUME on the runner so the Kasada clearance cookie / warm
+# context survives across runs — a cold profile re-triggers the JS challenge
+# every time. Example:
+#   docker run --rm \
+#     -e DATABASE_URL=... -e BRANDBRAIN_URL=... \
+#     -e CRAWL_MAX_SUBURBS=3 -e CRAWL_DRY_RUN=true \
+#     -v /srv/pw-profile:/data/pw-profile \
+#     house-price-collector-crawl
+#
+# NOTE: do NOT build this in CI / on the disk-constrained dev box — the
+# Playwright browser download is large and the image only has a home on the
+# residential rig. Build + first paced live run happen there.
+
+# --- stealth source bind-mount (collector still imports services/pkg/stealthhttp
+#     via the VIC official tier; same PAT/bind pattern as ../Dockerfile) ---
+FROM scratch AS stealth
+
+FROM golang:1.26.0 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN --mount=type=secret,id=github_token \
+    --mount=type=bind,from=stealth,target=/stealth-src \
+    if [ -f /run/secrets/github_token ]; then \
+      git config --global url."https://x-access-token:$(cat /run/secrets/github_token)@github.com/skunkworq/".insteadOf "https://github.com/skunkworq/"; \
+    elif [ -f /stealth-src/go.mod ]; then \
+      cp -r /stealth-src /stealth && \
+      go mod edit -replace github.com/skunkworq/stealth=/stealth && \
+      cp go.mod /tmp/go.mod.stealth; \
+    fi && \
+    GOPRIVATE=github.com/skunkworq/* GONOSUMCHECK=github.com/skunkworq/* go mod download && \
+    rm -f ~/.gitconfig
+COPY . .
+RUN [ -f /tmp/go.mod.stealth ] && cp /tmp/go.mod.stealth go.mod || true
+RUN CGO_ENABLED=0 GOOS=linux go build -o /collector ./house-price-collector/
+
+# --- runtime: Debian slim + Node + Playwright(-go) driver + chromium + xvfb ---
+FROM debian:bookworm-slim
+
+# Node (for the playwright-go driver, which is the Node Playwright CLI under the
+# hood) + xvfb (virtual display for the HEADED browser) + ca-certs. The chromium
+# OS dependencies themselves are installed by `playwright install --with-deps`
+# below, so we don't hand-maintain that long, brittle apt list here.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        xvfb \
+        nodejs \
+        npm \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the playwright-go driver + the CHROMIUM browser (and its OS deps) at
+# BUILD time. The collector calls only playwright.Run() at runtime (never
+# .Install()), so the driver + browser MUST be baked in here. The CLI version is
+# pinned to match the go module (v0.5700.1) so the driver and the library agree.
+#   - PLAYWRIGHT_BROWSERS_PATH=0 keeps the browser next to the driver so a single
+#     well-known location holds both (no per-user cache surprises under xvfb).
+ENV PLAYWRIGHT_DRIVER_PATH=/opt/ms-playwright-go
+RUN GOBIN=/usr/local/bin \
+    && curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xz \
+    && /usr/local/go/bin/go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5700.1 install --with-deps chromium \
+    && rm -rf /usr/local/go /root/go /root/.cache/go-build
+# (If the above go-toolchain bootstrap is undesirable on the rig, the alternative
+# is to COPY a pre-fetched driver dir into PLAYWRIGHT_DRIVER_PATH; either way the
+# driver + chromium are present before runtime and .Install() is never called.)
+
+WORKDIR /app
+COPY --from=builder /collector /collector
+
+# Warm-profile volume (mount a host dir here on the runner) so the Kasada
+# clearance cookie / warm context survives across runs. Created so a missing
+# mount still has a writable default path.
+RUN mkdir -p /data/pw-profile
+ENV CRAWL_PROFILE_DIR=/data/pw-profile
+VOLUME ["/data/pw-profile"]
+
+# Run the collector's crawl mode under a virtual display so the HEADED Chromium
+# has an X server to render into. xvfb-run picks a free display and tears it down
+# when the collector exits.
+ENTRYPOINT ["xvfb-run", "-a", "--server-args=-screen 0 1440x900x24", "/collector", "-mode", "crawl"]

--- a/services/house-price-collector/Dockerfile.crawl
+++ b/services/house-price-collector/Dockerfile.crawl
@@ -1,37 +1,46 @@
 # syntax=docker/dockerfile:1
 #
-# Dockerfile.crawl — the Tier-3 RESIDENTIAL crawl image.
+# Dockerfile.crawl — the Tier-3 RESIDENTIAL crawl image (option (b): local-agent).
 #
 # ┌──────────────────────────────────────────────────────────────────────────┐
 # │ THIS IMAGE RUNS ONLY ON THE RESIDENTIAL "CUTTLEFISH" RUNNER — NEVER ON     │
 # │ CLOUD RUN.                                                                 │
 # │                                                                            │
-# │ The Tier-3 crawl drives a HEADED, persistent-profile Chromium (the only    │
-# │ client posture that survives realestate.com.au's Kasada and                │
-# │ domain.com.au's Akamai from a residential IP). A datacentre egress (Cloud  │
-# │ Run / GCP) is blocked/poisoned regardless of the browser, so deploying     │
-# │ this anywhere but the residential rig is pointless and will only burn      │
-# │ the IP. The official ABS/RBA backbone image (../Dockerfile, distroless,    │
-# │ -mode all) is the one that runs on Cloud Run.                              │
+# │ Option (b) — the container DOES NOT render pages itself. It drives the     │
+# │ HOST macOS Chrome via CDP (CRAWL_CDP_URL, e.g.                             │
+# │ http://host.docker.internal:9222) — the only browser empirically proven    │
+# │ to beat realestate.com.au's Kasada and domain.com.au's Akamai from a       │
+# │ residential IP. A Linux/xvfb Chromium inside the container is still        │
+# │ detected, so it's gone; this image is now just the Go collector + the      │
+# │ Playwright-go DRIVER (the CDP client), nothing more.                       │
+# │                                                                            │
+# │ The host Chrome MUST be started with --remote-debugging-port AND a         │
+# │ DEDICATED --user-data-dir (NEVER the personal profile — that warm profile  │
+# │ holds the Kasada clearance cookie and must be a throwaway), e.g.:          │
+# │   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \         │
+# │     --remote-debugging-port=9222 \                                         │
+# │     --user-data-dir="$HOME/.shorted-housing-crawl-chrome"                  │
+# │                                                                            │
+# │ A datacentre egress (Cloud Run / GCP) is blocked/poisoned regardless of    │
+# │ the browser, so deploying anywhere but the residential rig is pointless    │
+# │ and only burns the IP. The official ABS/RBA backbone image (../Dockerfile, │
+# │ distroless, -mode all) is the one that runs on Cloud Run.                  │
 # └──────────────────────────────────────────────────────────────────────────┘
 #
-# It bakes: the Go collector binary + Node + the Playwright CHROMIUM browser +
-# its OS deps + xvfb, and runs the collector under a virtual X display so the
-# "headed" browser has somewhere to draw.
+# It bakes: the Go collector binary + Node + the Playwright-go DRIVER (the CDP
+# client still needs the driver — playwright.Run() launches it; we never call
+# playwright.Install(), and we DON'T install any browser) + ca-certificates.
+# No xvfb, no Chromium, no virtual display — the rendering happens on the host.
 #
-# The persistent browser profile (CRAWL_PROFILE_DIR, default /data/pw-profile)
-# MUST be a MOUNTED VOLUME on the runner so the Kasada clearance cookie / warm
-# context survives across runs — a cold profile re-triggers the JS challenge
-# every time. Example:
+# Example run on the residential rig (Docker-Desktop-for-Mac):
 #   docker run --rm \
 #     -e DATABASE_URL=... -e BRANDBRAIN_URL=... \
+#     -e CRAWL_CDP_URL=http://host.docker.internal:9222 \
 #     -e CRAWL_MAX_SUBURBS=3 -e CRAWL_DRY_RUN=true \
-#     -v /srv/pw-profile:/data/pw-profile \
 #     house-price-collector-crawl
 #
-# NOTE: do NOT build this in CI / on the disk-constrained dev box — the
-# Playwright browser download is large and the image only has a home on the
-# residential rig. Build + first paced live run happen there.
+# NOTE: this image is small now (no browser download), but it still only has a
+# home on the residential rig — the crawl is pointless from a datacentre egress.
 
 # --- stealth source bind-mount (collector still imports services/pkg/stealthhttp
 #     via the VIC official tier; same PAT/bind pattern as ../Dockerfile) ---
@@ -55,47 +64,35 @@ COPY . .
 RUN [ -f /tmp/go.mod.stealth ] && cp /tmp/go.mod.stealth go.mod || true
 RUN CGO_ENABLED=0 GOOS=linux go build -o /collector ./house-price-collector/
 
-# --- runtime: Debian slim + Node + Playwright(-go) driver + chromium + xvfb ---
+# --- runtime: Debian slim + Node + the Playwright-go DRIVER ONLY (no browser) ---
 FROM debian:bookworm-slim
 
-# Node (for the playwright-go driver, which is the Node Playwright CLI under the
-# hood) + xvfb (virtual display for the HEADED browser) + ca-certs. The chromium
-# OS dependencies themselves are installed by `playwright install --with-deps`
-# below, so we don't hand-maintain that long, brittle apt list here.
+# Node runs the playwright-go driver (the Node Playwright CLI under the hood),
+# which is the CDP client that talks to the HOST Chrome. ca-certificates for TLS.
+# NO xvfb, NO chromium — option (b) renders on the host, not here.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
-        xvfb \
         nodejs \
         npm \
-        curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the playwright-go driver + the CHROMIUM browser (and its OS deps) at
-# BUILD time. The collector calls only playwright.Run() at runtime (never
-# .Install()), so the driver + browser MUST be baked in here. The CLI version is
-# pinned to match the go module (v0.5700.1) so the driver and the library agree.
-#   - PLAYWRIGHT_BROWSERS_PATH=0 keeps the browser next to the driver so a single
-#     well-known location holds both (no per-user cache surprises under xvfb).
+# Install ONLY the playwright-go DRIVER at build time (the CDP client needs it;
+# the collector calls playwright.Run() at runtime, never .Install()). We pass NO
+# browser name to `playwright install`, so NO Chromium is downloaded — the host
+# Chrome does all rendering. The CLI version is pinned to match the go module
+# (v0.5700.1) so the driver and the library agree.
 ENV PLAYWRIGHT_DRIVER_PATH=/opt/ms-playwright-go
-RUN GOBIN=/usr/local/bin \
-    && curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xz \
-    && /usr/local/go/bin/go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5700.1 install --with-deps chromium \
+RUN curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xz \
+    && /usr/local/go/bin/go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5700.1 install \
     && rm -rf /usr/local/go /root/go /root/.cache/go-build
-# (If the above go-toolchain bootstrap is undesirable on the rig, the alternative
-# is to COPY a pre-fetched driver dir into PLAYWRIGHT_DRIVER_PATH; either way the
-# driver + chromium are present before runtime and .Install() is never called.)
+# (`playwright install` with no browser arg installs the driver only — NO browser
+# binaries. If even this go-toolchain bootstrap is undesirable on the rig, COPY a
+# pre-fetched driver dir into PLAYWRIGHT_DRIVER_PATH instead; either way the
+# driver is present before runtime and .Install() is never called.)
 
 WORKDIR /app
 COPY --from=builder /collector /collector
 
-# Warm-profile volume (mount a host dir here on the runner) so the Kasada
-# clearance cookie / warm context survives across runs. Created so a missing
-# mount still has a writable default path.
-RUN mkdir -p /data/pw-profile
-ENV CRAWL_PROFILE_DIR=/data/pw-profile
-VOLUME ["/data/pw-profile"]
-
-# Run the collector's crawl mode under a virtual display so the HEADED Chromium
-# has an X server to render into. xvfb-run picks a free display and tears it down
-# when the collector exits.
-ENTRYPOINT ["xvfb-run", "-a", "--server-args=-screen 0 1440x900x24", "/collector", "-mode", "crawl"]
+# Run the collector's crawl mode. It drives the HOST Chrome over CDP
+# (CRAWL_CDP_URL); no local browser/display is launched.
+ENTRYPOINT ["/collector", "-mode", "crawl"]

--- a/services/house-price-collector/crawl.go
+++ b/services/house-price-collector/crawl.go
@@ -35,6 +35,52 @@ type htmlFetcher interface {
 	fetch(ctx context.Context, url string) (html []byte, finalURL string, err error)
 }
 
+// crawlFetcher is the lifecycle-owning fetcher returned by newCrawlFetcher: a
+// concrete browser-backed fetcher that the run owns and must Close(). Both
+// fetchers (CDP-to-host-Chrome and self-launched persistent Chromium) satisfy it.
+type crawlFetcher interface {
+	htmlFetcher
+	Close()
+}
+
+// fetcherMode names the browser-execution model selected for a run.
+type fetcherMode int
+
+const (
+	// fetcherModePlaywright launches a self-contained, headed persistent
+	// Chromium inside this process (native/launchd fallback).
+	fetcherModePlaywright fetcherMode = iota
+	// fetcherModeCDP connects over CDP to an already-running Chrome — in
+	// option (b), the HOST's macOS Chrome reached via host.docker.internal.
+	fetcherModeCDP
+)
+
+// selectFetcherMode is the pure, testable selection rule: CRAWL_CDP_URL set ->
+// drive the host Chrome over CDP; empty -> self-launch a persistent Chromium.
+func selectFetcherMode(cfg crawlConfig) fetcherMode {
+	if cfg.cdpURL != "" {
+		return fetcherModeCDP
+	}
+	return fetcherModePlaywright
+}
+
+func crawlFetcherMode(cfg crawlConfig) string {
+	if selectFetcherMode(cfg) == fetcherModeCDP {
+		return "cdp-host-chrome"
+	}
+	return "headed-playwright"
+}
+
+// newCrawlFetcher constructs the browser-backed fetcher for the run, branching on
+// CRAWL_CDP_URL. Errors are returned (never panics) so runCrawl can fail
+// non-fatally — the official ABS/RBA backbone is unaffected either way.
+func newCrawlFetcher(cfg crawlConfig) (crawlFetcher, error) {
+	if selectFetcherMode(cfg) == fetcherModeCDP {
+		return newCDPFetcher(cfg)
+	}
+	return newPlaywrightFetcher(cfg)
+}
+
 type crawlConfig struct {
 	maxSuburbs      int
 	minDelay        time.Duration
@@ -44,6 +90,13 @@ type crawlConfig struct {
 	fetchTimeout    time.Duration
 	brandbrainURL   string
 	profileDir      string
+	// cdpURL, when set, selects the "option (b)" local-agent execution model:
+	// instead of the container rendering pages itself, the collector drives the
+	// HOST's macOS-native Chrome over CDP (the only browser proven to beat
+	// Kasada/Akamai). The container reaches the host via host.docker.internal.
+	// Empty -> launch a self-contained persistent Chromium (native/launchd
+	// fallback). See newCDPFetcher / newPlaywrightFetcher.
+	cdpURL string
 }
 
 func loadCrawlConfig() crawlConfig {
@@ -58,6 +111,7 @@ func loadCrawlConfig() crawlConfig {
 		fetchTimeout:    time.Duration(envInt("CRAWL_FETCH_TIMEOUT_S", 60)) * time.Second,
 		brandbrainURL:   os.Getenv("BRANDBRAIN_URL"), // "" -> brandbrainEndpoint() default
 		profileDir:      envStr("CRAWL_PROFILE_DIR", "/data/pw-profile"),
+		cdpURL:          os.Getenv("CRAWL_CDP_URL"), // e.g. http://host.docker.internal:9222
 	}
 }
 
@@ -108,13 +162,16 @@ func runCrawl(ctx context.Context, pool *pgxpool.Pool) {
 		baselines = map[string]float64{}
 	}
 
-	// The headed Playwright browser is the ONLY client that survives Kasada/Akamai
-	// from a residential IP. If its driver/browser is missing (e.g. running outside
-	// the cuttlefish image), fail non-fatally — the official backbone is unaffected.
-	fetcher, err := newPlaywrightFetcher(cfg)
+	// A real, headed Chrome is the ONLY client that survives Kasada/Akamai from a
+	// residential IP. With CRAWL_CDP_URL set we drive the HOST's macOS Chrome over
+	// CDP (option (b)); otherwise we launch a self-contained persistent Chromium
+	// (native/launchd fallback). If the chosen client can't init (e.g. driver
+	// missing, host Chrome not on :9222), fail non-fatally — the official backbone
+	// is unaffected.
+	fetcher, err := newCrawlFetcher(cfg)
 	if err != nil {
-		log.Printf("[crawl] playwright fetcher init failed (%v) — aborting crawl (non-fatal; official backbone unaffected)", err)
-		_ = updateRun(ctx, pool, "crawl", nil, 0, "error", "playwright init: "+err.Error())
+		log.Printf("[crawl] crawl fetcher init failed (%v) — aborting crawl (non-fatal; official backbone unaffected)", err)
+		_ = updateRun(ctx, pool, "crawl", nil, 0, "error", "fetcher init: "+err.Error())
 		return
 	}
 	defer fetcher.Close()
@@ -125,7 +182,7 @@ func runCrawl(ctx context.Context, pool *pgxpool.Pool) {
 	if cfg.maxSuburbs >= 0 && cfg.maxSuburbs < len(targets) {
 		targets = targets[:cfg.maxSuburbs]
 	}
-	log.Printf("[crawl] start: %d suburbs · headed-playwright · profile=%s · dryRun=%v", len(targets), cfg.profileDir, cfg.dryRun)
+	log.Printf("[crawl] start: %d suburbs · %s · profile=%s · dryRun=%v", len(targets), crawlFetcherMode(cfg), cfg.profileDir, cfg.dryRun)
 
 	var obs []Observation
 	for i, t := range targets {

--- a/services/house-price-collector/crawl.go
+++ b/services/house-price-collector/crawl.go
@@ -6,44 +6,58 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/castlemilk/shorted.com.au/services/pkg/stealthhttp"
 )
 
 // The Tier-3 crawl. SUPPLEMENTARY and OPTIONAL: realestate.com.au (Kasada) and
 // domain.com.au (Akamai) actively block and — in REA's case — feed false data to
-// suspected bots. So this tier is built to FAIL SAFE: it never blocks the
-// pipeline, never stores a value that fails validation, and self-throttles via a
-// per-site circuit breaker. The official ABS/RBA backbone is the source of truth;
-// the crawl only ever adds licence-gated suburb detail on top.
+// suspected bots. The stealth native/chromedp waterfall this tier originally used
+// is reliably DETECTED and blocked/poisoned from a residential IP, so the page
+// FETCH is now done with a real, HEADED, persistent-profile browser (see
+// crawl_playwright.go) — the only client that survives Kasada/Akamai from a
+// residential egress. The rendered HTML is then handed to brandbrain's
+// ExtractRealEstate LLM (crawl_brandbrain.go) for the suburb-aggregate fields.
+//
+// This tier is built to FAIL SAFE: it never blocks the pipeline, never stores a
+// value that fails validation, and self-throttles via a per-site circuit breaker.
+// The official ABS/RBA backbone is the source of truth; the crawl only ever adds
+// licence-gated suburb detail on top.
+
+// htmlFetcher fetches a fully-rendered page and returns its HTML, the final URL
+// after any redirects, and an error. The orchestration depends only on this seam
+// (not on any concrete engine), which keeps the crawl flow unit-testable with a
+// fake fetcher and lets the real fetch be a headed Playwright browser.
+type htmlFetcher interface {
+	fetch(ctx context.Context, url string) (html []byte, finalURL string, err error)
+}
 
 type crawlConfig struct {
 	maxSuburbs      int
 	minDelay        time.Duration
 	maxDelay        time.Duration
-	proxy           string
-	disableChromium bool
 	dryRun          bool
 	maxConsecBlocks int
-	perFetchRetries int
 	fetchTimeout    time.Duration
+	brandbrainURL   string
+	profileDir      string
 }
 
 func loadCrawlConfig() crawlConfig {
 	return crawlConfig{
-		maxSuburbs:      envInt("CRAWL_MAX_SUBURBS", len(crawlTargets)),
-		minDelay:        time.Duration(envInt("CRAWL_MIN_DELAY_MS", 5000)) * time.Millisecond,
-		maxDelay:        time.Duration(envInt("CRAWL_MAX_DELAY_MS", 15000)) * time.Millisecond,
-		proxy:           os.Getenv("CRAWL_PROXY"),
-		disableChromium: os.Getenv("CRAWL_DISABLE_CHROMIUM") == "true",
+		maxSuburbs: envInt("CRAWL_MAX_SUBURBS", len(crawlTargets)),
+		// HEAVIER pacing than the old stealth tier: a headed browser hitting a
+		// Kasada/Akamai-protected site must look human (20–45s between suburbs).
+		minDelay:        time.Duration(envInt("CRAWL_MIN_DELAY_MS", 20000)) * time.Millisecond,
+		maxDelay:        time.Duration(envInt("CRAWL_MAX_DELAY_MS", 45000)) * time.Millisecond,
 		dryRun:          os.Getenv("CRAWL_DRY_RUN") == "true",
 		maxConsecBlocks: envInt("CRAWL_MAX_CONSEC_BLOCKS", 3),
-		perFetchRetries: envInt("CRAWL_FETCH_RETRIES", 2),
-		fetchTimeout:    time.Duration(envInt("CRAWL_FETCH_TIMEOUT_S", 30)) * time.Second,
+		fetchTimeout:    time.Duration(envInt("CRAWL_FETCH_TIMEOUT_S", 60)) * time.Second,
+		brandbrainURL:   os.Getenv("BRANDBRAIN_URL"), // "" -> brandbrainEndpoint() default
+		profileDir:      envStr("CRAWL_PROFILE_DIR", "/data/pw-profile"),
 	}
 }
 
@@ -52,6 +66,13 @@ func envInt(key string, def int) int {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
 		}
+	}
+	return def
+}
+
+func envStr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
 	}
 	return def
 }
@@ -69,9 +90,8 @@ type crawlStats struct {
 }
 
 type crawler struct {
-	native    *stealthhttp.Client
-	chromium  *stealthhttp.Client // nil if unavailable
-	baselines map[string]float64  // capital GCCSA region_code -> trusted ABS median
+	fetcher   htmlFetcher        // headed Playwright in prod; a fake in tests
+	baselines map[string]float64 // capital GCCSA region_code -> trusted ABS median
 	cfg       crawlConfig
 	reaBlocks int // consecutive-block counters for the circuit breaker
 	domBlocks int
@@ -88,37 +108,24 @@ func runCrawl(ctx context.Context, pool *pgxpool.Pool) {
 		baselines = map[string]float64{}
 	}
 
-	nativeOpts := []stealthhttp.Option{stealthhttp.WithTimeout(cfg.fetchTimeout)}
-	if cfg.proxy != "" {
-		nativeOpts = append(nativeOpts, stealthhttp.WithProxy(cfg.proxy))
-	}
-	native, err := stealthhttp.New(nativeOpts...)
+	// The headed Playwright browser is the ONLY client that survives Kasada/Akamai
+	// from a residential IP. If its driver/browser is missing (e.g. running outside
+	// the cuttlefish image), fail non-fatally — the official backbone is unaffected.
+	fetcher, err := newPlaywrightFetcher(cfg)
 	if err != nil {
-		log.Printf("[crawl] native client init failed: %v — aborting crawl (non-fatal)", err)
-		_ = updateRun(ctx, pool, "crawl", nil, 0, "error", "native client init: "+err.Error())
+		log.Printf("[crawl] playwright fetcher init failed (%v) — aborting crawl (non-fatal; official backbone unaffected)", err)
+		_ = updateRun(ctx, pool, "crawl", nil, 0, "error", "playwright init: "+err.Error())
 		return
 	}
+	defer fetcher.Close()
 
-	var chromium *stealthhttp.Client
-	if !cfg.disableChromium {
-		copts := []stealthhttp.Option{stealthhttp.WithTimeout(cfg.fetchTimeout + 30*time.Second)}
-		if cfg.proxy != "" {
-			copts = append(copts, stealthhttp.WithProxy(cfg.proxy))
-		}
-		if c, cerr := stealthhttp.NewChromium(copts...); cerr != nil {
-			log.Printf("[crawl] chromium unavailable (%v) — REA/Kasada likely unreachable; native-only", cerr)
-		} else {
-			chromium = c
-		}
-	}
-
-	cr := &crawler{native: native, chromium: chromium, baselines: baselines, cfg: cfg}
+	cr := &crawler{fetcher: fetcher, baselines: baselines, cfg: cfg}
 
 	targets := crawlTargets
 	if cfg.maxSuburbs >= 0 && cfg.maxSuburbs < len(targets) {
 		targets = targets[:cfg.maxSuburbs]
 	}
-	log.Printf("[crawl] start: %d suburbs · chromium=%v · proxy=%v · dryRun=%v", len(targets), chromium != nil, cfg.proxy != "", cfg.dryRun)
+	log.Printf("[crawl] start: %d suburbs · headed-playwright · profile=%s · dryRun=%v", len(targets), cfg.profileDir, cfg.dryRun)
 
 	var obs []Observation
 	for i, t := range targets {
@@ -149,46 +156,33 @@ func runCrawl(ctx context.Context, pool *pgxpool.Pool) {
 		s.attempted, s.accepted, s.blocked, s.rejected, s.diverged)
 }
 
-// crawlSuburb fetches both sources, validates, and applies the cross-source
-// trust rule. Returns the observations to store (0, 1, or 2).
+// crawlSuburb fetches both sources via the headed browser, hands each rendered
+// page to brandbrain's ExtractRealEstate, and maps the returned suburb-aggregate
+// fields into validated Observations. Returns everything to store (0..N).
 func (cr *crawler) crawlSuburb(ctx context.Context, t CrawlTarget) []Observation {
 	cr.stats.attempted++
-	base := cr.baselines[t.Capital] // 0 == unknown -> capital-band check skipped
 
-	reaMed, reaOK := cr.siteMedian(ctx, "rea", t.reaURL(), base, &cr.reaBlocks)
-	domMed, domOK := cr.siteMedian(ctx, "domain", t.domainURL(), base, &cr.domBlocks)
+	var obs []Observation
+	obs = append(obs, cr.crawlSource(ctx, t, "rea", t.reaURL(), &cr.reaBlocks)...)
+	obs = append(obs, cr.crawlSource(ctx, t, "domain", t.domainURL(), &cr.domBlocks)...)
 
-	switch {
-	case reaOK && domOK:
-		if !crossSourceAgrees(reaMed, domMed) {
-			cr.stats.diverged++
-			log.Printf("[crawl] %s: REA $%.0f vs Domain $%.0f diverge — rejecting BOTH (possible poisoning)", t.Display, reaMed, domMed)
-			return nil
-		}
+	if len(obs) > 0 {
 		cr.stats.accepted++
-		log.Printf("[crawl] %s: accepted (REA $%.0f ~ Domain $%.0f)", t.Display, reaMed, domMed)
-		return []Observation{cr.obs(t, reaMed, "crawl_rea", false), cr.obs(t, domMed, "crawl_domain", false)}
-	case reaOK:
-		cr.stats.accepted++
-		log.Printf("[crawl] %s: accepted single-source REA $%.0f (preliminary)", t.Display, reaMed)
-		return []Observation{cr.obs(t, reaMed, "crawl_rea", true)}
-	case domOK:
-		cr.stats.accepted++
-		log.Printf("[crawl] %s: accepted single-source Domain $%.0f (preliminary)", t.Display, domMed)
-		return []Observation{cr.obs(t, domMed, "crawl_domain", true)}
-	default:
-		return nil
+		log.Printf("[crawl] %s: accepted %d observation(s)", t.Display, len(obs))
 	}
+	return obs
 }
 
-// siteMedian fetches one source (with the circuit breaker), extracts candidate
-// medians and returns the validated robust median for that page.
-func (cr *crawler) siteMedian(ctx context.Context, site, url string, baseline float64, blockCounter *int) (float64, bool) {
+// crawlSource fetches ONE source's rendered page (honouring the per-site circuit
+// breaker), routes the HTML through brandbrain's extractor, and returns the
+// validated brandbrain Observations. The legacy extractSaleMedians path is run as
+// a non-blocking cross-check against the same rendered HTML (logged only).
+func (cr *crawler) crawlSource(ctx context.Context, t CrawlTarget, site, url string, blockCounter *int) []Observation {
 	if *blockCounter >= cr.cfg.maxConsecBlocks {
-		return 0, false // breaker open: stop hammering this source for the rest of the run
+		return nil // breaker open: stop hammering this source for the rest of the run
 	}
 
-	doc, outcome := cr.fetchWaterfall(ctx, url)
+	html, finalURL, outcome := cr.fetchPage(ctx, url)
 	switch outcome {
 	case outcomeBlocked:
 		*blockCounter++
@@ -196,85 +190,77 @@ func (cr *crawler) siteMedian(ctx context.Context, site, url string, baseline fl
 		if *blockCounter == cr.cfg.maxConsecBlocks {
 			log.Printf("[crawl] %s circuit-breaker tripped (%d consecutive blocks) — skipping remaining %s fetches", site, *blockCounter, site)
 		}
-		return 0, false
+		return nil
 	case outcomeError:
-		return 0, false
+		return nil
 	}
 	*blockCounter = 0 // a success resets the breaker
 
+	x, err := extractRealEstate(ctx, cr.cfg.brandbrainURL, string(html), finalURL, t.Display, t.State)
+	if err != nil {
+		log.Printf("[crawl] %s %s: brandbrain extract failed: %v", t.Display, site, err)
+		return nil
+	}
+
+	obs := cr.brandbrainObservations(t, site, x)
+	if len(obs) == 0 {
+		cr.stats.rejected++ // page rendered but nothing survived extraction/validation
+	}
+
+	// Optional, non-blocking cross-check: the schema-agnostic median harvester on
+	// the SAME rendered HTML. If it finds a robust median that diverges sharply
+	// from brandbrain's, log it as a poisoning/extraction-drift signal — but never
+	// drop the brandbrain observations on it (the capital-band gate already ran).
+	cr.crossCheck(t, site, html, obs)
+
+	return obs
+}
+
+// fetchPage fetches one URL via the injected htmlFetcher and classifies the
+// outcome. A block (Kasada/Akamai 403/429-style) trips the circuit breaker; any
+// other error is transient and simply skips this source for this run.
+func (cr *crawler) fetchPage(ctx context.Context, url string) ([]byte, string, fetchOutcome) {
+	html, finalURL, err := cr.fetcher.fetch(ctx, url)
+	if err != nil {
+		if isBlockError(err) {
+			return nil, "", outcomeBlocked
+		}
+		return nil, "", outcomeError
+	}
+	if looksBlocked(html, finalURL) {
+		return nil, "", outcomeBlocked
+	}
+	return html, finalURL, outcomeOK
+}
+
+// crossCheck runs the legacy extractSaleMedians harvester over the rendered HTML
+// and logs (only) when its robust median diverges from brandbrain's house median.
+// It is deliberately advisory — extraction drift on an adversarial page is a
+// signal, not a reason to discard the already-capital-band-gated value.
+func (cr *crawler) crossCheck(t CrawlTarget, site string, html []byte, obs []Observation) {
+	var bbHouse float64
+	for _, o := range obs {
+		if o.Measure == "median_price" && o.DwellingType == "house" {
+			bbHouse = o.Value
+			break
+		}
+	}
+	if bbHouse == 0 {
+		return
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(html)))
+	if err != nil {
+		return
+	}
 	candidates := extractSaleMedians(doc)
-	med, ok := robustMedian(candidates, baseline)
+	raw, ok := robustMedian(candidates, cr.baselines[t.Capital])
 	if !ok {
-		if len(candidates) > 0 {
-			cr.stats.rejected++ // page returned numbers but none survived validation (poison / wrong page)
-		}
-		return 0, false
+		return
 	}
-	return med, true
-}
-
-// fetchWaterfall tries the cheap native engine first, then escalates to Chromium
-// (for JS challenges) only if the native fetch was actively blocked.
-func (cr *crawler) fetchWaterfall(ctx context.Context, url string) (*goquery.Document, fetchOutcome) {
-	doc, oc := cr.fetchOne(ctx, cr.native, url)
-	if oc == outcomeOK {
-		return doc, outcomeOK
-	}
-	if oc == outcomeBlocked && cr.chromium != nil {
-		if doc2, oc2 := cr.fetchOne(ctx, cr.chromium, url); oc2 == outcomeOK {
-			return doc2, outcomeOK
-		} else if oc2 == outcomeBlocked {
-			return nil, outcomeBlocked
-		}
-	}
-	return nil, oc
-}
-
-// fetchOne fetches with one engine, retrying transient failures with quadratic
-// backoff but returning immediately on a hard block (403/429/401).
-func (cr *crawler) fetchOne(ctx context.Context, client *stealthhttp.Client, url string) (*goquery.Document, fetchOutcome) {
-	if client == nil {
-		return nil, outcomeError
-	}
-	for attempt := 0; attempt <= cr.cfg.perFetchRetries; attempt++ {
-		if attempt > 0 {
-			select {
-			case <-time.After(time.Duration(attempt*attempt) * time.Second):
-			case <-ctx.Done():
-				return nil, outcomeError
-			}
-		}
-		doc, _, err := client.FetchHTML(ctx, url)
-		if err == nil {
-			return doc, outcomeOK
-		}
-		switch stealthhttp.StatusError(err) {
-		case 401, 403, 429:
-			return nil, outcomeBlocked // hard block — don't retry the same engine
-		}
-		// otherwise transient (timeout / 5xx / network) — retry
-	}
-	return nil, outcomeError
-}
-
-func (cr *crawler) obs(t CrawlTarget, value float64, source string, prelim bool) Observation {
-	return Observation{
-		RegionCode:    t.regionCode(),
-		RegionType:    "suburb",
-		RegionName:    t.regionName(),
-		StateCode:     t.State,
-		Postcode:      t.Postcode,
-		Measure:       "median_price",
-		DwellingType:  "all",
-		Period:        currentQuarterEnd(),
-		PeriodFreq:    "Q",
-		Value:         value,
-		Unit:          "AUD",
-		IsPreliminary: prelim,
-		Source:        source,
-		// ToS-restricted: gated out of any commercial/republished surface via
-		// the house_prices.source_licence column.
-		SourceLicence: "proprietary-tos-restricted",
+	if !crossSourceAgrees(bbHouse, raw) {
+		cr.stats.diverged++
+		log.Printf("[crawl] %s %s: brandbrain $%.0f vs page-harvest $%.0f diverge (>%.0f%%) — extraction-drift signal (value kept; capital-band gate passed)",
+			t.Display, site, bbHouse, raw, maxCrossSourceDivergence*100)
 	}
 }
 

--- a/services/house-price-collector/crawl_brandbrain.go
+++ b/services/house-price-collector/crawl_brandbrain.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// crawl_brandbrain.go is the FETCH-INDEPENDENT enrichment core of the Tier-3
+// crawl: given already-fetched, real-browser-rendered suburb-page HTML, it calls
+// brandbrain's ExtractRealEstate RPC (an LLM extractor) and maps the suburb
+// AGGREGATE fields it returns into validated EAV Observations.
+//
+// The page FETCH is deliberately NOT wired here — the caller will pass `rawHTML`
+// from a real-browser fetch in a later step. This separation keeps the
+// extraction + validation + mapping logic fully unit-testable against canned
+// brandbrain responses without touching the adversarial live sites.
+//
+// Every value still goes through the SAME anti-poisoning gate as the raw crawl:
+// median prices are checked against the trusted ABS capital-city baseline via
+// validateMedian; non-price measures get simple sanity bounds. Anything that
+// fails is dropped (and logged), never stored.
+
+const defaultBrandbrainEndpoint = "https://api.brandbrain.dev/brandbrain.v1.DiscoveryService/ExtractRealEstate"
+
+// brandbrainEndpoint returns the FULL ExtractRealEstate endpoint URL, honouring
+// the BRANDBRAIN_URL override (which is expected to be the complete endpoint).
+func brandbrainEndpoint() string {
+	if v := os.Getenv("BRANDBRAIN_URL"); v != "" {
+		return v
+	}
+	return defaultBrandbrainEndpoint
+}
+
+// reaExtract mirrors the ExtractRealEstate response — only the fields we use. For
+// suburb pages the meaningful data is the suburb-aggregate fields carried on each
+// listing object; we read them from whichever listing first provides a value.
+type reaExtract struct {
+	Listings   []reaListing `json:"listings"`
+	AgencyName string       `json:"agency_name"`
+	SourceURL  string       `json:"source_url"`
+	Confidence float64      `json:"confidence"`
+	Notes      string       `json:"notes"`
+}
+
+// reaListing carries the suburb-aggregate measures we map to Observations. A 0
+// (or absent) value means "not present" and is skipped — never emitted as a
+// zero-value Observation.
+type reaListing struct {
+	MedianHousePrice float64 `json:"median_house_price"`
+	MedianUnitPrice  float64 `json:"median_unit_price"`
+	RentalYield      float64 `json:"rental_yield"`
+	DaysOnMarket     float64 `json:"days_on_market"`
+	ClearanceRate    float64 `json:"clearance_rate"`
+	AnnualGrowth     float64 `json:"annual_growth"`
+}
+
+// extractRealEstateReq is the protojson request body (snake_case keys).
+type extractRealEstateReq struct {
+	HTML       string `json:"html"`
+	URL        string `json:"url"`
+	SuburbHint string `json:"suburb_hint"`
+	StateHint  string `json:"state_hint"`
+}
+
+// brandbrainBackoffs is the serial retry schedule for the (sometimes 502-ing
+// under load) brandbrain RPC: 3 tries total, sleeping 1s/3s/6s between them.
+var brandbrainBackoffs = []time.Duration{1 * time.Second, 3 * time.Second, 6 * time.Second}
+
+// brandbrainHTTPClient is the shared client for the RPC call. It has a generous
+// timeout because the extractor runs an LLM over a full rendered page.
+var brandbrainHTTPClient = &http.Client{Timeout: 90 * time.Second}
+
+// extractRealEstate POSTs the rendered HTML to brandbrain's ExtractRealEstate RPC
+// and decodes the response. It retries on 5xx (brandbrain 502s under load) with
+// the 1s/3s/6s backoff; 4xx and decode errors fail fast.
+func extractRealEstate(ctx context.Context, endpoint, rawHTML, pageURL, suburb, state string) (*reaExtract, error) {
+	if endpoint == "" {
+		endpoint = brandbrainEndpoint()
+	}
+	body, err := json.Marshal(extractRealEstateReq{
+		HTML:       rawHTML,
+		URL:        pageURL,
+		SuburbHint: suburb,
+		StateHint:  state,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < len(brandbrainBackoffs); attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(brandbrainBackoffs[attempt]):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := brandbrainHTTPClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue // transient (network/timeout) — retry
+		}
+
+		if resp.StatusCode >= 500 {
+			drainClose(resp.Body)
+			lastErr = fmt.Errorf("brandbrain %d", resp.StatusCode)
+			continue // 5xx (e.g. 502 under load) — retry
+		}
+		if resp.StatusCode != http.StatusOK {
+			snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			drainClose(resp.Body)
+			return nil, fmt.Errorf("brandbrain %d: %s", resp.StatusCode, string(snippet))
+		}
+
+		var out reaExtract
+		dec := json.NewDecoder(resp.Body)
+		decErr := dec.Decode(&out)
+		drainClose(resp.Body)
+		if decErr != nil {
+			return nil, fmt.Errorf("decode response: %w", decErr)
+		}
+		return &out, nil
+	}
+	return nil, fmt.Errorf("brandbrain ExtractRealEstate failed after %d attempts: %w", len(brandbrainBackoffs), lastErr)
+}
+
+func drainClose(rc io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, rc)
+	_ = rc.Close()
+}
+
+// non-price measure sanity bounds (the analogue of validateMedian for the
+// aggregate metrics that aren't dollar medians).
+const (
+	minRentalYield   = 0.0
+	maxRentalYield   = 0.2 // 20% gross yield is already absurd for AU residential
+	minClearanceRate = 0.0
+	maxClearanceRate = 1.0
+	minAnnualGrowth  = -0.5
+	maxAnnualGrowth  = 1.0
+	minDaysOnMarket  = 0.0
+	maxDaysOnMarket  = 365.0
+)
+
+// brandbrainSource maps a site key ("rea"/"domain", or any other) to the
+// canonical Source string for brandbrain-extracted observations.
+func brandbrainSource(site string) string {
+	if site == "domain" {
+		return "brandbrain_domain"
+	}
+	return "brandbrain_rea"
+}
+
+// firstNonZero returns the first non-zero value produced by sel across listings,
+// since the suburb-aggregate fields are carried (redundantly) on listing objects
+// and not every listing necessarily populates every metric.
+func firstNonZero(listings []reaListing, sel func(reaListing) float64) float64 {
+	for _, l := range listings {
+		if v := sel(l); v != 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// brandbrainObservations maps the suburb-aggregate fields from a brandbrain
+// extraction into validated EAV Observations for one CrawlTarget.
+//
+//   - median_house_price / median_unit_price → median_price (house|unit), AUD,
+//     gated through validateMedian against the trusted ABS capital baseline.
+//   - rental_yield / days_on_market / clearance_rate / annual_growth → their
+//     respective measures (all dwellings), gated by simple sanity bounds.
+//
+// site is "rea" or "domain" (anything else maps to brandbrain_rea). Zero/absent
+// fields and out-of-bounds values are skipped (the latter logged).
+func (cr *crawler) brandbrainObservations(t CrawlTarget, site string, x *reaExtract) []Observation {
+	if x == nil || len(x.Listings) == 0 {
+		return nil
+	}
+	source := brandbrainSource(site)
+	baseline := cr.baselines[t.Capital] // 0 == unknown -> capital-band check skipped
+
+	// base returns an Observation with all the shared region/period/source fields
+	// populated; the caller fills measure/dwelling/value/unit.
+	base := func(measure, dwelling string, value float64, unit string) Observation {
+		return Observation{
+			RegionCode:    t.regionCode(),
+			RegionType:    "suburb",
+			RegionName:    t.regionName(),
+			StateCode:     t.State,
+			Postcode:      t.Postcode,
+			Measure:       measure,
+			DwellingType:  dwelling,
+			Period:        currentQuarterEnd(),
+			PeriodFreq:    "Q",
+			Value:         value,
+			Unit:          unit,
+			IsPreliminary: false,
+			Source:        source,
+			// ToS-restricted: gated out of any commercial/republished surface via
+			// the house_prices.source_licence column.
+			SourceLicence: "proprietary-tos-restricted",
+		}
+	}
+
+	var obs []Observation
+
+	// --- median prices (anti-poisoning capital-band gate) ---
+	if v := firstNonZero(x.Listings, func(l reaListing) float64 { return l.MedianHousePrice }); v != 0 {
+		if res := validateMedian(v, baseline); res.ok {
+			obs = append(obs, base("median_price", "house", v, "AUD"))
+		} else {
+			log.Printf("[brandbrain] %s: dropped house median $%.0f (%s)", t.Display, v, res.reason)
+		}
+	}
+	if v := firstNonZero(x.Listings, func(l reaListing) float64 { return l.MedianUnitPrice }); v != 0 {
+		if res := validateMedian(v, baseline); res.ok {
+			obs = append(obs, base("median_price", "unit", v, "AUD"))
+		} else {
+			log.Printf("[brandbrain] %s: dropped unit median $%.0f (%s)", t.Display, v, res.reason)
+		}
+	}
+
+	// --- non-price measures (simple sanity bounds) ---
+	if v := firstNonZero(x.Listings, func(l reaListing) float64 { return l.RentalYield }); v != 0 {
+		if inBounds(v, minRentalYield, maxRentalYield) {
+			obs = append(obs, base("rental_yield", "all", v, "ratio"))
+		} else {
+			log.Printf("[brandbrain] %s: dropped rental_yield %.4f (out of bounds)", t.Display, v)
+		}
+	}
+	if v := firstNonZero(x.Listings, func(l reaListing) float64 { return l.DaysOnMarket }); v != 0 {
+		if inBounds(v, minDaysOnMarket, maxDaysOnMarket) {
+			obs = append(obs, base("days_on_market", "all", v, "count"))
+		} else {
+			log.Printf("[brandbrain] %s: dropped days_on_market %.0f (out of bounds)", t.Display, v)
+		}
+	}
+	if v := firstNonZero(x.Listings, func(l reaListing) float64 { return l.ClearanceRate }); v != 0 {
+		if inBounds(v, minClearanceRate, maxClearanceRate) {
+			obs = append(obs, base("auction_clearance", "all", v, "ratio"))
+		} else {
+			log.Printf("[brandbrain] %s: dropped auction_clearance %.4f (out of bounds)", t.Display, v)
+		}
+	}
+	if v := firstNonZero(x.Listings, func(l reaListing) float64 { return l.AnnualGrowth }); v != 0 {
+		if inBounds(v, minAnnualGrowth, maxAnnualGrowth) {
+			obs = append(obs, base("price_growth_12m", "all", v, "ratio"))
+		} else {
+			log.Printf("[brandbrain] %s: dropped price_growth_12m %.4f (out of bounds)", t.Display, v)
+		}
+	}
+
+	return obs
+}
+
+func inBounds(v, lo, hi float64) bool {
+	return v >= lo && v <= hi
+}

--- a/services/house-price-collector/crawl_brandbrain_test.go
+++ b/services/house-price-collector/crawl_brandbrain_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests cover the fetch-INDEPENDENT brandbrain enrichment core: the
+// ExtractRealEstate client (POST + retry + decode) and the aggregate-field →
+// validated-Observation mapping. The real page FETCH is out of scope; the caller
+// supplies rawHTML.
+
+// bondi is the canonical CrawlTarget used across these tests. Its capital GCCSA
+// (1GSYD) is the key into the crawler's trusted ABS baseline map.
+var bondi = CrawlTarget{Suburb: "bondi", Display: "Bondi", Postcode: "2026", State: "NSW", Capital: "1GSYD"}
+
+// Real Bondi suburb-aggregate numbers used as the canned brandbrain response.
+const (
+	bondiHouseMedian  = 4_275_000.0
+	bondiUnitMedian   = 1_457_500.0
+	bondiRentalYield  = 0.023
+	bondiDaysOnMarket = 26.0
+	bondiAnnualGrowth = 0.0364
+)
+
+// bondiExtractJSON is a realistic ExtractRealEstate response body (snake_case,
+// protojson shape). The aggregate measures live on the listing object(s).
+func bondiExtractJSON() string {
+	resp := reaExtract{
+		Listings: []reaListing{{
+			MedianHousePrice: bondiHouseMedian,
+			MedianUnitPrice:  bondiUnitMedian,
+			RentalYield:      bondiRentalYield,
+			DaysOnMarket:     bondiDaysOnMarket,
+			AnnualGrowth:     bondiAnnualGrowth,
+			// ClearanceRate intentionally absent (0) — must emit no observation.
+		}},
+		AgencyName: "realestate.com.au",
+		SourceURL:  bondi.reaURL(),
+		Confidence: 0.92,
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+// newCrawlerWithBaseline returns a crawler whose ABS baseline for Sydney makes
+// the capital-band validation active (Bondi's $4.275M house median sits ~2.9× the
+// $1.485M Sydney median — well inside the 0.15×–8× band).
+func newCrawlerWithBaseline() *crawler {
+	return &crawler{baselines: map[string]float64{"1GSYD": 1_485_000.0}}
+}
+
+func TestBrandbrain_ExtractRealEstate_ParsesBondi(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		var req extractRealEstateReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("server could not decode request body: %v", err)
+		}
+		if req.SuburbHint != "Bondi" || req.StateHint != "NSW" {
+			t.Errorf("hints = %q/%q, want Bondi/NSW", req.SuburbHint, req.StateHint)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(bondiExtractJSON()))
+	}))
+	defer srv.Close()
+
+	x, err := extractRealEstate(context.Background(), srv.URL, "<html>...</html>", bondi.reaURL(), "Bondi", "NSW")
+	if err != nil {
+		t.Fatalf("extractRealEstate: %v", err)
+	}
+	if len(x.Listings) != 1 {
+		t.Fatalf("listings = %d, want 1", len(x.Listings))
+	}
+	l := x.Listings[0]
+	if l.MedianHousePrice != bondiHouseMedian || l.MedianUnitPrice != bondiUnitMedian {
+		t.Errorf("medians = %.0f/%.0f, want %.0f/%.0f", l.MedianHousePrice, l.MedianUnitPrice, bondiHouseMedian, bondiUnitMedian)
+	}
+	if l.RentalYield != bondiRentalYield || l.DaysOnMarket != bondiDaysOnMarket || l.AnnualGrowth != bondiAnnualGrowth {
+		t.Errorf("metrics = %.4f/%.0f/%.4f, want %.4f/%.0f/%.4f",
+			l.RentalYield, l.DaysOnMarket, l.AnnualGrowth, bondiRentalYield, bondiDaysOnMarket, bondiAnnualGrowth)
+	}
+}
+
+func TestBrandbrain_Observations_MapsBondi(t *testing.T) {
+	cr := newCrawlerWithBaseline()
+	x, err := extractFromJSON(bondiExtractJSON())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obs := cr.brandbrainObservations(bondi, "rea", x)
+
+	// Index by measure|dwelling for assertion.
+	type key struct{ measure, dwelling string }
+	got := map[key]Observation{}
+	for _, o := range obs {
+		got[key{o.Measure, o.DwellingType}] = o
+	}
+
+	want := []struct {
+		measure, dwelling string
+		value             float64
+		unit              string
+	}{
+		{"median_price", "house", bondiHouseMedian, "AUD"},
+		{"median_price", "unit", bondiUnitMedian, "AUD"},
+		{"rental_yield", "all", bondiRentalYield, "ratio"},
+		{"days_on_market", "all", bondiDaysOnMarket, "count"},
+		{"price_growth_12m", "all", bondiAnnualGrowth, "ratio"},
+	}
+
+	if len(obs) != len(want) {
+		t.Fatalf("got %d observations, want %d: %+v", len(obs), len(want), obs)
+	}
+	for _, w := range want {
+		o, ok := got[key{w.measure, w.dwelling}]
+		if !ok {
+			t.Errorf("missing observation %s/%s", w.measure, w.dwelling)
+			continue
+		}
+		if o.Value != w.value {
+			t.Errorf("%s/%s value = %v, want %v", w.measure, w.dwelling, o.Value, w.value)
+		}
+		if o.Unit != w.unit {
+			t.Errorf("%s/%s unit = %q, want %q", w.measure, w.dwelling, o.Unit, w.unit)
+		}
+		// Shared fields are identical across all observations.
+		if o.RegionCode != bondi.regionCode() || o.RegionType != "suburb" || o.RegionName != bondi.regionName() {
+			t.Errorf("%s/%s region fields wrong: %q/%q/%q", w.measure, w.dwelling, o.RegionCode, o.RegionType, o.RegionName)
+		}
+		if o.StateCode != "NSW" || o.Postcode != "2026" {
+			t.Errorf("%s/%s state/postcode wrong: %q/%q", w.measure, w.dwelling, o.StateCode, o.Postcode)
+		}
+		if o.Source != "brandbrain_rea" {
+			t.Errorf("%s/%s source = %q, want brandbrain_rea", w.measure, w.dwelling, o.Source)
+		}
+		if o.SourceLicence != "proprietary-tos-restricted" {
+			t.Errorf("%s/%s licence = %q, want proprietary-tos-restricted", w.measure, w.dwelling, o.SourceLicence)
+		}
+		if o.PeriodFreq != "Q" {
+			t.Errorf("%s/%s period_freq = %q, want Q", w.measure, w.dwelling, o.PeriodFreq)
+		}
+	}
+
+	// ClearanceRate was absent → no auction_clearance observation.
+	if _, ok := got[key{"auction_clearance", "all"}]; ok {
+		t.Error("absent clearance_rate must not emit an observation")
+	}
+}
+
+func TestBrandbrain_Observations_DomainSource(t *testing.T) {
+	cr := newCrawlerWithBaseline()
+	x := &reaExtract{Listings: []reaListing{{MedianHousePrice: bondiHouseMedian}}}
+	obs := cr.brandbrainObservations(bondi, "domain", x)
+	if len(obs) != 1 || obs[0].Source != "brandbrain_domain" {
+		t.Fatalf("domain site should map to brandbrain_domain: %+v", obs)
+	}
+}
+
+func TestBrandbrain_Observations_PoisonedMedianDropped(t *testing.T) {
+	cr := newCrawlerWithBaseline() // Sydney baseline 1.485M active
+	// $50M for a ~$1M-band suburb: passes the absolute ceiling? No — 50M is at the
+	// absolute boundary but >8× the capital median, so the capital-band gate drops
+	// it. Unit median stays clean and must still come through.
+	x := &reaExtract{Listings: []reaListing{{
+		MedianHousePrice: 50_000_000,
+		MedianUnitPrice:  bondiUnitMedian,
+	}}}
+
+	obs := cr.brandbrainObservations(bondi, "rea", x)
+
+	for _, o := range obs {
+		if o.Measure == "median_price" && o.DwellingType == "house" {
+			t.Fatalf("poisoned house median $50M must be dropped, got %v", o.Value)
+		}
+	}
+	// The clean unit median should survive.
+	found := false
+	for _, o := range obs {
+		if o.Measure == "median_price" && o.DwellingType == "unit" && o.Value == bondiUnitMedian {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("clean unit median should survive the poison gate")
+	}
+}
+
+func TestBrandbrain_Observations_NonPriceOutOfBoundsDropped(t *testing.T) {
+	cr := newCrawlerWithBaseline()
+	x := &reaExtract{Listings: []reaListing{{
+		RentalYield:   0.5,   // >0.2 → drop
+		ClearanceRate: 1.5,   // >1.0 → drop
+		AnnualGrowth:  2.0,   // >1.0 → drop
+		DaysOnMarket:  400.0, // >365 → drop
+	}}}
+	obs := cr.brandbrainObservations(bondi, "rea", x)
+	if len(obs) != 0 {
+		t.Fatalf("all four out-of-bounds metrics must be dropped, got %+v", obs)
+	}
+}
+
+func TestBrandbrain_Observations_ZeroFieldEmitsNothing(t *testing.T) {
+	cr := newCrawlerWithBaseline()
+	// A listing with every aggregate field zero/absent.
+	x := &reaExtract{Listings: []reaListing{{}}}
+	if obs := cr.brandbrainObservations(bondi, "rea", x); len(obs) != 0 {
+		t.Fatalf("a fully-empty listing must emit no observations, got %+v", obs)
+	}
+	// nil extract / no listings → nothing.
+	if obs := cr.brandbrainObservations(bondi, "rea", nil); obs != nil {
+		t.Fatalf("nil extract must emit no observations, got %+v", obs)
+	}
+	if obs := cr.brandbrainObservations(bondi, "rea", &reaExtract{}); obs != nil {
+		t.Fatalf("empty listings must emit no observations, got %+v", obs)
+	}
+}
+
+func TestBrandbrain_ExtractRealEstate_RetriesOn5xx(t *testing.T) {
+	// Speed up the backoff schedule for the test, restore afterwards.
+	orig := brandbrainBackoffs
+	brandbrainBackoffs = []time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	defer func() { brandbrainBackoffs = orig }()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			http.Error(w, "upstream overloaded", http.StatusBadGateway) // 502 first
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(bondiExtractJSON()))
+	}))
+	defer srv.Close()
+
+	x, err := extractRealEstate(context.Background(), srv.URL, "<html>", bondi.reaURL(), "Bondi", "NSW")
+	if err != nil {
+		t.Fatalf("extractRealEstate should succeed after a 502 retry: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 calls (502 then 200), got %d", got)
+	}
+	if len(x.Listings) != 1 || x.Listings[0].MedianHousePrice != bondiHouseMedian {
+		t.Errorf("retry response not parsed correctly: %+v", x)
+	}
+}
+
+func TestBrandbrain_ExtractRealEstate_GivesUpAfterAll5xx(t *testing.T) {
+	orig := brandbrainBackoffs
+	brandbrainBackoffs = []time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	defer func() { brandbrainBackoffs = orig }()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.Error(w, "still down", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	if _, err := extractRealEstate(context.Background(), srv.URL, "<html>", bondi.reaURL(), "Bondi", "NSW"); err == nil {
+		t.Fatal("expected error after exhausting retries on persistent 5xx")
+	}
+	if got := atomic.LoadInt32(&calls); got != int32(len(brandbrainBackoffs)) {
+		t.Errorf("expected %d attempts, got %d", len(brandbrainBackoffs), got)
+	}
+}
+
+// extractFromJSON is a tiny test helper that decodes a canned response body the
+// same way extractRealEstate's decoder does (without a live server).
+func extractFromJSON(s string) (*reaExtract, error) {
+	var x reaExtract
+	if err := json.Unmarshal([]byte(s), &x); err != nil {
+		return nil, err
+	}
+	return &x, nil
+}

--- a/services/house-price-collector/crawl_cdp.go
+++ b/services/house-price-collector/crawl_cdp.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/playwright-community/playwright-go"
+)
+
+// crawl_cdp.go implements the "option (b)" local-agent execution model: instead
+// of the container rendering pages itself, the collector drives the HOST's
+// macOS-native Chrome over the Chrome DevTools Protocol (CDP). A real,
+// user-driven macOS Chrome is the only browser empirically proven to beat
+// realestate.com.au's Kasada and domain.com.au's Akamai from a residential IP —
+// a Linux/xvfb Chromium (even headed) is still detected.
+//
+// The runner container reaches the host Chrome via host.docker.internal (e.g.
+// CRAWL_CDP_URL=http://host.docker.internal:9222 on Docker-Desktop-for-Mac).
+// The host Chrome MUST be started with --remote-debugging-port=9222 AND a
+// DEDICATED --user-data-dir (NEVER the personal profile — see the project's
+// browser-automation safety rules), e.g.:
+//
+//	/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+//	  --remote-debugging-port=9222 \
+//	  --user-data-dir="$HOME/.shorted-housing-crawl-chrome"
+//
+// Why reuse browser.Contexts()[0]: ConnectOverCDP attaches to the live browser,
+// and its first (default) context IS the host Chrome's warm, persistent context.
+// The Kasada clearance cookie + warmed profile live on the HOST and survive
+// across runs, so we don't re-trigger the JS challenge every run. We open a fresh
+// page per suburb on that shared context (same as the persistent-Chromium tier).
+//
+// Close() detaches WITHOUT killing the host browser — it's the user's Chrome, not
+// ours to terminate. We never call browser.Close() here.
+
+// cdpFetcher drives an already-running host Chrome over CDP. Like
+// playwrightFetcher it is NOT safe for concurrent fetches (one shared context);
+// the crawl loop is serial by design, and the mutex is belt-and-braces.
+type cdpFetcher struct {
+	pw       *playwright.Playwright
+	browser  playwright.Browser
+	ctx      playwright.BrowserContext
+	ownedCtx bool // true if we created the context (must Close it); false if we reused the host's default context
+	cfg      crawlConfig
+	mu       sync.Mutex
+	closeMu  sync.Once
+}
+
+// newCDPFetcher starts the Playwright driver (the CDP client needs only the
+// DRIVER, not a bundled browser) and connects over CDP to the host Chrome at
+// cfg.cdpURL. It reuses the host's warm default context when present (preserving
+// the Kasada clearance cookie); only if the connected browser exposes no context
+// does it create a fresh, AU-localised one. A connect failure returns a clear
+// error so runCrawl fails non-fatally (the official backbone is unaffected).
+func newCDPFetcher(cfg crawlConfig) (*cdpFetcher, error) {
+	pw, err := playwright.Run()
+	if err != nil {
+		return nil, fmt.Errorf("playwright driver unavailable (CDP client still needs the driver; not installed in this environment — expected only inside Dockerfile.crawl): %w", err)
+	}
+
+	browser, err := pw.Chromium.ConnectOverCDP(cfg.cdpURL)
+	if err != nil {
+		_ = pw.Stop()
+		return nil, fmt.Errorf("connect over CDP to %s: %w (is the host Chrome running with --remote-debugging-port and reachable via host.docker.internal?)", cfg.cdpURL, err)
+	}
+
+	// Reuse the host Chrome's warm, persistent default context (index 0). That is
+	// where the Kasada clearance cookie + warmed profile live, so reusing it is
+	// the whole point of option (b). Only fabricate a context if the connected
+	// browser somehow exposes none.
+	var bctx playwright.BrowserContext
+	ownedCtx := false
+	if ctxs := browser.Contexts(); len(ctxs) > 0 {
+		bctx = ctxs[0]
+	} else {
+		bctx, err = browser.NewContext(playwright.BrowserNewContextOptions{
+			Locale:     playwright.String("en-AU"),
+			TimezoneId: playwright.String("Australia/Sydney"),
+			UserAgent:  playwright.String(crawlUserAgent),
+			Viewport:   &playwright.Size{Width: 1440, Height: 900},
+		})
+		if err != nil {
+			_ = browser.Close()
+			_ = pw.Stop()
+			return nil, fmt.Errorf("create CDP browser context on %s: %w", cfg.cdpURL, err)
+		}
+		ownedCtx = true
+	}
+
+	return &cdpFetcher{pw: pw, browser: browser, ctx: bctx, ownedCtx: ownedCtx, cfg: cfg}, nil
+}
+
+// fetch reuses the SAME page-fetch/settle logic as playwrightFetcher (a fresh
+// page on the shared context, floored DOMContentLoaded goto, bounded networkidle
+// settle, Content() + URL()). looksBlocked detection happens in crawl.go's
+// fetchPage, identical for both fetchers.
+func (f *cdpFetcher) fetch(ctx context.Context, url string) ([]byte, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return fetchInContext(ctx, f.ctx, f.cfg, url)
+}
+
+// Close detaches from the host Chrome WITHOUT killing it. We only close a context
+// WE created (never the host's warm default context), then stop the driver. We
+// deliberately do NOT call browser.Close() — that would terminate the user's host
+// Chrome. Idempotent.
+func (f *cdpFetcher) Close() {
+	f.closeMu.Do(func() {
+		// Only tear down a context we created ourselves; never the host's warm
+		// default context (closing it would discard the Kasada clearance cookie).
+		if f.ownedCtx && f.ctx != nil {
+			_ = f.ctx.Close()
+		}
+		// Stop the local driver. We intentionally skip browser.Close() so the
+		// host Chrome keeps running (it's the user's browser, not ours).
+		if f.pw != nil {
+			_ = f.pw.Stop()
+		}
+	})
+}
+
+// compile-time assertions that cdpFetcher satisfies both seams.
+var (
+	_ htmlFetcher  = (*cdpFetcher)(nil)
+	_ crawlFetcher = (*cdpFetcher)(nil)
+)

--- a/services/house-price-collector/crawl_playwright.go
+++ b/services/house-price-collector/crawl_playwright.go
@@ -10,22 +10,25 @@ import (
 	"github.com/playwright-community/playwright-go"
 )
 
-// crawl_playwright.go is the real-browser FETCH for the Tier-3 crawl. It drives a
-// HEADED, PERSISTENT-PROFILE Chromium via playwright-go — empirically the only
-// client posture that survives realestate.com.au's Kasada and domain.com.au's
-// Akamai from a residential IP (headless Chromium and chromedp are both detected
-// and blocked/poisoned).
+// crawl_playwright.go is the SELF-LAUNCHED real-browser FETCH for the Tier-3
+// crawl: it launches its OWN headed, persistent-profile Chromium via playwright-go.
+// This is the native/launchd FALLBACK path (used when CRAWL_CDP_URL is NOT set).
+// The primary, "option (b)" path is crawl_cdp.go, which instead drives the HOST
+// macOS Chrome over CDP — empirically the only client that survives
+// realestate.com.au's Kasada and domain.com.au's Akamai from a residential IP
+// (headless Chromium and chromedp are both detected and blocked/poisoned).
 //
-// Persistence is the whole point: the user-data-dir (CRAWL_PROFILE_DIR, a mounted
-// volume in the cuttlefish image) lets the Kasada clearance cookie survive across
-// runs, so a warm profile rarely re-triggers the JS challenge. We reuse ONE
-// browser context for the whole run and open a fresh page per suburb.
+// Persistence is the whole point of this fallback: the user-data-dir
+// (CRAWL_PROFILE_DIR) lets the Kasada clearance cookie survive across runs, so a
+// warm profile rarely re-triggers the JS challenge. We reuse ONE browser context
+// for the whole run and open a fresh page per suburb — the SAME fetch/settle logic
+// (fetchInContext, below) that the CDP fetcher reuses.
 //
 // This file is compiled everywhere but only does real work when the Playwright
-// driver + chromium browser are present (baked into Dockerfile.crawl). We NEVER
-// call playwright.Install() here — that would download browsers at runtime; the
-// image provides them. A missing driver yields a clear error so runCrawl can fail
-// non-fatally and tests can verify the build without any browser.
+// driver + chromium browser are present. We NEVER call playwright.Install() here —
+// that would download browsers at runtime. A missing driver yields a clear error
+// so runCrawl can fail non-fatally and tests can verify the build without any
+// browser.
 
 // realistic, current desktop Chrome on Windows UA (matches the headed Chromium we
 // launch closely enough to avoid trivial UA/engine mismatch heuristics).
@@ -83,18 +86,29 @@ func newPlaywrightFetcher(cfg crawlConfig) (*playwrightFetcher, error) {
 func (f *playwrightFetcher) fetch(ctx context.Context, url string) ([]byte, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	return fetchInContext(ctx, f.ctx, f.cfg, url)
+}
 
+// fetchInContext is the SHARED page-fetch/settle logic used by BOTH browser
+// fetchers (the self-launched persistent Chromium and the CDP-to-host-Chrome
+// fetcher). It opens a fresh page on the given BrowserContext, navigates with a
+// floored DOMContentLoaded timeout, waits a bounded network-idle settle (Kasada/
+// Akamai beacons keep the network "busy", so the settle is best-effort), and
+// returns the rendered DOM + final URL. Bounded by the page timeout and the
+// caller's context; it never hangs. The same looksBlocked detection (in crawl.go's
+// fetchPage) classifies the result for both fetchers.
+func fetchInContext(ctx context.Context, bctx playwright.BrowserContext, cfg crawlConfig, url string) ([]byte, string, error) {
 	if ctx.Err() != nil {
 		return nil, "", ctx.Err()
 	}
 
-	page, err := f.ctx.NewPage()
+	page, err := bctx.NewPage()
 	if err != nil {
 		return nil, "", fmt.Errorf("new page: %w", err)
 	}
 	defer func() { _ = page.Close() }()
 
-	gotoTimeout := float64(f.cfg.fetchTimeout / time.Millisecond)
+	gotoTimeout := float64(cfg.fetchTimeout / time.Millisecond)
 	if gotoTimeout < 45000 {
 		gotoTimeout = 45000 // floor: a real first navigation through a JS challenge is slow
 	}
@@ -187,5 +201,8 @@ func looksBlocked(html []byte, finalURL string) bool {
 	return false
 }
 
-// compile-time assertion that playwrightFetcher satisfies the seam.
-var _ htmlFetcher = (*playwrightFetcher)(nil)
+// compile-time assertions that playwrightFetcher satisfies both seams.
+var (
+	_ htmlFetcher  = (*playwrightFetcher)(nil)
+	_ crawlFetcher = (*playwrightFetcher)(nil)
+)

--- a/services/house-price-collector/crawl_playwright.go
+++ b/services/house-price-collector/crawl_playwright.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/playwright-community/playwright-go"
+)
+
+// crawl_playwright.go is the real-browser FETCH for the Tier-3 crawl. It drives a
+// HEADED, PERSISTENT-PROFILE Chromium via playwright-go — empirically the only
+// client posture that survives realestate.com.au's Kasada and domain.com.au's
+// Akamai from a residential IP (headless Chromium and chromedp are both detected
+// and blocked/poisoned).
+//
+// Persistence is the whole point: the user-data-dir (CRAWL_PROFILE_DIR, a mounted
+// volume in the cuttlefish image) lets the Kasada clearance cookie survive across
+// runs, so a warm profile rarely re-triggers the JS challenge. We reuse ONE
+// browser context for the whole run and open a fresh page per suburb.
+//
+// This file is compiled everywhere but only does real work when the Playwright
+// driver + chromium browser are present (baked into Dockerfile.crawl). We NEVER
+// call playwright.Install() here — that would download browsers at runtime; the
+// image provides them. A missing driver yields a clear error so runCrawl can fail
+// non-fatally and tests can verify the build without any browser.
+
+// realistic, current desktop Chrome on Windows UA (matches the headed Chromium we
+// launch closely enough to avoid trivial UA/engine mismatch heuristics).
+const crawlUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+// settleCap bounds the post-navigation "network idle" settle wait. Kasada/Akamai
+// pages keep beacons alive, so networkidle often never fires — we tolerate the
+// timeout and return whatever DOM we have.
+const settleCap = 12 * time.Second
+
+// playwrightFetcher is a headed, persistent-context Chromium fetcher. It is NOT
+// safe for concurrent fetches (one shared context); the crawl loop is serial by
+// design (heavy human-like pacing), so a mutex is sufficient belt-and-braces.
+type playwrightFetcher struct {
+	pw      *playwright.Playwright
+	ctx     playwright.BrowserContext
+	cfg     crawlConfig
+	mu      sync.Mutex
+	closeMu sync.Once
+}
+
+// newPlaywrightFetcher starts the Playwright driver (already installed in the
+// image) and launches a headed, persistent Chromium context with an AU locale /
+// timezone, a realistic UA and a 1440x900 viewport. Returns a clear error if the
+// driver or browser is missing (so the build is verifiable without browsers).
+func newPlaywrightFetcher(cfg crawlConfig) (*playwrightFetcher, error) {
+	pw, err := playwright.Run()
+	if err != nil {
+		return nil, fmt.Errorf("playwright driver/browsers unavailable (not installed in this environment — expected only inside Dockerfile.crawl): %w", err)
+	}
+
+	bctx, err := pw.Chromium.LaunchPersistentContext(cfg.profileDir, playwright.BrowserTypeLaunchPersistentContextOptions{
+		Headless:   playwright.Bool(false), // headed: the only posture Kasada/Akamai don't block from a residential IP
+		Locale:     playwright.String("en-AU"),
+		TimezoneId: playwright.String("Australia/Sydney"),
+		UserAgent:  playwright.String(crawlUserAgent),
+		Viewport:   &playwright.Size{Width: 1440, Height: 900},
+		Args: []string{
+			// reduce the most obvious automation tells without faking a headless flag
+			"--disable-blink-features=AutomationControlled",
+		},
+	})
+	if err != nil {
+		_ = pw.Stop()
+		return nil, fmt.Errorf("launch headed persistent chromium (profile=%s): %w", cfg.profileDir, err)
+	}
+
+	return &playwrightFetcher{pw: pw, ctx: bctx, cfg: cfg}, nil
+}
+
+// fetch navigates to url in a fresh page on the shared persistent context, waits
+// for DOMContentLoaded then a bounded network-idle settle, and returns the fully
+// rendered DOM plus the final URL. Everything is bounded by the page timeout and
+// the caller's context; it never hangs.
+func (f *playwrightFetcher) fetch(ctx context.Context, url string) ([]byte, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if ctx.Err() != nil {
+		return nil, "", ctx.Err()
+	}
+
+	page, err := f.ctx.NewPage()
+	if err != nil {
+		return nil, "", fmt.Errorf("new page: %w", err)
+	}
+	defer func() { _ = page.Close() }()
+
+	gotoTimeout := float64(f.cfg.fetchTimeout / time.Millisecond)
+	if gotoTimeout < 45000 {
+		gotoTimeout = 45000 // floor: a real first navigation through a JS challenge is slow
+	}
+	if _, err := page.Goto(url, playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+		Timeout:   playwright.Float(gotoTimeout),
+	}); err != nil {
+		return nil, "", fmt.Errorf("goto %s: %w", url, err)
+	}
+
+	// Bounded settle wait: try for networkidle but tolerate the (common) timeout —
+	// Kasada/Akamai beacons keep the network "busy" indefinitely.
+	_ = page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+		State:   playwright.LoadStateNetworkidle,
+		Timeout: playwright.Float(float64(settleCap / time.Millisecond)),
+	})
+
+	html, err := page.Content()
+	if err != nil {
+		return nil, "", fmt.Errorf("content: %w", err)
+	}
+	return []byte(html), page.URL(), nil
+}
+
+// Close tears down the browser context and the driver. Idempotent.
+func (f *playwrightFetcher) Close() {
+	f.closeMu.Do(func() {
+		if f.ctx != nil {
+			_ = f.ctx.Close()
+		}
+		if f.pw != nil {
+			_ = f.pw.Stop()
+		}
+	})
+}
+
+// --- block detection (shared by the orchestration in crawl.go) ---
+
+// isBlockError reports whether a fetch error looks like an anti-bot block (vs a
+// transient network/timeout error). Playwright surfaces HTTP status only via the
+// Response object, so a hard 403/429 navigation generally still resolves with a
+// body; the textual heuristics in looksBlocked catch those. Here we only treat an
+// explicit access-denied style navigation error as a block.
+func isBlockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{"err_http_response_code_failure", "403", "429", "access denied", "net::err_blocked"} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	// context cancellation/timeout is NOT a block — let it be a transient error.
+	return false
+}
+
+// blockMarkers are fragments that appear on a Kasada/Akamai challenge or
+// access-denied interstitial (rather than a real suburb page). A rendered DOM
+// containing one of these — or a redirect to a challenge URL — is treated as a
+// block so the circuit breaker can back off.
+var blockMarkers = []string{
+	"kasada",
+	"px-captcha",
+	"/_incapsula_",
+	"access denied",
+	"are you a human",
+	"please enable javascript and cookies",
+	"reference #", // Akamai access-denied interstitial
+	"request unsuccessful. incapsula",
+}
+
+// looksBlocked inspects the rendered HTML and final URL for anti-bot interstitial
+// markers. It is conservative (substring match on lowercased content) and only
+// used to trip the circuit breaker — never to mutate stored data.
+func looksBlocked(html []byte, finalURL string) bool {
+	if len(html) == 0 {
+		return true
+	}
+	lower := strings.ToLower(string(html))
+	for _, m := range blockMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	u := strings.ToLower(finalURL)
+	if strings.Contains(u, "/distil_") || strings.Contains(u, "challenge") {
+		return true
+	}
+	return false
+}
+
+// compile-time assertion that playwrightFetcher satisfies the seam.
+var _ htmlFetcher = (*playwrightFetcher)(nil)

--- a/services/house-price-collector/crawl_playwright_test.go
+++ b/services/house-price-collector/crawl_playwright_test.go
@@ -325,6 +325,88 @@ func TestCrawlSource_BrandbrainErrorSkips(t *testing.T) {
 	}
 }
 
+// TestCrawlConfig_ReadsCDPURL verifies loadCrawlConfig wires CRAWL_CDP_URL into
+// the config (the option-(b) host-Chrome-over-CDP selector), and that an unset
+// var leaves it empty (the native/launchd persistent-Chromium fallback).
+func TestCrawlConfig_ReadsCDPURL(t *testing.T) {
+	t.Setenv("CRAWL_CDP_URL", "http://host.docker.internal:9222")
+	if got := loadCrawlConfig().cdpURL; got != "http://host.docker.internal:9222" {
+		t.Errorf("cdpURL = %q, want http://host.docker.internal:9222", got)
+	}
+
+	t.Setenv("CRAWL_CDP_URL", "")
+	_ = os.Unsetenv("CRAWL_CDP_URL")
+	if got := loadCrawlConfig().cdpURL; got != "" {
+		t.Errorf("cdpURL with unset env = %q, want empty", got)
+	}
+}
+
+// TestSelectFetcherMode_BranchesOnCDPURL pins the pure selection rule: CDP path
+// when CRAWL_CDP_URL is set, persistent-Chromium path when it's empty.
+func TestSelectFetcherMode_BranchesOnCDPURL(t *testing.T) {
+	if m := selectFetcherMode(crawlConfig{cdpURL: "http://host.docker.internal:9222"}); m != fetcherModeCDP {
+		t.Errorf("cdpURL set: mode = %v, want fetcherModeCDP", m)
+	}
+	if s := crawlFetcherMode(crawlConfig{cdpURL: "http://host.docker.internal:9222"}); s != "cdp-host-chrome" {
+		t.Errorf("cdpURL set: label = %q, want cdp-host-chrome", s)
+	}
+
+	if m := selectFetcherMode(crawlConfig{cdpURL: ""}); m != fetcherModePlaywright {
+		t.Errorf("cdpURL empty: mode = %v, want fetcherModePlaywright", m)
+	}
+	if s := crawlFetcherMode(crawlConfig{cdpURL: ""}); s != "headed-playwright" {
+		t.Errorf("cdpURL empty: label = %q, want headed-playwright", s)
+	}
+}
+
+// TestNewCDPFetcher_UnreachableEndpoint asserts that connecting to a bogus/dead
+// CDP endpoint returns a clear "connect over CDP to <url>" error (no browser
+// needed). It skips only if the Playwright DRIVER is absent (the CDP client needs
+// the driver to even attempt the connect), so the no-driver build still passes.
+func TestNewCDPFetcher_UnreachableEndpoint(t *testing.T) {
+	cfg := loadCrawlConfig()
+	cfg.cdpURL = "http://127.0.0.1:1" // nothing listens here
+	cfg.fetchTimeout = 2 * time.Second
+
+	f, err := newCDPFetcher(cfg)
+	if err == nil {
+		f.Close()
+		t.Fatal("expected an error connecting to an unreachable CDP endpoint")
+	}
+	low := strings.ToLower(err.Error())
+	// If the driver itself is missing we get a "playwright driver unavailable"
+	// error before the connect is even attempted — that's the hermetic-CI case;
+	// the connect-error contract can't be exercised, so skip.
+	if strings.Contains(low, "driver unavailable") {
+		t.Skip("Playwright driver absent in this environment; CDP connect path not exercised")
+	}
+	if !strings.Contains(low, "connect over cdp to http://127.0.0.1:1") {
+		t.Errorf("error should clearly name the failed CDP connect, got: %v", err)
+	}
+}
+
+// TestNewCrawlFetcher_SelectsCDPPath confirms the dispatcher routes a set
+// CRAWL_CDP_URL through the CDP fetcher (we observe the CDP-specific connect error
+// rather than the Playwright launch error). Skips if the driver is absent.
+func TestNewCrawlFetcher_SelectsCDPPath(t *testing.T) {
+	cfg := loadCrawlConfig()
+	cfg.cdpURL = "http://127.0.0.1:1"
+	cfg.fetchTimeout = 2 * time.Second
+
+	f, err := newCrawlFetcher(cfg)
+	if err == nil {
+		f.Close()
+		t.Skip("a reachable CDP endpoint exists on 127.0.0.1:1?? — unexpected; skipping")
+	}
+	low := strings.ToLower(err.Error())
+	if strings.Contains(low, "driver unavailable") {
+		t.Skip("Playwright driver absent; CDP selection path not exercised")
+	}
+	if !strings.Contains(low, "connect over cdp") {
+		t.Errorf("newCrawlFetcher with CRAWL_CDP_URL should take the CDP path, got: %v", err)
+	}
+}
+
 // TestPlaywrightFetcher_NoDriver verifies the build is usable without browsers:
 // newPlaywrightFetcher returns a clear error when the Playwright driver/browsers
 // are absent (the case in CI / on this disk-constrained dev box). We force the

--- a/services/house-price-collector/crawl_playwright_test.go
+++ b/services/house-price-collector/crawl_playwright_test.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests exercise the rewired Tier-3 crawl ORCHESTRATION end-to-end with a
+// fake htmlFetcher (canned HTML, no browser) and a fake brandbrain server (no live
+// REA/Domain). They assert that both sources are fetched, the rendered HTML is
+// routed to brandbrain's ExtractRealEstate, the returned aggregates are mapped to
+// Observations with the correct Source, and the pacing / circuit-breaker / dry-run
+// scaffolding still holds. NO browser and NO live anti-bot site are touched.
+
+// fakeFetcher is a scripted htmlFetcher: it returns canned HTML keyed by a
+// substring of the URL (so REA vs Domain can return different bodies), records
+// every URL it was asked for, and can be told to "block" or error specific hosts.
+type fakeFetcher struct {
+	html     map[string]string // url-substring -> html body
+	blockOn  map[string]bool   // url-substring -> return a block error
+	errorOn  map[string]bool   // url-substring -> return a transient error
+	calls    []string
+	closed   int32
+	fetchDur time.Duration // optional artificial latency
+}
+
+func (f *fakeFetcher) fetch(ctx context.Context, url string) ([]byte, string, error) {
+	f.calls = append(f.calls, url)
+	if f.fetchDur > 0 {
+		select {
+		case <-time.After(f.fetchDur):
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+	}
+	for sub := range f.blockOn {
+		if strings.Contains(url, sub) {
+			return nil, "", errors.New("net::ERR_HTTP_RESPONSE_CODE_FAILURE 403")
+		}
+	}
+	for sub := range f.errorOn {
+		if strings.Contains(url, sub) {
+			return nil, "", errors.New("net::ERR_TIMED_OUT")
+		}
+	}
+	for sub, body := range f.html {
+		if strings.Contains(url, sub) {
+			return []byte(body), url, nil
+		}
+	}
+	// default: an innocuous page with no anti-bot markers and no usable medians.
+	return []byte("<html><body>no data</body></html>"), url, nil
+}
+
+func (f *fakeFetcher) Close() { atomic.AddInt32(&f.closed, 1) }
+
+// newTestCrawler wires a crawler with a fake fetcher, a Sydney baseline (so the
+// capital-band gate is active) and fast pacing for tests.
+func newTestCrawler(ff htmlFetcher, brandbrainURL string) *crawler {
+	return &crawler{
+		fetcher:   ff,
+		baselines: map[string]float64{"1GSYD": 1_485_000.0, "2GMEL": 850_000.0},
+		cfg: crawlConfig{
+			maxSuburbs:      len(crawlTargets),
+			minDelay:        1 * time.Millisecond,
+			maxDelay:        2 * time.Millisecond,
+			maxConsecBlocks: 3,
+			fetchTimeout:    60 * time.Second,
+			brandbrainURL:   brandbrainURL,
+			profileDir:      "/tmp/test-profile",
+		},
+	}
+}
+
+// brandbrainServer returns a fake brandbrain that echoes a canned ExtractRealEstate
+// response and records how many times it was hit + the suburb/state hints seen.
+func brandbrainServer(t *testing.T, body string) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		var req extractRealEstateReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("brandbrain: bad request body: %v", err)
+		}
+		if req.HTML == "" {
+			t.Errorf("brandbrain: empty HTML forwarded")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	return srv, &hits
+}
+
+func TestCrawlSuburb_RoutesBothSourcesToBrandbrain(t *testing.T) {
+	bb, hits := brandbrainServer(t, bondiExtractJSON())
+	defer bb.Close()
+
+	ff := &fakeFetcher{html: map[string]string{
+		"realestate.com.au": "<html><body>REA Bondi rendered</body></html>",
+		"domain.com.au":     "<html><body>Domain Bondi rendered</body></html>",
+	}}
+	cr := newTestCrawler(ff, bb.URL)
+
+	obs := cr.crawlSuburb(context.Background(), bondi)
+
+	// Both sources fetched, in REA-then-Domain order.
+	if len(ff.calls) != 2 {
+		t.Fatalf("expected 2 fetches (REA+Domain), got %d: %v", len(ff.calls), ff.calls)
+	}
+	if !strings.Contains(ff.calls[0], "realestate.com.au") || !strings.Contains(ff.calls[1], "domain.com.au") {
+		t.Errorf("fetch order wrong: %v", ff.calls)
+	}
+	// Brandbrain hit once per source.
+	if got := atomic.LoadInt32(hits); got != 2 {
+		t.Errorf("brandbrain hits = %d, want 2", got)
+	}
+
+	// Each source produces the full bondi measure set; assert both Source tags.
+	var reaCount, domCount int
+	for _, o := range obs {
+		switch o.Source {
+		case "brandbrain_rea":
+			reaCount++
+		case "brandbrain_domain":
+			domCount++
+		default:
+			t.Errorf("unexpected source %q", o.Source)
+		}
+		if o.SourceLicence != "proprietary-tos-restricted" {
+			t.Errorf("licence = %q, want proprietary-tos-restricted", o.SourceLicence)
+		}
+	}
+	if reaCount == 0 || domCount == 0 {
+		t.Errorf("expected observations from BOTH sources, got rea=%d dom=%d", reaCount, domCount)
+	}
+	// 5 measures (house, unit, yield, days, growth) per source = 10.
+	if len(obs) != 10 {
+		t.Errorf("expected 10 observations (5×2 sources), got %d", len(obs))
+	}
+	if cr.stats.accepted != 1 || cr.stats.attempted != 1 {
+		t.Errorf("stats attempted/accepted = %d/%d, want 1/1", cr.stats.attempted, cr.stats.accepted)
+	}
+}
+
+func TestCrawlSource_BlockTripsCircuitBreaker(t *testing.T) {
+	bb, hits := brandbrainServer(t, bondiExtractJSON())
+	defer bb.Close()
+
+	// REA always blocks; Domain always succeeds.
+	ff := &fakeFetcher{
+		html:    map[string]string{"domain.com.au": "<html><body>Domain ok</body></html>"},
+		blockOn: map[string]bool{"realestate.com.au": true},
+	}
+	cr := newTestCrawler(ff, bb.URL)
+
+	// Crawl three suburbs: REA should block 3× then the breaker opens for REA;
+	// Domain succeeds each time.
+	targets := crawlTargets[:3]
+	for _, target := range targets {
+		_ = cr.crawlSuburb(context.Background(), target)
+	}
+
+	if cr.reaBlocks < cr.cfg.maxConsecBlocks {
+		t.Errorf("expected REA breaker to reach %d blocks, got %d", cr.cfg.maxConsecBlocks, cr.reaBlocks)
+	}
+	if cr.stats.blocked != cr.cfg.maxConsecBlocks {
+		t.Errorf("blocked stat = %d, want %d (breaker stops further REA fetches)", cr.stats.blocked, cr.cfg.maxConsecBlocks)
+	}
+	// Domain was never blocked, so it keeps its counter at 0.
+	if cr.domBlocks != 0 {
+		t.Errorf("domain breaker should stay closed, got %d", cr.domBlocks)
+	}
+	// brandbrain only ever saw Domain pages (3), never the blocked REA pages.
+	if got := atomic.LoadInt32(hits); got != 3 {
+		t.Errorf("brandbrain hits = %d, want 3 (Domain only)", got)
+	}
+}
+
+func TestCrawlSource_BlockedHTMLBodyDetected(t *testing.T) {
+	bb, hits := brandbrainServer(t, bondiExtractJSON())
+	defer bb.Close()
+
+	// REA returns 200 but with a Kasada interstitial body — must be treated as a
+	// block, NOT forwarded to brandbrain.
+	ff := &fakeFetcher{html: map[string]string{
+		"realestate.com.au": `<html><body>Please enable JavaScript and cookies to continue. (kasada)</body></html>`,
+		"domain.com.au":     "<html><body>Domain ok</body></html>",
+	}}
+	cr := newTestCrawler(ff, bb.URL)
+
+	_ = cr.crawlSuburb(context.Background(), bondi)
+
+	if cr.reaBlocks != 1 {
+		t.Errorf("kasada interstitial should trip a block, reaBlocks=%d", cr.reaBlocks)
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Errorf("brandbrain hits = %d, want 1 (only Domain forwarded; blocked REA skipped)", got)
+	}
+}
+
+func TestRunCrawl_RespectsMaxSuburbs_viaLoop(t *testing.T) {
+	// Mirror runCrawl's target-slicing + pacing loop without a DB/browser: assert
+	// CRAWL_MAX_SUBURBS bounds the number of suburbs crawled.
+	bb, _ := brandbrainServer(t, bondiExtractJSON())
+	defer bb.Close()
+
+	ff := &fakeFetcher{html: map[string]string{
+		"realestate.com.au": "<html><body>x</body></html>",
+		"domain.com.au":     "<html><body>x</body></html>",
+	}}
+	cr := newTestCrawler(ff, bb.URL)
+	cr.cfg.maxSuburbs = 2
+
+	targets := crawlTargets
+	if cr.cfg.maxSuburbs >= 0 && cr.cfg.maxSuburbs < len(targets) {
+		targets = targets[:cr.cfg.maxSuburbs]
+	}
+	for i, target := range targets {
+		if i > 0 {
+			cr.sleepJitter(context.Background())
+		}
+		_ = cr.crawlSuburb(context.Background(), target)
+	}
+
+	if cr.stats.attempted != 2 {
+		t.Errorf("attempted = %d, want 2 (CRAWL_MAX_SUBURBS honored)", cr.stats.attempted)
+	}
+	// 2 suburbs × 2 sources fetched.
+	if len(ff.calls) != 4 {
+		t.Errorf("fetch calls = %d, want 4", len(ff.calls))
+	}
+}
+
+func TestSleepJitter_HonorsPacingAndCancellation(t *testing.T) {
+	cr := newTestCrawler(&fakeFetcher{}, "")
+	cr.cfg.minDelay = 50 * time.Millisecond
+	cr.cfg.maxDelay = 60 * time.Millisecond
+
+	start := time.Now()
+	cr.sleepJitter(context.Background())
+	if elapsed := time.Since(start); elapsed < cr.cfg.minDelay {
+		t.Errorf("sleepJitter returned in %v, want >= %v", elapsed, cr.cfg.minDelay)
+	}
+
+	// A cancelled context returns promptly (no hang).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start = time.Now()
+	cr.sleepJitter(ctx)
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Errorf("sleepJitter ignored cancellation, took %v", elapsed)
+	}
+}
+
+func TestCrawlConfig_HeavyPacingDefaults(t *testing.T) {
+	// With no CRAWL_* env set, the headed-browser tier defaults to heavy pacing.
+	for _, k := range []string{"CRAWL_MIN_DELAY_MS", "CRAWL_MAX_DELAY_MS", "CRAWL_FETCH_TIMEOUT_S", "CRAWL_PROFILE_DIR", "BRANDBRAIN_URL"} {
+		t.Setenv(k, "")
+		_ = os.Unsetenv(k)
+	}
+	cfg := loadCrawlConfig()
+	if cfg.minDelay != 20*time.Second {
+		t.Errorf("default minDelay = %v, want 20s", cfg.minDelay)
+	}
+	if cfg.maxDelay != 45*time.Second {
+		t.Errorf("default maxDelay = %v, want 45s", cfg.maxDelay)
+	}
+	if cfg.profileDir != "/data/pw-profile" {
+		t.Errorf("default profileDir = %q, want /data/pw-profile", cfg.profileDir)
+	}
+}
+
+func TestCrawlConfig_EnvOverrides(t *testing.T) {
+	t.Setenv("CRAWL_MIN_DELAY_MS", "1000")
+	t.Setenv("CRAWL_MAX_DELAY_MS", "2000")
+	t.Setenv("CRAWL_PROFILE_DIR", "/mnt/warm-profile")
+	t.Setenv("BRANDBRAIN_URL", "https://bb.example/x")
+	cfg := loadCrawlConfig()
+	if cfg.minDelay != time.Second || cfg.maxDelay != 2*time.Second {
+		t.Errorf("env override delays = %v/%v", cfg.minDelay, cfg.maxDelay)
+	}
+	if cfg.profileDir != "/mnt/warm-profile" {
+		t.Errorf("profileDir override = %q", cfg.profileDir)
+	}
+	if cfg.brandbrainURL != "https://bb.example/x" {
+		t.Errorf("brandbrainURL override = %q", cfg.brandbrainURL)
+	}
+}
+
+func TestCrawlSource_BrandbrainErrorSkips(t *testing.T) {
+	// brandbrain returns persistent 5xx → extractRealEstate fails after retries →
+	// the source yields nothing, the breaker is NOT tripped (a real page was
+	// fetched), and nothing is stored.
+	orig := brandbrainBackoffs
+	brandbrainBackoffs = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	defer func() { brandbrainBackoffs = orig }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	ff := &fakeFetcher{html: map[string]string{
+		"realestate.com.au": "<html><body>real page</body></html>",
+		"domain.com.au":     "<html><body>real page</body></html>",
+	}}
+	cr := newTestCrawler(ff, srv.URL)
+
+	obs := cr.crawlSuburb(context.Background(), bondi)
+	if len(obs) != 0 {
+		t.Errorf("brandbrain failure must yield no observations, got %d", len(obs))
+	}
+	if cr.reaBlocks != 0 || cr.domBlocks != 0 {
+		t.Errorf("a brandbrain error is not a fetch block; breakers should stay closed (rea=%d dom=%d)", cr.reaBlocks, cr.domBlocks)
+	}
+}
+
+// TestPlaywrightFetcher_NoDriver verifies the build is usable without browsers:
+// newPlaywrightFetcher returns a clear error when the Playwright driver/browsers
+// are absent (the case in CI / on this disk-constrained dev box). We force the
+// driver lookup at a directory we know has no driver.
+func TestPlaywrightFetcher_NoDriver(t *testing.T) {
+	t.Setenv("PLAYWRIGHT_DRIVER_PATH", filepath.Join(t.TempDir(), "no-driver-here"))
+	cfg := loadCrawlConfig()
+	cfg.profileDir = t.TempDir()
+
+	f, err := newPlaywrightFetcher(cfg)
+	if err == nil {
+		// If a driver IS somehow present in this environment, don't fail the suite —
+		// just clean up. The contract we care about (clear error when ABSENT) can't
+		// be exercised here, so skip.
+		f.Close()
+		t.Skip("a Playwright driver is present in this environment; no-driver path not exercised")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "playwright") {
+		t.Errorf("error should mention playwright, got: %v", err)
+	}
+}
+
+// TestCrawlSource_WithRealFixtureHTML feeds a captured REA suburb page (if present
+// locally) through the fake fetcher to brandbrain, proving the HTML→brandbrain→
+// Observation path handles a real rendered DOM. The fixture lives OUTSIDE the repo
+// (~/projects/housing-fixtures, gitignored/uncommittable) — the test skips if it's
+// absent so the suite stays hermetic.
+func TestCrawlSource_WithRealFixtureHTML(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	path := filepath.Join(home, "projects", "housing-fixtures", "rea-bondi-2026.html")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("fixture absent (%s) — skipping (this is expected in CI)", path)
+	}
+	html := unescapeFixture(raw)
+
+	bb, hits := brandbrainServer(t, bondiExtractJSON())
+	defer bb.Close()
+
+	ff := &fakeFetcher{html: map[string]string{"realestate.com.au": html}}
+	cr := newTestCrawler(ff, bb.URL)
+
+	obs := cr.crawlSource(context.Background(), bondi, "rea", bondi.reaURL(), &cr.reaBlocks)
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Fatalf("brandbrain hits = %d, want 1", got)
+	}
+	if len(obs) == 0 {
+		t.Fatal("expected observations from the real fixture HTML routed through brandbrain")
+	}
+	for _, o := range obs {
+		if o.Source != "brandbrain_rea" {
+			t.Errorf("source = %q, want brandbrain_rea", o.Source)
+		}
+	}
+}
+
+// unescapeFixture handles the captured fixtures which may be stored as a
+// JSON-escaped HTML string (leading quote + \" escapes). If it doesn't look
+// JSON-escaped, the bytes are returned as-is.
+func unescapeFixture(raw []byte) string {
+	s := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(s, "\"") {
+		var unq string
+		if err := json.Unmarshal([]byte(s), &unq); err == nil {
+			return unq
+		}
+	}
+	return s
+}

--- a/services/house-price-collector/main.go
+++ b/services/house-price-collector/main.go
@@ -38,7 +38,9 @@ func main() {
 		refresh(ctx, pool)
 	case "crawl":
 		// Supplementary suburb crawl — opt-in only, never part of the default
-		// scheduled run (it's slow, adversarial and licence-gated).
+		// scheduled run (it's slow, adversarial and licence-gated). Drives a HEADED,
+		// persistent-profile Playwright browser, so it runs ONLY on the residential
+		// cuttlefish rig under xvfb (see Dockerfile.crawl), never on Cloud Run.
 		runCrawl(ctx, pool)
 		refresh(ctx, pool)
 	case "refresh":

--- a/services/migrations/000054_housing_licence_gate.down.sql
+++ b/services/migrations/000054_housing_licence_gate.down.sql
@@ -1,0 +1,28 @@
+-- Revert mv_housing_headline to the un-gated definition from 000053 (includes
+-- all source_licence values). NOTE: rolling this back re-exposes proprietary
+-- rows to GetHousingOverview if any exist — only do so deliberately.
+
+DROP MATERIALIZED VIEW IF EXISTS mv_housing_headline;
+
+CREATE MATERIALIZED VIEW mv_housing_headline AS
+WITH ranked AS (
+    SELECT
+        region_code, measure, dwelling_type, period, value, unit, is_preliminary,
+        value - LAG(value, 1) OVER w AS qoq_abs,
+        (value / NULLIF(LAG(value, 1) OVER w, 0) - 1) * 100 AS qoq_pct,
+        value - LAG(value, 4) OVER w AS yoy_abs,
+        (value / NULLIF(LAG(value, 4) OVER w, 0) - 1) * 100 AS yoy_pct,
+        ROW_NUMBER() OVER (
+            PARTITION BY region_code, measure, dwelling_type ORDER BY period DESC
+        ) AS rn
+    FROM house_prices
+    WHERE period_freq = 'Q'
+    WINDOW w AS (PARTITION BY region_code, measure, dwelling_type ORDER BY period)
+)
+SELECT region_code, measure, dwelling_type, period, value, unit, is_preliminary,
+       qoq_abs, qoq_pct, yoy_abs, yoy_pct
+FROM ranked
+WHERE rn = 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_housing_headline_key
+    ON mv_housing_headline (region_code, measure, dwelling_type);

--- a/services/migrations/000054_housing_licence_gate.up.sql
+++ b/services/migrations/000054_housing_licence_gate.up.sql
@@ -1,0 +1,38 @@
+-- Safety gate: keep internal, ToS-restricted REA/Domain/brandbrain rows
+-- (source_licence = 'proprietary-tos-restricted') out of the public housing
+-- read surface. The base-table read paths (GetHousePriceSeries,
+-- ListHousingRegions) gate in their query bodies, but mv_housing_headline —
+-- which drives GetHousingOverview — does not carry source_licence, so the
+-- exclusion must be baked into the MV definition itself.
+--
+-- This migration redefines mv_housing_headline to exclude proprietary rows
+-- before ranking. Apply separately from the code change (the MV is already
+-- deployed). On prod Supabase, run via the SESSION pooler (port 5432) with
+-- PGOPTIONS="-c statement_timeout=0" so the CONCURRENTLY refresh can complete.
+
+DROP MATERIALIZED VIEW IF EXISTS mv_housing_headline;
+
+CREATE MATERIALIZED VIEW mv_housing_headline AS
+WITH ranked AS (
+    SELECT
+        region_code, measure, dwelling_type, period, value, unit, is_preliminary,
+        value - LAG(value, 1) OVER w AS qoq_abs,
+        (value / NULLIF(LAG(value, 1) OVER w, 0) - 1) * 100 AS qoq_pct,
+        value - LAG(value, 4) OVER w AS yoy_abs,
+        (value / NULLIF(LAG(value, 4) OVER w, 0) - 1) * 100 AS yoy_pct,
+        ROW_NUMBER() OVER (
+            PARTITION BY region_code, measure, dwelling_type ORDER BY period DESC
+        ) AS rn
+    FROM house_prices
+    WHERE period_freq = 'Q'
+      AND source_licence <> 'proprietary-tos-restricted'  -- public surface only
+    WINDOW w AS (PARTITION BY region_code, measure, dwelling_type ORDER BY period)
+)
+SELECT region_code, measure, dwelling_type, period, value, unit, is_preliminary,
+       qoq_abs, qoq_pct, yoy_abs, yoy_pct
+FROM ranked
+WHERE rn = 1;
+
+-- Unique index enables REFRESH ... CONCURRENTLY.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_housing_headline_key
+    ON mv_housing_headline (region_code, measure, dwelling_type);

--- a/services/shorts/internal/store/shorts/postgres_house_prices.go
+++ b/services/shorts/internal/store/shorts/postgres_house_prices.go
@@ -85,12 +85,16 @@ func (s *postgresStore) GetHousePriceSeries(regionCode, measure, dwellingType st
 		dwellingType = "all"
 	}
 
+	// publicLicenceFilter excludes internal, ToS-restricted rows (REA/Domain
+	// crawl + brandbrain, source_licence = 'proprietary-tos-restricted') from
+	// every public read path — those rows may NEVER reach a public surface.
 	const query = `
 		SELECT hp.period, hp.value, hp.is_preliminary, COALESCE(hp.unit, ''),
 		       hp.source, hp.source_licence, COALESCE(r.region_name, '')
 		FROM house_prices hp
 		JOIN house_price_regions r ON r.region_code = hp.region_code
 		WHERE hp.region_code = $1 AND hp.measure = $2 AND hp.dwelling_type = $3
+		  AND hp.source_licence <> 'proprietary-tos-restricted'
 		ORDER BY hp.period ASC`
 
 	rows, err := s.db.Query(ctx, query, regionCode, measure, dwellingType)
@@ -135,6 +139,10 @@ func (s *postgresStore) GetHousingRegions(regionType, stateCode, query string, l
 		limit = 2000
 	}
 
+	// Gate out internal, ToS-restricted REA/Domain/brandbrain rows
+	// (source_licence = 'proprietary-tos-restricted'): the latest-median lateral
+	// only considers public-licence observations, and the EXISTS guard drops
+	// regions whose entire footprint is proprietary so they never surface here.
 	const q = `
 		SELECT r.region_code, COALESCE(r.region_name, ''), COALESCE(r.region_type, ''),
 		       COALESCE(r.state_code, ''), COALESCE(r.postcode, ''),
@@ -143,12 +151,21 @@ func (s *postgresStore) GetHousingRegions(regionType, stateCode, query string, l
 		LEFT JOIN LATERAL (
 			SELECT value, period FROM house_prices hp
 			WHERE hp.region_code = r.region_code AND hp.measure = 'median_price'
+			  AND hp.source_licence <> 'proprietary-tos-restricted'
 			ORDER BY hp.period DESC
 			LIMIT 1
 		) lp ON true
 		WHERE ($1 = '' OR r.region_type = $1)
 		  AND ($2 = '' OR r.state_code = $2)
 		  AND ($3 = '' OR r.region_name ILIKE '%' || $3 || '%')
+		  AND (
+		    NOT EXISTS (SELECT 1 FROM house_prices hp WHERE hp.region_code = r.region_code)
+		    OR EXISTS (
+		      SELECT 1 FROM house_prices hp
+		      WHERE hp.region_code = r.region_code
+		        AND hp.source_licence <> 'proprietary-tos-restricted'
+		    )
+		  )
 		ORDER BY r.region_name
 		LIMIT $4`
 

--- a/services/shorts/internal/store/shorts/postgres_house_prices_test.go
+++ b/services/shorts/internal/store/shorts/postgres_house_prices_test.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+package shorts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupHousingTestDatabase spins up Postgres with the house-price schema + MV
+// and seeds a mix of public (CC-BY-4.0) and proprietary (ToS-restricted) rows
+// across two states so we can assert both the licence gate and the state filter.
+func setupHousingTestDatabase(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	pgc, err := postgres.Run(ctx,
+		"postgres:14-alpine",
+		postgres.WithDatabase("housing_test"),
+		postgres.WithUsername("test_user"),
+		postgres.WithPassword("test_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	checkDockerError(t, err)
+	require.NoError(t, err, "Failed to start PostgreSQL container")
+
+	connStr, err := pgc.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	setupHousingSchema(t, pool)
+	loadHousingTestData(t, pool)
+
+	cleanup := func() {
+		pool.Close()
+		if err := pgc.Terminate(ctx); err != nil {
+			t.Logf("Failed to terminate container: %v", err)
+		}
+	}
+	return pool, cleanup
+}
+
+func setupHousingSchema(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Mirrors services/migrations/000053 + 000054 (the licence-gated MV).
+	const schema = `
+	CREATE TABLE IF NOT EXISTS house_price_regions (
+		region_code TEXT PRIMARY KEY,
+		region_type TEXT NOT NULL,
+		region_name TEXT NOT NULL,
+		state_code  TEXT,
+		postcode    TEXT
+	);
+
+	CREATE TABLE IF NOT EXISTS house_prices (
+		id             BIGSERIAL PRIMARY KEY,
+		region_code    TEXT NOT NULL REFERENCES house_price_regions(region_code),
+		measure        TEXT NOT NULL,
+		dwelling_type  TEXT NOT NULL DEFAULT 'all',
+		period         DATE NOT NULL,
+		period_freq    TEXT NOT NULL DEFAULT 'Q',
+		value          DOUBLE PRECISION NOT NULL,
+		unit           TEXT,
+		is_preliminary BOOLEAN NOT NULL DEFAULT false,
+		source         TEXT NOT NULL,
+		source_licence TEXT NOT NULL DEFAULT 'CC-BY-4.0',
+		content_hash   TEXT NOT NULL,
+		fetched_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+		UNIQUE (region_code, measure, dwelling_type, period, source)
+	);
+
+	-- 000054: MV excludes proprietary-tos-restricted rows.
+	CREATE MATERIALIZED VIEW IF NOT EXISTS mv_housing_headline AS
+	WITH ranked AS (
+		SELECT
+			region_code, measure, dwelling_type, period, value, unit, is_preliminary,
+			value - LAG(value, 1) OVER w AS qoq_abs,
+			(value / NULLIF(LAG(value, 1) OVER w, 0) - 1) * 100 AS qoq_pct,
+			value - LAG(value, 4) OVER w AS yoy_abs,
+			(value / NULLIF(LAG(value, 4) OVER w, 0) - 1) * 100 AS yoy_pct,
+			ROW_NUMBER() OVER (
+				PARTITION BY region_code, measure, dwelling_type ORDER BY period DESC
+			) AS rn
+		FROM house_prices
+		WHERE period_freq = 'Q'
+		  AND source_licence <> 'proprietary-tos-restricted'
+		WINDOW w AS (PARTITION BY region_code, measure, dwelling_type ORDER BY period)
+	)
+	SELECT region_code, measure, dwelling_type, period, value, unit, is_preliminary,
+		   qoq_abs, qoq_pct, yoy_abs, yoy_pct
+	FROM ranked
+	WHERE rn = 1;
+	`
+	_, err := pool.Exec(ctx, schema)
+	require.NoError(t, err, "failed to create housing schema")
+}
+
+func loadHousingTestData(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	const regions = `
+	INSERT INTO house_price_regions (region_code, region_type, region_name, state_code) VALUES
+		('SUBURB:VIC-RICHMOND', 'suburb', 'RICHMOND', 'VIC'),
+		('SUBURB:SA-NORWOOD',   'suburb', 'NORWOOD',  'SA'),
+		('SUBURB:VIC-CROWNLAND','suburb', 'CROWNLAND','VIC')`
+	_, err := pool.Exec(ctx, regions)
+	require.NoError(t, err)
+
+	// One public + one proprietary observation per public region, plus a region
+	// (CROWNLAND) whose ONLY data is proprietary — it must never be listed.
+	const facts = `
+	INSERT INTO house_prices
+		(region_code, measure, dwelling_type, period, period_freq, value, unit, source, source_licence, content_hash) VALUES
+		-- RICHMOND (VIC): public + proprietary
+		('SUBURB:VIC-RICHMOND','median_price','house','2024-03-31','Q', 1200000, 'AUD', 'vg_vic',      'CC-BY-4.0',                 'h1'),
+		('SUBURB:VIC-RICHMOND','median_price','house','2024-06-30','Q', 1250000, 'AUD', 'vg_vic',      'CC-BY-4.0',                 'h2'),
+		('SUBURB:VIC-RICHMOND','median_price','house','2024-06-30','Q', 9999999, 'AUD', 'crawl_domain','proprietary-tos-restricted','h3'),
+		-- NORWOOD (SA): public + proprietary
+		('SUBURB:SA-NORWOOD','median_price','house','2024-03-31','Q', 900000, 'AUD', 'vg_sa',       'CC-BY',                     'h4'),
+		('SUBURB:SA-NORWOOD','median_price','house','2024-06-30','Q', 950000, 'AUD', 'vg_sa',       'CC-BY',                     'h5'),
+		('SUBURB:SA-NORWOOD','median_price','house','2024-06-30','Q', 8888888,'AUD', 'crawl_rea',   'proprietary-tos-restricted','h6'),
+		-- CROWNLAND (VIC): proprietary ONLY
+		('SUBURB:VIC-CROWNLAND','median_price','house','2024-06-30','Q', 7777777,'AUD','crawl_domain','proprietary-tos-restricted','h7')`
+	_, err = pool.Exec(ctx, facts)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `REFRESH MATERIALIZED VIEW mv_housing_headline`)
+	require.NoError(t, err)
+}
+
+// TestHousingLicenceGate_Overview asserts GetHousingOverview (which reads the
+// 000054-gated MV) never surfaces proprietary-tos-restricted values.
+func TestHousingLicenceGate_Overview(t *testing.T) {
+	pool, cleanup := setupHousingTestDatabase(t)
+	defer cleanup()
+	s := &postgresStore{db: pool}
+
+	rows, err := s.GetHousingOverview("suburb")
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+
+	for _, r := range rows {
+		assert.NotEqual(t, 9999999.0, r.Value, "proprietary VIC value leaked into overview")
+		assert.NotEqual(t, 8888888.0, r.Value, "proprietary SA value leaked into overview")
+		assert.NotEqual(t, 7777777.0, r.Value, "proprietary-only region leaked into overview")
+	}
+
+	// The public latest (2024-06-30) values should be present.
+	var richmond, norwood float64
+	for _, r := range rows {
+		switch r.RegionCode {
+		case "SUBURB:VIC-RICHMOND":
+			richmond = r.Value
+		case "SUBURB:SA-NORWOOD":
+			norwood = r.Value
+		}
+	}
+	assert.InDelta(t, 1250000.0, richmond, 0.5, "expected public RICHMOND median")
+	assert.InDelta(t, 950000.0, norwood, 0.5, "expected public NORWOOD median")
+}
+
+// TestHousingLicenceGate_Series asserts GetHousePriceSeries excludes the
+// proprietary point while keeping the public points.
+func TestHousingLicenceGate_Series(t *testing.T) {
+	pool, cleanup := setupHousingTestDatabase(t)
+	defer cleanup()
+	s := &postgresStore{db: pool}
+
+	res, err := s.GetHousePriceSeries("SUBURB:VIC-RICHMOND", "median_price", "house")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Two public points (Mar + Jun), no proprietary 9,999,999 point.
+	assert.Len(t, res.Points, 2, "expected only the 2 public points")
+	for _, p := range res.Points {
+		assert.NotEqual(t, 9999999.0, p.Value, "proprietary point leaked into series")
+	}
+}
+
+// TestHousingLicenceGate_Regions asserts ListHousingRegions excludes a region
+// whose only data is proprietary, and that listed regions report a public
+// latest-median (not the proprietary value).
+func TestHousingLicenceGate_Regions(t *testing.T) {
+	pool, cleanup := setupHousingTestDatabase(t)
+	defer cleanup()
+	s := &postgresStore{db: pool}
+
+	rows, err := s.GetHousingRegions("suburb", "", "", 0)
+	require.NoError(t, err)
+
+	codes := map[string]float64{}
+	for _, r := range rows {
+		codes[r.RegionCode] = r.LatestValue
+	}
+	assert.Contains(t, codes, "SUBURB:VIC-RICHMOND")
+	assert.Contains(t, codes, "SUBURB:SA-NORWOOD")
+	assert.NotContains(t, codes, "SUBURB:VIC-CROWNLAND", "proprietary-only region must not be listed")
+
+	assert.InDelta(t, 1250000.0, codes["SUBURB:VIC-RICHMOND"], 0.5, "latest median must be public value")
+	assert.InDelta(t, 950000.0, codes["SUBURB:SA-NORWOOD"], 0.5, "latest median must be public value")
+}
+
+// TestHousingRegions_StateFilter asserts a state_code filter returns only that
+// state's regions (the /housing/suburbs state-filter bug).
+func TestHousingRegions_StateFilter(t *testing.T) {
+	pool, cleanup := setupHousingTestDatabase(t)
+	defer cleanup()
+	s := &postgresStore{db: pool}
+
+	vic, err := s.GetHousingRegions("suburb", "VIC", "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, vic)
+	for _, r := range vic {
+		assert.Equal(t, "VIC", r.StateCode, "VIC filter returned a non-VIC region: %s", r.RegionCode)
+	}
+
+	sa, err := s.GetHousingRegions("suburb", "SA", "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, sa)
+	for _, r := range sa {
+		assert.Equal(t, "SA", r.StateCode, "SA filter returned a non-SA region: %s", r.RegionCode)
+	}
+
+	// VIC and SA must be disjoint, not "identical mixed results".
+	assert.NotEqual(t, len(vic)+len(sa), 0)
+	for _, v := range vic {
+		for _, a := range sa {
+			assert.NotEqual(t, v.RegionCode, a.RegionCode, "state filters overlap")
+		}
+	}
+}

--- a/web/src/@/components/housing/suburb-explorer.tsx
+++ b/web/src/@/components/housing/suburb-explorer.tsx
@@ -38,9 +38,17 @@ function pointDate(p: { period?: { seconds?: bigint } }): number {
  * housing-charts.tsx because it pulls in connect-web.
  */
 export function SuburbExplorer() {
+  const [stateFilter, setStateFilter] = useState("VIC");
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+
+  // State is filtered SERVER-SIDE: the selected state_code is passed to
+  // ListHousingRegions so the SQL WHERE narrows the result set. (Previously the
+  // client fetched all suburbs with an empty state_code and tried to filter in
+  // memory, which let mixed SA+VIC results through.)
   const { data: regionsResp, isLoading } = useQuery({
-    queryKey: ["housing-regions", "suburb"],
-    queryFn: () => listHousingRegionsClient("suburb", "", "", 2000),
+    queryKey: ["housing-regions", "suburb", stateFilter],
+    queryFn: () => listHousingRegionsClient("suburb", stateFilter, "", 2000),
     staleTime: 60 * 60 * 1000,
   });
 
@@ -55,11 +63,8 @@ export function SuburbExplorer() {
     [regionsResp],
   );
 
-  const [stateFilter, setStateFilter] = useState("VIC");
-  const [search, setSearch] = useState("");
-  const [selected, setSelected] = useState<string | null>(null);
-
-  // map shows the whole state (no text filter); the list narrows by search.
+  // Server already narrows by state_code; this stays as a defensive guard
+  // (and a no-op pass-through for the "All" selection).
   const stateFiltered = useMemo(
     () => regions.filter((r) => !stateFilter || r.stateCode === stateFilter),
     [regions, stateFilter],


### PR DESCRIPTION
## Residential intelligent housing crawl (collector + API)

Adds the Tier-3 **residential** suburb crawl and the supporting API hygiene, combining cuttlefish (scheduling/runner) + brandbrain (extraction) + the house-price collector.

### What's in here
- **Crawl pipeline** (`services/house-price-collector`): headed-Playwright fetch behind an `htmlFetcher` seam → **brandbrain `ExtractRealEstate`** → 4-gate anti-poisoning validation → stored as **segregated** EAV rows (`source=brandbrain_rea|brandbrain_domain`, `source_licence=proprietary-tos-restricted`). New measures: `median_price` (house/unit), `rental_yield`, `days_on_market`, `auction_clearance`, `price_growth_12m`.
- **Local-agent execution (option b)**: the cuttlefish crawl container drives the **host macOS-native Chrome** via `ConnectOverCDP` (`CRAWL_CDP_URL`) — the only browser proven to beat Kasada/Akamai from a residential IP — reusing a warm persistent context. `Dockerfile.crawl` is browser-less (driver only) and **runner-only, never Cloud Run**. `LaunchPersistentContext` fallback retained.
- **Licence gate (safety)**: public housing queries now exclude `proprietary-tos-restricted`. Overview reads the MV, so **migration `000054`** rebuilds `mv_housing_headline` with the gate — **must be applied separately on prod (session pooler :5432, `statement_timeout=0`)**.
- **Bugfix**: `/housing/suburbs` state filter (was web-side in-memory filtering; now passes `state_code` server-side).
- **Docs**: design spec + Phase-0 feasibility findings under `docs/superpowers/`.

### Tests
`go build` + `go vet` clean; collector 40 tests; shorts store/services 136 tests + **4/4 housing integration (testcontainers)** green.

### Notes / follow-ups
- Live Kasada/Akamai validation is **deferred to the residential rig** (headless/chromedp are blocked; only macOS-native headed + warm profile + heavy pacing works; single-IP volume gets flagged → managed-unblocker is the documented escalation).
- Apply migration `000054` before relying on the overview gate.
- web `tsc` not run in the worktree (no `node_modules`); CI covers it.
