### PR TITLE
fix(asx-discovery): raise memory 1Gi→4Gi to stop 6-week weekly OOM

### DIFF
--- a/terraform/modules/market-discovery-sync/main.tf
+++ b/terraform/modules/market-discovery-sync/main.tf
@@ -59,9 +59,16 @@ resource "google_cloud_run_v2_job" "asx_discovery" {
         }
 
         resources {
+          # asx-discovery drives a headless Chromium (Playwright) to scrape ASX
+          # listings. At 1Gi every weekly run OOM-killed ("configured memory limit
+          # was reached") — headless Chrome needs several GB, and the job also
+          # transiently re-downloads a ~165 MiB Chromium at startup. 4Gi/2 CPU gives
+          # comfortable headroom; the job runs weekly for a couple of minutes, so the
+          # cost is negligible. (Follow-up: bundle the browser at the playwright-go
+          # version so it stops re-downloading at runtime.)
           limits = {
-            cpu    = "1"
-            memory = "1Gi"
+            cpu    = "2"
+            memory = "4Gi"
           }
         }
       }


### PR DESCRIPTION
## Finding
While investigating job errors, `asx-discovery` (Cloud Run Job, **us-central1**, module `market-discovery-sync`) turned out to be **100% broken for 6+ weeks**. Every weekly execution back to at least **2026-05-24** fails with:

> Task …-task0 failed with exit code: 0 and message: **The configured memory limit was reached.**

16 container OOM-kill events in the last 30 days. Raw logs:
```
Starting ASX Discovery Service → Downloading browsers... →
Downloading Chromium 143.0.7499.4 ... 164.7 MiB →
Out-of-memory event detected in container → Container terminated on signal 9.
```
(repeats each retry attempt → whole execution fails). So new-ASX-instrument discovery has been silently dead.

## Root cause
The job drives a **headless Chromium (Playwright)** to scrape ASX listings but was capped at **1Gi / 1 CPU**. Headless Chrome needs several GB; 1Gi was simply under-provisioned. It's compounded by a redundant ~165 MiB Chromium **re-download at startup** (see follow-up), whose spike tips it over.

## Fix
Raise the job to **4Gi / 2 CPU** in `terraform/modules/market-discovery-sync/main.tf`. The job runs weekly for ~minutes, so the cost is negligible. This definitively removes the OOM.

## Follow-up (separate, build-verified change — NOT in this PR)
The Dockerfile bundles Chromium via npm `playwright@latest`, but the Go code uses **`playwright-go v0.5200.1`** whose pinned browser build differs, so `playwright.Install()` **re-downloads Chromium at runtime every attempt** (a startup memory spike + a hard dependency on `cdn.playwright.dev`). Bundling the browser at the matching playwright-go version eliminates the download. Left out of this PR because it's a Dockerfile refactor that warrants a build check.

## Verification
`terraform fmt` ✅. Deploys via merge → `terraform apply`. Confirm next weekly run (Sat 12:00 UTC) completes instead of OOM-killing, or trigger the `asx-discovery` job manually to verify sooner.