### PR TITLE
feat(broadcasts): safe test-send (?to=) + /admin Test button

### DIFF
--- a/services/shorts/internal/services/shorts/serve.go
+++ b/services/shorts/internal/services/shorts/serve.go
@@ -607,6 +607,45 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 			http.Error(w, "broadcast not found", http.StatusNotFound)
 			return
 		}
+		cfg := broadcast.Config{
+			APIKey:            os.Getenv("RESEND_API_KEY"),
+			From:              envOr("BROADCAST_FROM", "Shorted <updates@shorted.com.au>"),
+			ReplyTo:           envOr("BROADCAST_REPLY_TO", "support@shorted.com.au"),
+			UnsubscribeSecret: os.Getenv("UNSUBSCRIBE_SECRET"),
+			BaseURL:           envOr("PUBLIC_SITE_URL", "https://shorted.com.au"),
+		}
+
+		// TEST SEND: ?to=<email> delivers to that ONE address only. It must be an
+		// active subscriber (so the unsubscribe link is real). This never claims,
+		// never touches the subscriber list, and never changes the broadcast status
+		// — the draft stays sendable for the real blast.
+		if to := r.URL.Query().Get("to"); to != "" {
+			subs, err := s.store.ListActiveSubscribers()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			var recip *broadcast.Recipient
+			for _, su := range subs {
+				if su.Email == to {
+					recip = &broadcast.Recipient{ID: su.ID, Email: su.Email}
+					break
+				}
+			}
+			if recip == nil {
+				http.Error(w, "test recipient must be an active subscriber", http.StatusBadRequest)
+				return
+			}
+			sent, sendErr := broadcast.Send(r.Context(), cfg, b.Subject, b.Subject, b.HTMLBody, b.TextBody, []broadcast.Recipient{*recip}, register.SignUnsubscribeToken)
+			if sendErr != nil {
+				http.Error(w, sendErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"sent": sent, "test": true, "to": to})
+			return
+		}
+
 		claimed, err := s.store.ClaimBroadcastForSending(id)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -623,13 +662,6 @@ func (s *ShortsServer) Serve(ctx context.Context, logger *log.Logger, address st
 			}
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
-		}
-		cfg := broadcast.Config{
-			APIKey:            os.Getenv("RESEND_API_KEY"),
-			From:              envOr("BROADCAST_FROM", "Shorted <updates@shorted.com.au>"),
-			ReplyTo:           envOr("BROADCAST_REPLY_TO", "support@shorted.com.au"),
-			UnsubscribeSecret: os.Getenv("UNSUBSCRIBE_SECRET"),
-			BaseURL:           envOr("PUBLIC_SITE_URL", "https://shorted.com.au"),
 		}
 		recips := make([]broadcast.Recipient, len(subs))
 		for i, su := range subs {

--- a/web/src/app/actions/sendBroadcast.ts
+++ b/web/src/app/actions/sendBroadcast.ts
@@ -7,10 +7,15 @@ const INTERNAL_SECRET = process.env.INTERNAL_SERVICE_SECRET ?? "dev-internal-sec
 
 export async function sendBroadcast(
   id: string,
+  to?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   try {
+    // When `to` is set the backend delivers only to that one address (a test
+    // send): it must be an active subscriber, the subscriber list is untouched,
+    // and the broadcast stays a draft (not marked sent).
+    const testParam = to ? `&to=${encodeURIComponent(to)}` : "";
     const response = await fetch(
-      `${SHORTS_API_URL}/api/admin/broadcasts/send?id=${encodeURIComponent(id)}`,
+      `${SHORTS_API_URL}/api/admin/broadcasts/send?id=${encodeURIComponent(id)}${testParam}`,
       {
         method: "POST",
         headers: {

--- a/web/src/app/admin/broadcasts/broadcasts-client.tsx
+++ b/web/src/app/admin/broadcasts/broadcasts-client.tsx
@@ -85,6 +85,23 @@ export function BroadcastsClient({ initial }: { initial: Broadcast[] }) {
     }
   }
 
+  async function onTest(b: Broadcast) {
+    const to = prompt(
+      `Send a TEST of "${b.subject}" to a single address.\n\nThe address must already be an active subscriber. This does NOT email the list and does NOT mark the broadcast sent.`,
+      "",
+    );
+    if (!to) return;
+    setBusy(b.id);
+    setMsg(null);
+    const res = await sendBroadcast(b.id, to.trim());
+    setBusy(null);
+    setMsg(
+      res.ok
+        ? { text: `Test sent to ${to.trim()} — the draft is unchanged.`, ok: true }
+        : { text: `Test failed: ${res.error ?? "unknown error"}`, ok: false },
+    );
+  }
+
   if (broadcasts.length === 0) {
     return (
       <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
@@ -117,7 +134,7 @@ export function BroadcastsClient({ initial }: { initial: Broadcast[] }) {
             <TableHead className="w-[80px] text-right">Recipients</TableHead>
             <TableHead className="w-[160px]">Created</TableHead>
             <TableHead className="w-[160px]">Sent</TableHead>
-            <TableHead className="w-[90px]">Action</TableHead>
+            <TableHead className="w-[170px]">Action</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -163,23 +180,38 @@ export function BroadcastsClient({ initial }: { initial: Broadcast[] }) {
                 <TableCell className="text-sm text-muted-foreground">{fmtDate(b.createdAt)}</TableCell>
                 <TableCell className="text-sm text-muted-foreground">{fmtDate(b.sentAt)}</TableCell>
                 <TableCell>
-                  {canSend ? (
+                  <div className="flex items-center gap-1.5">
                     <Button
                       size="sm"
+                      variant="outline"
                       disabled={isBusy || busy !== null}
-                      onClick={() => onSend(b)}
+                      onClick={() => onTest(b)}
                       className="gap-1.5"
+                      title="Send a test to one address (does not email the list)"
                     >
                       {isBusy ? (
                         <Loader2 className="h-3.5 w-3.5 animate-spin" />
                       ) : (
-                        <Send className="h-3.5 w-3.5" />
+                        <Mail className="h-3.5 w-3.5" />
                       )}
-                      Send
+                      Test
                     </Button>
-                  ) : (
-                    <span className="text-muted-foreground/30 text-xs">—</span>
-                  )}
+                    {canSend ? (
+                      <Button
+                        size="sm"
+                        disabled={isBusy || busy !== null}
+                        onClick={() => onSend(b)}
+                        className="gap-1.5"
+                      >
+                        {isBusy ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Send className="h-3.5 w-3.5" />
+                        )}
+                        Send
+                      </Button>
+                    ) : null}
+                  </div>
                 </TableCell>
               </TableRow>
             );


### PR DESCRIPTION
Adds a safe way to preview-send a broadcast before blasting the list.

- Admin `POST /api/admin/broadcasts/send?id=…&to=<email>` delivers to **one** address only. It must be an active subscriber (so the unsubscribe link is real), never touches the subscriber list, and never changes the broadcast status (draft stays sendable for the real send).
- `/admin/broadcasts` gets a **Test** button (prompts for an address) next to Send.

Verified: go build/vet clean, tsc + eslint clean. Enables the delivery/unsubscribe e2e without emailing real subscribers.