### PR TITLE
Filter invalid instruments from top page data

### DIFF
--- a/web/src/app/actions/top/__tests__/getTopPageData.test.ts
+++ b/web/src/app/actions/top/__tests__/getTopPageData.test.ts
@@ -91,4 +91,83 @@ describe("getTopPageData", () => {
     expect(mockDeleteCached).toHaveBeenCalledWith("cache:top:3m:100");
     expect(mockGetTopShortsData).toHaveBeenCalledWith("3m", 100, 0);
   });
+
+  it("refreshes cached top-page data containing invalid instruments", async () => {
+    mockGetCached.mockResolvedValueOnce({
+      timeSeries: [
+        {
+          productCode: "ATBHQ",
+          name: "ASIAN DEVELOPMENT 4.35% 17-JAN-29",
+          latestShortPosition: 100,
+          points: [{ shortPosition: 100 }],
+        },
+      ],
+      movers: {
+        biggestGainers: [],
+        biggestLosers: [
+          {
+            productCode: "ATBHQ",
+            name: "ASIAN DEVELOPMENT 4.35% 17-JAN-29",
+            latestShortPosition: 100,
+            points: [{ shortPosition: 100 }],
+            change: -60,
+          },
+        ],
+        mostVolatile: [],
+      },
+      stockListItems: [],
+      lastUpdated: "2026-07-01T00:00:00.000Z",
+      period: "3m",
+    });
+
+    const result = await getTopPageData("3m", 100);
+
+    expect(result.timeSeries.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(result.movers.biggestLosers.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(mockDeleteCached).toHaveBeenCalledWith("cache:top:3m:100");
+    expect(mockGetTopShortsData).toHaveBeenCalledWith("3m", 100, 0);
+  });
+
+  it("filters invalid instruments before deriving top-page stats and movers", async () => {
+    mockGetTopShortsData.mockResolvedValueOnce({
+      timeSeries: [
+        {
+          productCode: "ATBHQ",
+          name: "ASIAN DEVELOPMENT 4.35% 17-JAN-29",
+          latestShortPosition: 100,
+          points: [
+            { timestamp: "2026-04-01T00:00:00Z", shortPosition: 160 },
+            { timestamp: "2026-07-01T00:00:00Z", shortPosition: 100 },
+          ],
+        },
+        {
+          productCode: "OOO",
+          name: "BETASHARESCRUDEOIL ETF UNITS",
+          latestShortPosition: 20,
+          points: [
+            { timestamp: "2026-04-01T00:00:00Z", shortPosition: 10 },
+            { timestamp: "2026-07-01T00:00:00Z", shortPosition: 20 },
+          ],
+        },
+        {
+          productCode: "LOT",
+          name: "LOTUS RESOURCES LTD ORDINARY",
+          latestShortPosition: 22.82,
+          points: [
+            { timestamp: "2026-04-01T00:00:00Z", shortPosition: 10 },
+            { timestamp: "2026-07-01T00:00:00Z", shortPosition: 22.82 },
+          ],
+        },
+      ],
+      offset: 0,
+    });
+
+    const result = await getTopPageData("3m", 100);
+
+    expect(result.timeSeries.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(result.stockListItems.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(result.movers.biggestGainers.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(result.movers.biggestLosers.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(result.movers.mostVolatile.map((stock) => stock.productCode)).toEqual(["LOT"]);
+  });
 });

--- a/web/src/app/actions/top/getTopPageData.ts
+++ b/web/src/app/actions/top/getTopPageData.ts
@@ -67,6 +67,26 @@ export interface TopPageData {
   period: TimePeriod;
 }
 
+interface InstrumentCandidate {
+  productCode?: string;
+  name?: string;
+}
+
+const LISTED_EQUITY_CODE_PATTERN = /^[A-Z0-9]{3,4}$/;
+const ETF_NAME_PATTERN = /\bETF\b/i;
+const COUPON_PERCENT_NAME_PATTERN = /[0-9]+(\.[0-9]+)?\s*%/;
+
+function isEligibleTopPageInstrument(stock: InstrumentCandidate): boolean {
+  const productCode = (stock.productCode ?? "").trim().toUpperCase();
+  const name = stock.name ?? "";
+
+  return (
+    LISTED_EQUITY_CODE_PATTERN.test(productCode) &&
+    !ETF_NAME_PATTERN.test(name) &&
+    !COUPON_PERCENT_NAME_PATTERN.test(name)
+  );
+}
+
 /**
  * Serialize TimeSeriesData to plain object for caching
  */
@@ -206,7 +226,12 @@ function isUsableTopPageData(data: TopPageData | null): data is TopPageData {
     data.timeSeries.some(
       (stock) =>
         !!stock?.productCode && toFiniteNumber(stock.latestShortPosition) > 0,
-    )
+    ) &&
+    data.timeSeries.every(isEligibleTopPageInstrument) &&
+    data.stockListItems.every(isEligibleTopPageInstrument) &&
+    data.movers.biggestGainers.every(isEligibleTopPageInstrument) &&
+    data.movers.biggestLosers.every(isEligibleTopPageInstrument) &&
+    data.movers.mostVolatile.every(isEligibleTopPageInstrument)
   );
 }
 
@@ -216,7 +241,9 @@ async function buildTopPageData(
 ): Promise<TopPageData> {
   // Fetch raw data
   const response = await getTopShortsData(period, limit, 0);
-  const rawTimeSeries = response?.timeSeries ?? [];
+  const rawTimeSeries = (response?.timeSeries ?? []).filter(
+    isEligibleTopPageInstrument,
+  );
 
   // Calculate movers from raw data (before serialization)
   const rawMovers = calculateMovers(rawTimeSeries, period);


### PR DESCRIPTION
## Summary
- reject cached /top page data that still contains invalid instruments such as ATBHQ
- filter invalid instruments before deriving top-page stats, movers, and structured stock list data
- add regression coverage for stale cached ATBHQ data and fresh ATBHQ/ETF payloads

## Validation
- npm --prefix web test -- --runTestsByPath src/app/actions/top/__tests__/getTopPageData.test.ts
- sourced-env npx next build
- commit hook: frontend lint/build/tests, backend tests, shorts integration tests, market-data integration tests
- pre-push hook: Go lint/test, frontend lint/build/tests