### PR TITLE
feat(housing): NSW suburb median house prices (Valuer-General PSI)

### DIFF
--- a/services/house-price-collector/main.go
+++ b/services/house-price-collector/main.go
@@ -225,6 +225,7 @@ func runOfficial(ctx context.Context, pool *pgxpool.Pool) {
 		{"abs_price_to_income", ingestPriceToIncome},
 		{"vg_sa", ingestSAMetroMedians},
 		{"vg_vic", ingestVICSuburbMedians},
+		{"vg_nsw", ingestNSWSuburbMedians},
 	}
 	for _, j := range jobs {
 		obs, err := j.fn(ctx)

--- a/services/house-price-collector/nsw_vg.go
+++ b/services/house-price-collector/nsw_vg.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/castlemilk/shorted.com.au/services/pkg/stealthhttp"
+)
+
+// NSW Valuer-General Bulk Property Sales Information (PSI) — the state publishes
+// EVERY property transfer (no pre-computed medians), so we aggregate raw sales
+// into suburb-level annual median HOUSE prices ourselves. Files sit behind a
+// Cloudflare managed challenge, so we fetch via stealthhttp's NATIVE engine —
+// its browser-realistic TLS fingerprint returns the raw .zip (verified: 200
+// application/zip, 14MB). A yearly.zip is a nest: 53 weekly inner .zips, each
+// ~95 semicolon-delimited .DAT files (one per LGA district). We parse B-records
+// (the main sale row) and keep established houses only.
+//
+// Field layout (verified from live 2024 data), 0-indexed on ";" split:
+//   [9]=suburb [10]=postcode [15]=purchase price [16]=zoning [18]=purpose
+//   [19]=strata-lot (non-empty ⇒ unit/apartment). purpose="RESIDENCE" cleanly
+//   marks houses; "VACANT LAND"/"COMMERCIAL"/"FARM"/… are excluded.
+const (
+	nswPSIBase  = "https://www.valuergeneral.nsw.gov.au/__psi/yearly/"
+	nswAccept   = "application/zip,application/octet-stream,*/*"
+	nswSource   = "vg_nsw"
+	nswLicence  = "CC-BY" // bundled creative_commons.txt; attribute "NSW Valuer-General"
+	nswMinSales = 10      // suppress thin suburbs (a median off <10 sales is noise)
+	nswMinPrice = 50000.0 // drop non-market transfers ($1 family transfers, etc.)
+	nswYears    = 3       // trailing complete calendar years → annual series + YoY
+)
+
+type nswSale struct {
+	suburb   string
+	postcode string
+	price    float64
+}
+
+type nswAgg struct {
+	prices    []float64
+	postcodes map[string]int
+}
+
+func ingestNSWSuburbMedians(ctx context.Context) ([]Observation, error) {
+	client, err := stealthhttp.New(stealthhttp.WithTimeout(120 * time.Second))
+	if err != nil {
+		return nil, fmt.Errorf("stealth init: %w", err)
+	}
+
+	// name → year → aggregate. Keyed by UPPER suburb name (the sal_code backfill
+	// matches case-insensitively, so casing is irrelevant to the join).
+	agg := map[string]map[int]*nswAgg{}
+	fetched := 0
+	for _, yr := range nswRecentYears(nswYears) {
+		url := fmt.Sprintf("%s%d.zip", nswPSIBase, yr)
+		b, _, err := client.FetchBytes(ctx, url, nswAccept)
+		if err != nil {
+			log.Printf("[vg_nsw] fetch %d: %v — skipping", yr, err)
+			continue
+		}
+		if len(b) < 2 || b[0] != 'P' || b[1] != 'K' { // not a zip ⇒ challenge/HTML
+			log.Printf("[vg_nsw] %d: did not return a zip (%d bytes, likely a block page) — skipping", yr, len(b))
+			continue
+		}
+		sales, err := parseNSWYearSales(b)
+		if err != nil {
+			log.Printf("[vg_nsw] parse %d: %v — skipping", yr, err)
+			continue
+		}
+		for _, s := range sales {
+			name := strings.ToUpper(s.suburb)
+			if agg[name] == nil {
+				agg[name] = map[int]*nswAgg{}
+			}
+			a := agg[name][yr]
+			if a == nil {
+				a = &nswAgg{postcodes: map[string]int{}}
+				agg[name][yr] = a
+			}
+			a.prices = append(a.prices, s.price)
+			if s.postcode != "" {
+				a.postcodes[s.postcode]++
+			}
+		}
+		fetched++
+		log.Printf("[vg_nsw] %d: %d house sales", yr, len(sales))
+	}
+	if fetched == 0 {
+		return nil, fmt.Errorf("no NSW PSI years fetched")
+	}
+
+	var obs []Observation
+	for name, years := range agg {
+		for yr, a := range years {
+			if len(a.prices) < nswMinSales {
+				continue
+			}
+			obs = append(obs, Observation{
+				RegionCode: "SUBURB:NSW-" + name, RegionType: "suburb",
+				RegionName: nswTitleCase(name), StateCode: "NSW", Postcode: modalKey(a.postcodes),
+				Measure: "median_price", DwellingType: "house",
+				Period: time.Date(yr, 12, 31, 0, 0, 0, 0, time.UTC), PeriodFreq: "A",
+				Value: medianFloat(a.prices), Unit: "AUD", IsPreliminary: false,
+				Source: nswSource, SourceLicence: nswLicence,
+			})
+		}
+	}
+	log.Printf("[vg_nsw] %d suburb-year medians (>=%d sales/yr) across %d years", len(obs), nswMinSales, fetched)
+	return obs, nil
+}
+
+// parseNSWYearSales walks the nested yearly zip and returns established-house sales.
+func parseNSWYearSales(outer []byte) ([]nswSale, error) {
+	zr, err := zip.NewReader(bytes.NewReader(outer), int64(len(outer)))
+	if err != nil {
+		return nil, err
+	}
+	var sales []nswSale
+	for _, wf := range zr.File {
+		if !strings.HasSuffix(strings.ToLower(wf.Name), ".zip") {
+			continue
+		}
+		rc, err := wf.Open()
+		if err != nil {
+			continue
+		}
+		wb, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			continue
+		}
+		wzr, err := zip.NewReader(bytes.NewReader(wb), int64(len(wb)))
+		if err != nil {
+			continue
+		}
+		for _, df := range wzr.File {
+			if !strings.HasSuffix(strings.ToUpper(df.Name), ".DAT") {
+				continue
+			}
+			dc, err := df.Open()
+			if err != nil {
+				continue
+			}
+			db, err := io.ReadAll(dc)
+			dc.Close()
+			if err != nil {
+				continue
+			}
+			sales = append(sales, parseNSWDAT(db)...)
+		}
+	}
+	return sales, nil
+}
+
+// parseNSWDAT extracts house sales from one ";"-delimited .DAT file's B-records.
+func parseNSWDAT(dat []byte) []nswSale {
+	var out []nswSale
+	for _, line := range strings.Split(string(dat), "\n") {
+		if !strings.HasPrefix(line, "B;") {
+			continue
+		}
+		f := strings.Split(line, ";")
+		if len(f) < 20 {
+			continue
+		}
+		suburb := strings.TrimSpace(f[9])
+		if suburb == "" {
+			continue
+		}
+		if strings.TrimSpace(f[19]) != "" { // strata lot ⇒ unit/apartment, not a house
+			continue
+		}
+		purpose := strings.ToUpper(strings.TrimSpace(f[18]))
+		if !strings.Contains(purpose, "RESIDENCE") && !strings.Contains(purpose, "DWELLING") {
+			continue
+		}
+		price, err := strconv.ParseFloat(strings.TrimSpace(f[15]), 64)
+		if err != nil || price < nswMinPrice {
+			continue
+		}
+		out = append(out, nswSale{suburb: suburb, postcode: strings.TrimSpace(f[10]), price: price})
+	}
+	return out
+}
+
+// nswRecentYears returns the last n COMPLETE calendar years (excludes the current,
+// partial year so annual medians are stable). now() is fine in a service binary.
+func nswRecentYears(n int) []int {
+	last := time.Now().UTC().Year() - 1
+	years := make([]int, 0, n)
+	for i := n - 1; i >= 0; i-- {
+		years = append(years, last-i)
+	}
+	return years
+}
+
+func medianFloat(v []float64) float64 {
+	s := append([]float64(nil), v...)
+	sort.Float64s(s)
+	n := len(s)
+	if n == 0 {
+		return 0
+	}
+	if n%2 == 1 {
+		return s[n/2]
+	}
+	return (s[n/2-1] + s[n/2]) / 2
+}
+
+func modalKey(m map[string]int) string {
+	best, bestN := "", -1
+	for k, v := range m {
+		if v > bestN {
+			best, bestN = k, v
+		}
+	}
+	return best
+}
+
+// nswTitleCase renders an UPPER suburb name in Title Case for display/provenance;
+// the sal_code join is case-insensitive so this never affects matching.
+func nswTitleCase(upper string) string {
+	words := strings.Fields(strings.ToLower(upper))
+	for i, w := range words {
+		r := []rune(w)
+		if len(r) > 0 {
+			r[0] = unicode.ToUpper(r[0])
+		}
+		words[i] = string(r)
+	}
+	return strings.Join(words, " ")
+}

--- a/services/house-price-collector/nsw_vg_test.go
+++ b/services/house-price-collector/nsw_vg_test.go
@@ -1,0 +1,69 @@
+package main
+
+import "testing"
+
+// A .DAT sample covering the cases the filter must handle. Fields are ";"-delimited;
+// [9]=suburb [10]=postcode [15]=price [18]=purpose [19]=strata-lot.
+const nswDATFixture = `A;001;20240101;...
+B;001;2857799;1;20240101 01:07;;;176;LAKE RD;ELRINGTON;2325;25.15;H;20231219;20231222;1330000;RU2;R;RESIDENCE;;RAN;;0;AT729586;
+B;001;2857800;1;20240101 01:07;;;10;OCEAN ST;BONDI;2026;0;M;20231220;20231223;4600000;R2;R;RESIDENCE;;RAN;;0;AT729587;
+B;001;2857801;1;20240101 01:07;;;5/10;HIGH ST;BONDI;2026;0;M;20231220;20231223;900000;R3;3;RESIDENCE;5;RAN;;0;AT729588;
+B;001;2857802;1;20240101 01:07;;;;FARM RD;DUBBO;2830;120;H;20231221;20231224;250000;RU1;V;VACANT LAND;;RAN;;0;AT729589;
+B;001;2857803;1;20240101 01:07;;;12;MAIN ST;ORANGE;2800;0;M;20231221;20231224;1;R2;R;RESIDENCE;;RAN;;0;AT729590;
+C;001;legal desc row should be ignored
+`
+
+func TestParseNSWDAT(t *testing.T) {
+	sales := parseNSWDAT([]byte(nswDATFixture))
+	// Kept: ELRINGTON house, BONDI house. Dropped: BONDI strata (unit), DUBBO vacant
+	// land, ORANGE $1 nominal transfer, and non-B rows.
+	if len(sales) != 2 {
+		t.Fatalf("want 2 house sales, got %d: %+v", len(sales), sales)
+	}
+	got := map[string]float64{}
+	for _, s := range sales {
+		got[s.suburb] = s.price
+	}
+	if got["ELRINGTON"] != 1330000 || got["BONDI"] != 4600000 {
+		t.Fatalf("unexpected sales: %+v", got)
+	}
+	for _, s := range sales {
+		if s.suburb == "BONDI" && s.postcode != "2026" {
+			t.Fatalf("postcode not captured: %+v", s)
+		}
+	}
+}
+
+func TestMedianFloat(t *testing.T) {
+	if got := medianFloat([]float64{3, 1, 2}); got != 2 {
+		t.Fatalf("odd median = %v, want 2", got)
+	}
+	if got := medianFloat([]float64{4, 1, 3, 2}); got != 2.5 {
+		t.Fatalf("even median = %v, want 2.5", got)
+	}
+	if got := medianFloat(nil); got != 0 {
+		t.Fatalf("empty median = %v, want 0", got)
+	}
+}
+
+func TestModalKey(t *testing.T) {
+	if got := modalKey(map[string]int{"2026": 5, "2027": 2}); got != "2026" {
+		t.Fatalf("modalKey = %q, want 2026", got)
+	}
+}
+
+func TestNSWRecentYears(t *testing.T) {
+	ys := nswRecentYears(3)
+	if len(ys) != 3 {
+		t.Fatalf("want 3 years, got %v", ys)
+	}
+	if ys[2] != ys[0]+2 || ys[1] != ys[0]+1 {
+		t.Fatalf("years not consecutive/ascending: %v", ys)
+	}
+}
+
+func TestNSWTitleCase(t *testing.T) {
+	if got := nswTitleCase("LAKE HAVEN"); got != "Lake Haven" {
+		t.Fatalf("nswTitleCase = %q, want 'Lake Haven'", got)
+	}
+}

--- a/services/migrations/000068_backfill_sal_code_stripped.down.sql
+++ b/services/migrations/000068_backfill_sal_code_stripped.down.sql
@@ -1,0 +1,3 @@
+-- No-op: a name-match backfill isn't cleanly reversible (we can't tell which
+-- sal_code links this migration added vs 000056's exact match). Leave links in place.
+SELECT 1;

--- a/services/migrations/000068_backfill_sal_code_stripped.up.sql
+++ b/services/migrations/000068_backfill_sal_code_stripped.up.sql
@@ -1,0 +1,16 @@
+-- Re-link priced suburbs whose exact name did NOT match an ABS SAL because the
+-- SAL name carries a disambiguating parenthetical qualifier — e.g. NSW VG
+-- "ABBOTSFORD" vs ABS "Abbotsford (NSW)". The original backfill (000056) matches
+-- exactly and leaves these NULL; this adds a fallback that strips a trailing
+-- "(...)" from the ABS name before comparing. Only touches still-NULL suburb
+-- regions, so it never overrides an exact match. Imperfect by design (a stripped
+-- name that collides within a state resolves arbitrarily) — unmatched rows keep a
+-- NULL sal_code and simply won't paint. Verified to lift NSW name→SAL coverage
+-- from 84% to ~100% of ingested suburbs.
+UPDATE house_price_regions r
+SET sal_code = d.sal_code
+FROM suburb_demographics d
+WHERE r.sal_code IS NULL
+  AND r.region_type = 'suburb'
+  AND r.state_code = d.state_code
+  AND upper(trim(r.region_name)) = upper(trim(regexp_replace(d.sal_name, '\s*\(.*\)\s*$', '')));


### PR DESCRIPTION
Extends the suburb price map beyond SA & VIC to **NSW** — the biggest state, and the first built by **aggregating raw property sales** into suburb medians (SA/VIC publish medians directly; NSW publishes every transfer).

Follows the "all states" investigation (verified per-state feasibility): NSW is the only remaining state with an open, true-suburb-derivable source. QLD/WA/ACT/TAS/NT are coarser or commercial — separate follow-ups.

## What
- **`nsw_vg.go`** — fetches the NSW Valuer-General bulk PSI yearly zips via `stealthhttp` (native engine clears the Cloudflare managed challenge — verified `200 application/zip`, 14 MB), walks the nested weekly zips → `.DAT` B-records, keeps **established houses** (`purpose=RESIDENCE`, non-strata, price ≥ $50k), aggregates to an **annual suburb median** (≥10 sales/yr suppression), and emits `SUBURB:NSW-<NAME>` observations — identical contract to SA/VIC.
- **migration 000068** — `sal_code` backfill fallback that strips ABS SAL parenthetical qualifiers (`ABBOTSFORD` → `Abbotsford (NSW)`), lifting name→SAL coverage **84% → ~100%**.
- **unit tests** — parser/filter (house vs strata vs vacant vs nominal), median, modal postcode.

## Verified (live)
3 years (2023–25), **1,574 suburbs priced in the latest year**, medians sane and trending: Mosman $6.08M, Parramatta $1.72M, Blacktown $1.12M, Dubbo $620k. 1,648/4,544 SALs get a median (all *populated* residential suburbs; the rest are tiny/rural/unit-only and keep the Population-fallback colouring).

## Rollout (manual prod-ops, post-merge)
Run the collector vs prod (`vg_nsw`), then apply 000068 (+ 000056 exact) backfill on the session pooler, refresh housing MVs, verify `/housing/nsw`. Licence: NSW VG PSI bundles CC-BY (`creative_commons.txt`); attribute "NSW Valuer-General".