### PR TITLE
Filter invalid top shorts at shared cache boundary

### DIFF
--- a/web/src/@/lib/top-shorts-filter.ts
+++ b/web/src/@/lib/top-shorts-filter.ts
@@ -1,0 +1,51 @@
+export interface TopShortsInstrumentCandidate {
+  productCode?: string;
+  name?: string;
+}
+
+const LISTED_EQUITY_CODE_PATTERN = /^[A-Z0-9]{3,4}$/;
+const ETF_NAME_PATTERN = /\bETF\b/i;
+const COUPON_PERCENT_NAME_PATTERN = /[0-9]+(\.[0-9]+)?\s*%/;
+
+export function isEligibleTopShortsInstrument(
+  stock: TopShortsInstrumentCandidate,
+): boolean {
+  const productCode = (stock.productCode ?? "").trim().toUpperCase();
+  const name = stock.name ?? "";
+
+  return (
+    LISTED_EQUITY_CODE_PATTERN.test(productCode) &&
+    !ETF_NAME_PATTERN.test(name) &&
+    !COUPON_PERCENT_NAME_PATTERN.test(name)
+  );
+}
+
+export function hasOnlyEligibleTopShortsInstruments(
+  stocks: readonly TopShortsInstrumentCandidate[] | null | undefined,
+): boolean {
+  if (!stocks) return false;
+  return stocks.every((stock) => isEligibleTopShortsInstrument(stock));
+}
+
+export function filterEligibleTopShorts<T extends TopShortsInstrumentCandidate>(
+  stocks: readonly T[] | null | undefined,
+): T[] {
+  if (!stocks) return [];
+  return stocks.filter((stock) => isEligibleTopShortsInstrument(stock));
+}
+
+export function filterTopShortsResponse<
+  TStock extends TopShortsInstrumentCandidate,
+  TResponse extends { timeSeries?: TStock[] },
+>(response: TResponse): TResponse {
+  const timeSeries = response.timeSeries;
+  if (!timeSeries) return response;
+
+  const filteredTimeSeries = filterEligibleTopShorts(timeSeries);
+  if (filteredTimeSeries.length === timeSeries.length) return response;
+
+  return {
+    ...response,
+    timeSeries: filteredTimeSeries,
+  };
+}

--- a/web/src/app/actions/__tests__/getTopShorts-cache.test.ts
+++ b/web/src/app/actions/__tests__/getTopShorts-cache.test.ts
@@ -171,4 +171,94 @@ describe("getTopShortsData with KV Cache", () => {
     );
     expect(mockClient.getTopShorts).toHaveBeenCalled();
   });
+
+  it("refreshes stale cached top-shorts entries containing invalid instruments", async () => {
+    const staleCachedResponse = {
+      timeSeries: [
+        {
+          productCode: "ATBHQ",
+          name: "ASIAN DEVELOPMENT 4.35% 17-JAN-29",
+          latestShortPosition: 100,
+        },
+        {
+          productCode: "LOT",
+          name: "LOTUS RESOURCES LTD ORDINARY",
+          latestShortPosition: 22.82,
+        },
+      ],
+      offset: 0,
+    };
+    const apiResponse = {
+      timeSeries: [
+        {
+          productCode: "LOT",
+          name: "LOTUS RESOURCES LTD ORDINARY",
+          latestShortPosition: 22.82,
+        },
+      ],
+      offset: 0,
+    };
+    mockGetCached.mockResolvedValue(staleCachedResponse);
+
+    const { createClient } = require("@connectrpc/connect");
+    const mockClient = {
+      getTopShorts: jest.fn().mockResolvedValue(apiResponse),
+    };
+    createClient.mockReturnValue(mockClient);
+
+    const result = await getTopShortsData("3m", 20, 0);
+
+    expect(result.timeSeries.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(mockDeleteCached).toHaveBeenCalledWith(
+      "cache:homepage:top-shorts:3m:20:0",
+    );
+    expect(mockClient.getTopShorts).toHaveBeenCalled();
+  });
+
+  it("filters invalid instruments before caching fresh top-shorts responses", async () => {
+    const apiResponse = {
+      timeSeries: [
+        {
+          productCode: "ATBHQ",
+          name: "ASIAN DEVELOPMENT 4.35% 17-JAN-29",
+          latestShortPosition: 100,
+        },
+        {
+          productCode: "OOO",
+          name: "BETASHARES CRUDE OIL INDEX ETF-CURRENCY HEDGED",
+          latestShortPosition: 15,
+        },
+        {
+          productCode: "LOT",
+          name: "LOTUS RESOURCES LTD ORDINARY",
+          latestShortPosition: 22.82,
+        },
+      ],
+      offset: 0,
+    };
+
+    const { createClient } = require("@connectrpc/connect");
+    const mockClient = {
+      getTopShorts: jest.fn().mockResolvedValue(apiResponse),
+    };
+    createClient.mockReturnValue(mockClient);
+
+    const result = await getTopShortsData("3m", 20, 0);
+
+    expect(result.timeSeries.map((stock) => stock.productCode)).toEqual(["LOT"]);
+    expect(mockSetCached).toHaveBeenCalledWith(
+      "cache:homepage:top-shorts:3m:20:0",
+      {
+        ...apiResponse,
+        timeSeries: [
+          {
+            productCode: "LOT",
+            name: "LOTUS RESOURCES LTD ORDINARY",
+            latestShortPosition: 22.82,
+          },
+        ],
+      },
+      HOMEPAGE_TTL,
+    );
+  });
 });

--- a/web/src/app/actions/client/get-display-stocks.ts
+++ b/web/src/app/actions/client/get-display-stocks.ts
@@ -2,9 +2,13 @@
 
 import { cache } from "react";
 import { getTopShortsData } from "~/app/actions/getTopShorts";
-import { CACHE_KEYS, getCached, setCached } from "~/@/lib/kv-cache";
+import { CACHE_KEYS, deleteCached, getCached, setCached } from "~/@/lib/kv-cache";
 import type { TimeSeriesData } from "~/gen/stocks/v1alpha1/stocks_pb";
 import type { GetTopShortsResponse } from "~/gen/shorts/v1alpha1/shorts_pb";
+import {
+  filterTopShortsResponse,
+  hasOnlyEligibleTopShortsInstruments,
+} from "~/@/lib/top-shorts-filter";
 
 export interface StockDisplayData {
   code: string;
@@ -36,15 +40,23 @@ export const getTopStocksForDisplay = cache(async (limit = 5): Promise<StockDisp
     
     let response: GetTopShortsResponse | undefined;
 
-    if (cached) {
+    if (
+      cached &&
+      Array.isArray(cached.timeSeries) &&
+      hasOnlyEligibleTopShortsInstruments(cached.timeSeries)
+    ) {
       response = cached;
     } else {
+      if (cached) {
+        await deleteCached(cacheKey);
+      }
+
       // Cache miss - fetch from backend
       response = await getTopShortsData("3m", limit, 0);
 
       // Cache the result (async, don't wait)
       if (response) {
-        setCached(cacheKey, response, 300).catch((error) => {
+        setCached(cacheKey, filterTopShortsResponse(response), 300).catch((error) => {
           console.error("Failed to cache top stocks:", error);
         });
       }

--- a/web/src/app/actions/client/getTopShorts.ts
+++ b/web/src/app/actions/client/getTopShorts.ts
@@ -6,6 +6,10 @@ import { formatPeriodForAPI } from "~/lib/period-utils";
 import { SHORTS_API_URL } from "../config";
 import { retryWithBackoff } from "@/lib/retry";
 import { getSessionCached, setSessionCached } from "@/lib/session-cache";
+import {
+  filterTopShortsResponse,
+  hasOnlyEligibleTopShortsInstruments,
+} from "@/lib/top-shorts-filter";
 
 const RETRY_OPTIONS = {
   maxRetries: 3,
@@ -29,7 +33,13 @@ export const getTopShortsDataClient = async (
 
   if (!forceRefresh) {
     const cached = getSessionCached<GetTopShortsResponse>(cacheKey);
-    if (cached) return cached;
+    if (
+      cached &&
+      Array.isArray(cached.timeSeries) &&
+      hasOnlyEligibleTopShortsInstruments(cached.timeSeries)
+    ) {
+      return cached;
+    }
   }
 
   // Use relative URL so requests go through Next.js rewrites (avoids CORS)
@@ -49,6 +59,7 @@ export const getTopShortsDataClient = async (
     RETRY_OPTIONS,
   );
 
-  setSessionCached(cacheKey, result);
-  return result;
+  const filteredResult = filterTopShortsResponse(result);
+  setSessionCached(cacheKey, filteredResult);
+  return filteredResult;
 };

--- a/web/src/app/actions/getTopShorts.ts
+++ b/web/src/app/actions/getTopShorts.ts
@@ -14,13 +14,20 @@ import {
 } from "~/@/lib/kv-cache";
 import { withRetryAndNotFound } from "./withRetry";
 import { withSpan } from "~/@/lib/tracing";
+import {
+  filterTopShortsResponse,
+  hasOnlyEligibleTopShortsInstruments,
+} from "~/@/lib/top-shorts-filter";
 
 function isUsableTopShortsResponse(
   response: GetTopShortsResponse | null,
   offset: number,
 ): response is GetTopShortsResponse {
   if (!response || !Array.isArray(response.timeSeries)) return false;
-  return response.timeSeries.length > 0 || offset > 0;
+  return (
+    (response.timeSeries.length > 0 || offset > 0) &&
+    hasOnlyEligibleTopShortsInstruments(response.timeSeries)
+  );
 }
 
 // React cache() provides request deduplication during a single render
@@ -62,13 +69,15 @@ export const getTopShortsData = cache(
         },
       );
 
-      if (isUsableTopShortsResponse(response, offset)) {
-        setCached(cacheKey, response, Number(HOMEPAGE_TTL)).catch((error) => {
+      const filteredResponse = filterTopShortsResponse(response);
+
+      if (isUsableTopShortsResponse(filteredResponse, offset)) {
+        setCached(cacheKey, filteredResponse, Number(HOMEPAGE_TTL)).catch((error) => {
           console.error(`Failed to cache top shorts for key ${cacheKey}:`, error);
         });
       }
 
-      return response;
+      return filteredResponse;
     },
   ),
 );

--- a/web/src/app/actions/top/getTopPageData.ts
+++ b/web/src/app/actions/top/getTopPageData.ts
@@ -15,6 +15,7 @@ import {
 } from "~/@/lib/shorts-calculations";
 import { type TimeSeriesData } from "~/gen/stocks/v1alpha1/stocks_pb";
 import { siteConfig } from "~/@/config/site";
+import { isEligibleTopShortsInstrument } from "~/@/lib/top-shorts-filter";
 
 /**
  * Serialized time series point for caching
@@ -65,26 +66,6 @@ export interface TopPageData {
   stockListItems: StockListItem[];
   lastUpdated: string;
   period: TimePeriod;
-}
-
-interface InstrumentCandidate {
-  productCode?: string;
-  name?: string;
-}
-
-const LISTED_EQUITY_CODE_PATTERN = /^[A-Z0-9]{3,4}$/;
-const ETF_NAME_PATTERN = /\bETF\b/i;
-const COUPON_PERCENT_NAME_PATTERN = /[0-9]+(\.[0-9]+)?\s*%/;
-
-function isEligibleTopPageInstrument(stock: InstrumentCandidate): boolean {
-  const productCode = (stock.productCode ?? "").trim().toUpperCase();
-  const name = stock.name ?? "";
-
-  return (
-    LISTED_EQUITY_CODE_PATTERN.test(productCode) &&
-    !ETF_NAME_PATTERN.test(name) &&
-    !COUPON_PERCENT_NAME_PATTERN.test(name)
-  );
 }
 
 /**
@@ -227,11 +208,11 @@ function isUsableTopPageData(data: TopPageData | null): data is TopPageData {
       (stock) =>
         !!stock?.productCode && toFiniteNumber(stock.latestShortPosition) > 0,
     ) &&
-    data.timeSeries.every(isEligibleTopPageInstrument) &&
-    data.stockListItems.every(isEligibleTopPageInstrument) &&
-    data.movers.biggestGainers.every(isEligibleTopPageInstrument) &&
-    data.movers.biggestLosers.every(isEligibleTopPageInstrument) &&
-    data.movers.mostVolatile.every(isEligibleTopPageInstrument)
+    data.timeSeries.every(isEligibleTopShortsInstrument) &&
+    data.stockListItems.every(isEligibleTopShortsInstrument) &&
+    data.movers.biggestGainers.every(isEligibleTopShortsInstrument) &&
+    data.movers.biggestLosers.every(isEligibleTopShortsInstrument) &&
+    data.movers.mostVolatile.every(isEligibleTopShortsInstrument)
   );
 }
 
@@ -242,7 +223,7 @@ async function buildTopPageData(
   // Fetch raw data
   const response = await getTopShortsData(period, limit, 0);
   const rawTimeSeries = (response?.timeSeries ?? []).filter(
-    isEligibleTopPageInstrument,
+    isEligibleTopShortsInstrument,
   );
 
   // Calculate movers from raw data (before serialization)


### PR DESCRIPTION
## Summary
- centralize the Top Shorts instrument eligibility filter
- reject/delete stale top-shorts KV cache entries containing ATBHQ-style coupon instruments or ETFs
- filter fresh server/client Top Shorts responses before caching or rendering

## Verification
- RED: getTopShorts-cache regression failed with stale ATBHQ and ETF rows
- GREEN: npm --prefix web test -- --runTestsByPath src/app/actions/__tests__/getTopShorts-cache.test.ts
- npm --prefix web test -- --runTestsByPath src/app/actions/__tests__/getTopShorts-cache.test.ts src/app/actions/top/__tests__/getTopPageData.test.ts src/app/shorts/__tests__/page.test.tsx src/app/topShortsView/__tests__/topShorts.test.tsx
- npx next build
- pre-push hook passed: Go lint/test, frontend lint/build/tests

## Production symptom
Reproduced before fix: https://shorted.com.au/ and /shorts server HTML still contained /shorts/ATBHQ while /top and API were already clean.