### PR TITLE
fix(dev-jobs): bump asx-discovery memory + fix weekly-report image var

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -450,6 +450,7 @@ jobs:
             -var="enrichment_processor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/enrichment-processor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="news_aggregator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/news-aggregator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="asx_announcement_crawler_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/asx-announcement-crawler:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="weekly_report_generator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/weekly-report-generator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="house_price_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/house-price-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="signals_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/signals-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="report_extractor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/report-extractor:${{ needs.determine-environment.outputs.image-tag }}" \
@@ -1014,6 +1015,7 @@ jobs:
             -var="enrichment_processor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/enrichment-processor:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="news_aggregator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/news-aggregator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="asx_announcement_crawler_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/asx-announcement-crawler:${{ needs.determine-environment.outputs.image-tag }}" \
+            -var="weekly_report_generator_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/weekly-report-generator:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="house_price_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/house-price-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="signals_collector_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/signals-collector:${{ needs.determine-environment.outputs.image-tag }}" \
             -var="report_extractor_image=${{ env.ARTIFACT_REGISTRY }}/${{ needs.determine-environment.outputs.project-id }}/shorted/report-extractor:${{ needs.determine-environment.outputs.image-tag }}" \

--- a/terraform/modules/market-discovery-sync/main.tf
+++ b/terraform/modules/market-discovery-sync/main.tf
@@ -61,7 +61,7 @@ resource "google_cloud_run_v2_job" "asx_discovery" {
         resources {
           limits = {
             cpu    = "1"
-            memory = "512Mi"
+            memory = "1Gi"
           }
         }
       }


### PR DESCRIPTION
## What
Two durable IaC fixes surfaced while repairing the dev async jobs (which had stalled — paused schedulers + jobs pointing at missing/stale `:latest` image tags).

1. **`asx-discovery` memory 512Mi → 1Gi** (`terraform/modules/market-discovery-sync`) — 512Mi was insufficient (OOM).
2. **CI: pass `weekly_report_generator_image` in the terraform deploy** — the workflow overrode every job image var *except* this one, so it fell back to its `:latest` default (a tag that doesn't exist in the dev registry), leaving the weekly-report-generator job permanently broken on every apply. Added to both the plan and apply `-var` lists.

## Operational fixes already applied to dev (not code)
- Ran the deploy workflow (env=dev) → built fresh `manual-<sha>` images; jobs repointed off missing/stale `:latest`.
- The dev `terraform apply` is **partially blocked by pre-existing env debt** unrelated to this change (chat-service/newsroom images never built for dev, CI-SA IAM-grant 403s, grafana folder perms, an un-imported `enrichment-jobs` pubsub topic). Where apply errored on that debt, the affected services (`market-data-sync`, `stock-price-ingestion`) + `weekly-report-generator` were repointed to their built `manual-<sha>` images via `gcloud` directly.
- Resumed the 6 paused dev schedulers.
- Smoke-tested `shorts-data-sync` — runs and ingests successfully.

## Follow-ups (not in this PR)
- Clear the pre-existing dev terraform drift so `apply` goes green (separate effort).
- The `feat/job-monitoring` DB observability stack was **intentionally not revived** — it's superseded by the live GCP-native job monitoring already in main, and its `000046` migration is schema-incompatible with main's current `jobstatus.go` (missing `trigger` column).