### PR TITLE
feat(newsletter): activate Resend subscribe notifications → support@shorted.com.au

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -214,6 +214,10 @@ module "shorts_api" {
   scheduler_region             = "australia-southeast1"
   enable_key_metrics_scheduler = true
 
+  # Operator email on each newsletter subscribe — RESEND_API_KEY secret is
+  # provisioned in prod, so bind it (from/to default to support@shorted.com.au).
+  resend_secret_exists = true
+
   depends_on = [
     google_project_service.required_apis,
     google_artifact_registry_repository.shorted

--- a/terraform/modules/shorts-api/variables.tf
+++ b/terraform/modules/shorts-api/variables.tf
@@ -75,14 +75,14 @@ variable "resend_secret_exists" {
 }
 
 variable "resend_to" {
-  description = "Recipient address for new-subscriber notification emails."
+  description = "Recipient address for new-subscriber notification emails (support@ is a Google Workspace inbox on shorted.com.au)."
   type        = string
-  default     = "ben.ebsworth@gmail.com"
+  default     = "support@shorted.com.au"
 }
 
 variable "resend_from" {
-  description = "From address for new-subscriber notification emails (must be on a Resend-verified domain; shorted.com.au is SPF/DMARC-ready)."
+  description = "From address for new-subscriber notification emails. shorted.com.au is a Resend-verified sending domain (resend._domainkey + send.shorted.com.au SES SPF in DNS)."
   type        = string
-  default     = "Shorted <notifications@shorted.com.au>"
+  default     = "Shorted <support@shorted.com.au>"
 }
 


### PR DESCRIPTION
Activates the (already-deployed, dormant) subscribe notification now that the `RESEND_API_KEY` secret is provisioned in prod (Secret Manager).

- prod `shorts_api`: `resend_secret_exists = true` → binds the secret env + grants the shorts SA `secretAccessor`.
- from/to default to **support@shorted.com.au** (domain already Resend-verified per DNS: `resend._domainkey` + `send.shorted.com.au` SES SPF; `support@` receives via Google Workspace MX).

On merge → deploy, the RegisterEmail handler emails support@shorted.com.au on each new subscribe. Will send a live test subscribe to confirm delivery.