### PR TITLE
feat(housing): collector self-links suburb sal_codes post-ingest

### DIFF
--- a/services/house-price-collector/main.go
+++ b/services/house-price-collector/main.go
@@ -196,6 +196,14 @@ func runElectorates(ctx context.Context, pool *pgxpool.Pool) {
 }
 
 func refresh(ctx context.Context, pool *pgxpool.Pool) {
+	// Link any newly-ingested suburb regions to their ABS sal_code first, so the
+	// suburb map (which reads house_prices via the sal_code bridge) paints without
+	// a manual backfill step.
+	if n, err := linkSuburbSalCodes(ctx, pool); err != nil {
+		log.Printf("suburb sal_code link failed: %v", err)
+	} else {
+		log.Printf("linked %d suburb region(s) to sal_code", n)
+	}
 	if err := refreshHousingMV(ctx, pool); err != nil {
 		log.Printf("mv refresh failed: %v", err)
 		return

--- a/services/house-price-collector/store.go
+++ b/services/house-price-collector/store.go
@@ -123,6 +123,34 @@ func refreshHousingMV(ctx context.Context, pool *pgxpool.Pool) error {
 	return err
 }
 
+// linkSuburbSalCodes backfills house_price_regions.sal_code for suburb regions by
+// matching the region NAME to an ABS SAL name — the same logic as migrations 000056
+// (exact) + 000068 (parenthetical-stripped fallback for ABS names like
+// "Abbotsford (NSW)"). Run every ingest so newly-added suburbs (any state)
+// self-link without a manual SQL step. Idempotent: only touches NULL sal_codes.
+func linkSuburbSalCodes(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
+	var total int64
+	tag, err := pool.Exec(ctx, `
+		UPDATE house_price_regions r SET sal_code = d.sal_code
+		FROM suburb_demographics d
+		WHERE r.sal_code IS NULL AND r.region_type = 'suburb' AND r.state_code = d.state_code
+		  AND upper(trim(r.region_name)) = upper(trim(d.sal_name))`)
+	if err != nil {
+		return total, fmt.Errorf("sal link (exact): %w", err)
+	}
+	total += tag.RowsAffected()
+	tag, err = pool.Exec(ctx, `
+		UPDATE house_price_regions r SET sal_code = d.sal_code
+		FROM suburb_demographics d
+		WHERE r.sal_code IS NULL AND r.region_type = 'suburb' AND r.state_code = d.state_code
+		  AND upper(trim(r.region_name)) = upper(trim(regexp_replace(d.sal_name, '\s*\(.*\)\s*$', '')))`)
+	if err != nil {
+		return total, fmt.Errorf("sal link (stripped): %w", err)
+	}
+	total += tag.RowsAffected()
+	return total, nil
+}
+
 // upsertDemographics idempotently writes one row per boundary suburb (PK =
 // sal_code). v1 populates identity + population + the five G02 medians; the
 // tenure/dwelling columns are left to default NULL until those tables are


### PR DESCRIPTION
The suburb price choropleth paints via `house_price_regions.sal_code`, which was only populated by the manual migration backfill (000056 exact / 000068 parenthetical-stripped). So adding a new state's prices needed a separate SQL step to actually appear on the map.

This moves that name→SAL linking into the collector's `refresh()` (which already runs after `official`/`crawl`/`refresh` modes and refreshes the MVs). It matches suburb region NAME → ABS SAL (exact, then a `(...)`-stripped fallback for names like `Abbotsford (NSW)`) before the MV refresh. Idempotent — only touches NULL sal_codes.

Result: any collector run (local or the scheduled prod job) now fully wires new suburb prices in one step — for NSW (PR #237) and every future state — no manual backfill.