### PR TITLE
Fix disabled Cloudflare testing bypass expression

### DIFF
--- a/terraform/modules/cloudflare-edge/main.tf
+++ b/terraform/modules/cloudflare-edge/main.tf
@@ -16,7 +16,7 @@ locals {
   chat_service_hostname          = try(var.chat_service_origin != "" ? regex("^https?://([^/]+)", var.chat_service_origin)[0] : "", "")
   market_data_hostname           = try(var.market_data_origin != "" ? regex("^https?://([^/]+)", var.market_data_origin)[0] : "", "")
   api_rate_limit_host_expression = "http.host eq \"api.shorted.com.au\""
-  testing_bypass_expression      = var.rate_limit_testing_bypass_secret != "" ? "(http.user_agent contains \"${var.rate_limit_testing_bypass_user_agent}\" and any(http.request.headers[\"${var.rate_limit_testing_bypass_header_name}\"][*] eq \"${var.rate_limit_testing_bypass_secret}\"))" : "false"
+  testing_bypass_expression      = var.rate_limit_testing_bypass_secret != "" ? "(http.user_agent contains \"${var.rate_limit_testing_bypass_user_agent}\" and any(http.request.headers[\"${var.rate_limit_testing_bypass_header_name}\"][*] eq \"${var.rate_limit_testing_bypass_secret}\"))" : "(http.host eq \"__shorted-testing-bypass-disabled.invalid__\")"
   # Cloudflare's basic rate-limit phase does not allow request header or
   # user-agent fields in rate-limit expressions. Trusted tests bypass that
   # phase via the custom skip ruleset below, while normal API traffic remains

--- a/terraform/modules/cloudflare-edge/rate-limit-expression.test.mjs
+++ b/terraform/modules/cloudflare-edge/rate-limit-expression.test.mjs
@@ -60,6 +60,11 @@ test("testing bypass inputs are explicit and safe by default", () => {
   assert.match(variablesTf, /default\s+=\s+"x-shorted-testing-bypass"/);
   assert.match(variablesTf, /variable "rate_limit_testing_bypass_user_agent"/);
   assert.match(variablesTf, /default\s+=\s+"Shorted-E2E"/);
+  assert.match(
+    mainTf,
+    /: "\(\s*http\.host eq \\"__shorted-testing-bypass-disabled\.invalid__\\"\s*\)"/,
+  );
+  assert.doesNotMatch(mainTf, /: "false"/);
 });
 
 test("production environment passes testing bypass inputs into Cloudflare edge module", () => {


### PR DESCRIPTION
## Summary
- replace the disabled Cloudflare testing-bypass expression with a syntactically valid never-match host expression
- add a regression guard so the Terraform module cannot emit `: "false"` for the disabled bypass path

## Validation
- `node --test terraform/modules/cloudflare-edge/rate-limit-expression.test.mjs`
- `node --test scripts/release-pipeline.test.mjs terraform/modules/cloudflare-edge/rate-limit-expression.test.mjs`
- `terraform fmt -check terraform/modules/cloudflare-edge/main.tf terraform/modules/cloudflare-edge/variables.tf terraform/environments/prod/main.tf terraform/environments/prod/variables.tf`
- `git diff --check`

## Context
The main deploy workflow applied/published the smoked Vercel deployment successfully, but Terraform apply failed because Cloudflare rejected a ruleset expression ending in `and false` when the bypass secret is disabled.