### PR TITLE
perf(asx-discovery): stop re-downloading Chromium every run (bundle matching build + chromium-only)

### DIFF
--- a/services/asx-discovery/Dockerfile
+++ b/services/asx-discovery/Dockerfile
@@ -71,10 +71,15 @@ RUN apt-get update && apt-get install -y \
     xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Playwright browsers to a specific path
+# Pre-bundle the Chromium build that playwright-go v0.5200.1 (driver 1.57.0) expects.
+# Pin the npm playwright version to 1.57.0 so the bundled build matches the one the Go
+# runtime wants (build v1200). With `playwright@latest` the bundled build (e.g. 1228)
+# mismatched, so playwright-go deleted it and re-downloaded ~165 MiB of Chromium on every
+# run (a startup memory spike + a hard dependency on cdn.playwright.dev). Keep the driver
+# version in lockstep with services/asx-discovery/go.mod on any playwright-go bump.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes playwright@latest install chromium \
-    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes playwright@latest install-deps chromium || true \
+RUN PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes playwright@1.57.0 install chromium \
+    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes playwright@1.57.0 install-deps chromium || true \
     && rm -rf /root/.npm /root/.cache
 
 WORKDIR /app

--- a/services/asx-discovery/scraper/asx_scraper.go
+++ b/services/asx-discovery/scraper/asx_scraper.go
@@ -40,8 +40,10 @@ func (s *ASXScraper) DownloadCSV(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	// Install Playwright driver if not already installed
-	if err := playwright.Install(); err != nil {
+	// Install the Playwright driver if not already installed. Restrict to Chromium:
+	// the default (no options) downloads Chromium + Firefox + WebKit, but this scraper
+	// only ever launches Chromium — so Firefox/WebKit were pure waste (~150 MiB) each run.
+	if err := playwright.Install(&playwright.RunOptions{Browsers: []string{"chromium"}}); err != nil {
 		log.Printf("Warning: failed to install Playwright driver: %v (continuing anyway)", err)
 	}
 


### PR DESCRIPTION
Follow-up to #233 (the memory bump that fixed the OOM). #233 gave the job enough RAM to survive; this removes the wasteful work that was causing part of the memory spike in the first place.

## Problem
On every run, `asx-discovery` re-downloaded its whole browser set:
```
Removing unused browser at /ms-playwright/chromium-1228        ← bundled (npm @latest)
Downloading Chromium 143.0.7499.4 (playwright build v1200) ... 164.7 MiB   ← what the runtime actually wants
Downloading Firefox 144.0.2 (build v1497) ...
Downloading Webkit 26.0 (build v2227) ...
```
Two causes:
1. **Version mismatch** — the Dockerfile bundles Chromium with npm `playwright@latest` (build **1228**), but the Go code uses **`playwright-go v0.5200.1`** (driver **1.57.0**), which wants build **v1200**. So playwright-go deletes the bundled browser and re-downloads ~165 MiB of Chromium from `cdn.playwright.dev` every run — a startup memory spike (contributor to the OOMs) and a hard runtime network dependency.
2. **All-browsers install** — `playwright.Install()` with no options downloads Chromium **+ Firefox + WebKit**; this scraper only ever launches Chromium, so Firefox/WebKit (~150 MiB) were pure waste each run.

## Fix
1. Pin the Dockerfile to `playwright@1.57.0` — its Chromium build is exactly **1200**, matching the runtime. Verified with `playwright install --dry-run chromium`:
   ```
   browser: chromium version 143.0.7499.4
     Install location: /ms-playwright/chromium-1200      ← matches what playwright-go downloads
   ```
2. `playwright.Install(&playwright.RunOptions{Browsers: []string{"chromium"}})` — Chromium only.

Net: **no browser downloads at runtime** (only the ~2s driver extraction remains) → faster cold start, lower memory spike, no `cdn.playwright.dev` dependency.

## Verification
- `go build ./...` ✅ (the `RunOptions{Browsers}` change compiles)
- `npx playwright@1.57.0 install --dry-run chromium` → `chromium-1200` ✅ (matches the runtime's build)
- Post-merge: trigger the job and confirm the logs no longer show "Removing unused browser" / "Downloading Chromium".

**Maintenance note:** keep `playwright@<ver>` in the Dockerfile in lockstep with `services/asx-discovery/go.mod`'s `playwright-go` version on any bump.